### PR TITLE
feat: discover screen with like/pass buttons and full profile view

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -4,11 +4,12 @@ import { Session } from '@supabase/supabase-js';
 import { supabase } from './lib/supabase';
 import { hasPreferences } from './lib/preferences';
 import { profilePhotoPathsFromRow } from './lib/profileDisplay';
+import { NavigationContainer } from '@react-navigation/native';
 import AuthScreen from './screens/AuthScreen';
-import ProfileScreen from './screens/HomeScreen';
 import OnboardingScreen from './screens/OnboardingScreen';
 import ProfileCompletionScreen from './screens/ProfileCompletionScreen';
 import ProfileCardScreen from './screens/ProfileCardScreen';
+import MainTabNavigator from './navigation/MainTabNavigator';
 
 type AppState = 'loading' | 'auth' | 'onboarding' | 'profile-completion' | 'profile-card' | 'home';
 
@@ -125,7 +126,11 @@ export default function App() {
       {appState === 'profile-card' && (
         <ProfileCardScreen onComplete={handleProfileCardComplete} />
       )}
-      {appState === 'home' && <ProfileScreen />}
+      {appState === 'home' && (
+        <NavigationContainer>
+          <MainTabNavigator />
+        </NavigationContainer>
+      )}
     </>
   );
 }

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -1,0 +1,90 @@
+import { supabase } from './supabase';
+import { getProfileImageUrls } from './storage';
+
+export type DiscoverProfile = {
+  id: string;
+  name: string;
+  age: number | null;
+  bio: string | null;
+  hobbies: string[] | null;
+  photoUrls: string[];
+  location: string;
+};
+
+export async function fetchDiscoverProfiles(
+  userId: string,
+  limit = 10
+): Promise<DiscoverProfile[]> {
+  // Get IDs the user has already swiped on
+  const { data: swipedRows } = await supabase
+    .from('swipes')
+    .select('swiped_id')
+    .eq('swiper_id', userId);
+
+  const swipedIds = swipedRows?.map((r: any) => r.swiped_id) ?? [];
+
+  // Fetch other profiles, excluding self and already-swiped
+  let query = supabase
+    .from('profiles')
+    .select('id, name, age, bio, hobbies, profile_photo_url, preferences(city, state)')
+    .neq('id', userId)
+    .not('profile_photo_url', 'is', null)
+    .limit(limit);
+
+  if (swipedIds.length > 0) {
+    query = query.not('id', 'in', `(${swipedIds.join(',')})`);
+  }
+
+  const { data: rows, error } = await query;
+  if (error || !rows) return [];
+
+  const result: DiscoverProfile[] = [];
+
+  for (const row of rows) {
+    const urls = await getProfileImageUrls(row.profile_photo_url);
+    if (!urls || urls.length === 0) continue;
+
+    // Supabase returns 1:many as array even for 1:1 relationships
+    const prefs = Array.isArray(row.preferences) ? row.preferences[0] : row.preferences;
+    const city = prefs?.city?.trim() ?? '';
+    const state = prefs?.state?.trim() ?? '';
+    const location = city && state ? `${city}, ${state}` : city || state;
+
+    result.push({
+      id: row.id,
+      name: row.name ?? 'Unknown',
+      age: row.age ?? null,
+      bio: row.bio ?? null,
+      hobbies: row.hobbies ?? null,
+      photoUrls: urls,
+      location,
+    });
+  }
+
+  return result;
+}
+
+export async function recordSwipe(
+  swiperId: string,
+  swipedId: string,
+  direction: 'like' | 'pass'
+): Promise<{ isMatch: boolean }> {
+  await supabase.from('swipes').insert({
+    swiper_id: swiperId,
+    swiped_id: swipedId,
+    direction,
+  });
+
+  if (direction !== 'like') return { isMatch: false };
+
+  // Check if the other person already liked us back
+  const { data } = await supabase
+    .from('swipes')
+    .select('id')
+    .eq('swiper_id', swipedId)
+    .eq('swiped_id', swiperId)
+    .eq('direction', 'like')
+    .maybeSingle();
+
+  return { isMatch: !!data };
+}

--- a/apps/mobile/lib/matches.ts
+++ b/apps/mobile/lib/matches.ts
@@ -1,0 +1,76 @@
+import { supabase } from './supabase';
+import { getProfileImageUrls } from './storage';
+
+export type Match = {
+  id: string;
+  name: string;
+  age: number | null;
+  location: string;
+  photoUrls: string[];
+  matchedAt: string;
+};
+
+export async function fetchMatches(userId: string): Promise<Match[]> {
+  // Get everyone the current user liked
+  const { data: myLikes } = await supabase
+    .from('swipes')
+    .select('swiped_id, created_at')
+    .eq('swiper_id', userId)
+    .eq('direction', 'like');
+
+  if (!myLikes || myLikes.length === 0) return [];
+
+  const likedIds = myLikes.map((r: any) => r.swiped_id);
+
+  // Of those, find who also liked the current user back
+  const { data: mutualLikes } = await supabase
+    .from('swipes')
+    .select('swiper_id, created_at')
+    .eq('swiped_id', userId)
+    .eq('direction', 'like')
+    .in('swiper_id', likedIds);
+
+  if (!mutualLikes || mutualLikes.length === 0) return [];
+
+  const matchedUserIds = mutualLikes.map((r: any) => r.swiper_id);
+
+  // Fetch their profiles
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, name, age, profile_photo_url, preferences(city, state)')
+    .in('id', matchedUserIds);
+
+  if (!profiles) return [];
+
+  const result: Match[] = [];
+
+  for (const profile of profiles) {
+    const urls = profile.profile_photo_url
+      ? (await getProfileImageUrls(profile.profile_photo_url)) ?? []
+      : [];
+
+    const prefs = Array.isArray(profile.preferences)
+      ? profile.preferences[0]
+      : profile.preferences;
+    const city = prefs?.city?.trim() ?? '';
+    const state = prefs?.state?.trim() ?? '';
+    const location = city && state ? `${city}, ${state}` : city || state;
+
+    const matchedAt =
+      mutualLikes.find((r: any) => r.swiper_id === profile.id)?.created_at ?? '';
+
+    result.push({
+      id: profile.id,
+      name: profile.name ?? 'Unknown',
+      age: profile.age ?? null,
+      location,
+      photoUrls: urls,
+      matchedAt,
+    });
+  }
+
+  // Most recent matches first
+  result.sort((a, b) => b.matchedAt.localeCompare(a.matchedAt));
+
+  return result;
+}

--- a/apps/mobile/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/navigation/MainTabNavigator.tsx
@@ -1,0 +1,81 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
+import { View, Text, StyleSheet } from 'react-native';
+import DiscoverScreen from '../screens/DiscoverScreen';
+import HomeScreen from '../screens/HomeScreen';
+
+export type MainTabParamList = {
+  Discover: undefined;
+  Matches: undefined;
+  Messages: undefined;
+  Profile: undefined;
+};
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+const TAB_ICON: Record<keyof MainTabParamList, keyof typeof Ionicons.glyphMap> = {
+  Discover: 'home-outline',
+  Matches: 'heart-outline',
+  Messages: 'chatbubble-outline',
+  Profile: 'person-outline',
+};
+
+const TAB_ICON_FOCUSED: Record<keyof MainTabParamList, keyof typeof Ionicons.glyphMap> = {
+  Discover: 'home',
+  Matches: 'heart',
+  Messages: 'chatbubble',
+  Profile: 'person',
+};
+
+function Placeholder({ title }: { title: string }) {
+  return (
+    <View style={styles.placeholder}>
+      <Text style={styles.placeholderText}>{title}</Text>
+    </View>
+  );
+}
+
+export default function MainTabNavigator() {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarHideOnKeyboard: true,
+        tabBarActiveTintColor: '#0C5389',
+        tabBarInactiveTintColor: '#888',
+        tabBarStyle: {
+          borderTopColor: '#D9E1E6',
+          backgroundColor: '#FDFDFD',
+        },
+        tabBarIcon: ({ color, size, focused }) => {
+          const name = route.name as keyof MainTabParamList;
+          return (
+            <Ionicons
+              name={focused ? TAB_ICON_FOCUSED[name] : TAB_ICON[name]}
+              size={size}
+              color={color}
+            />
+          );
+        },
+      })}
+    >
+      <Tab.Screen name="Discover" component={DiscoverScreen} />
+      <Tab.Screen name="Matches" component={() => <Placeholder title="Matches" />} />
+      <Tab.Screen name="Messages" component={() => <Placeholder title="Messages" />} />
+      <Tab.Screen name="Profile" component={HomeScreen} />
+    </Tab.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  placeholder: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FDFDFD',
+  },
+  placeholderText: {
+    fontSize: 18,
+    color: '#2B3A4A',
+  },
+});

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -1,0 +1,479 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Animated,
+  Dimensions,
+  Image,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { supabase } from '../lib/supabase';
+import { fetchDiscoverProfiles, recordSwipe, type DiscoverProfile } from '../lib/discover';
+import PublicProfileCard from '../components/PublicProfileCard';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+
+const COLORS = {
+  blue: '#0C5389',
+  teal: '#189AA2',
+  green: '#46BD7F',
+  white: '#FDFDFD',
+  ink: '#0B1B2B',
+  border: '#D9E1E6',
+  text: '#2B3A4A',
+};
+
+export default function DiscoverScreen() {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [profiles, setProfiles] = useState<DiscoverProfile[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [matchName, setMatchName] = useState<string | null>(null);
+  const [expandedProfile, setExpandedProfile] = useState<DiscoverProfile | null>(null);
+  const [actionDisabled, setActionDisabled] = useState(false);
+
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      const uid = data.session?.user.id ?? null;
+      setUserId(uid);
+      if (uid) loadProfiles(uid);
+    });
+  }, []);
+
+  async function loadProfiles(uid: string) {
+    setLoading(true);
+    const data = await fetchDiscoverProfiles(uid);
+    setProfiles(data);
+    setCurrentIndex(0);
+    setLoading(false);
+  }
+
+  async function handleAction(direction: 'like' | 'pass') {
+    if (actionDisabled) return;
+    setActionDisabled(true);
+
+    // Fade out current card
+    Animated.timing(fadeAnim, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(async () => {
+      const current = profiles[currentIndex];
+      if (current && userId) {
+        const { isMatch } = await recordSwipe(userId, current.id, direction);
+        if (isMatch) setMatchName(current.name);
+      }
+
+      setCurrentIndex((prev) => prev + 1);
+
+      // Fade in next card
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start(() => setActionDisabled(false));
+    });
+  }
+
+  const currentProfile = profiles[currentIndex];
+  const hasMore = currentIndex < profiles.length;
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>Finding roommates...</Text>
+      </View>
+    );
+  }
+
+  if (!hasMore) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyTitle}>You're all caught up</Text>
+        <Text style={styles.emptyText}>No more profiles right now.{'\n'}Check back later!</Text>
+        <TouchableOpacity
+          style={styles.refreshButton}
+          onPress={() => userId && loadProfiles(userId)}
+        >
+          <Text style={styles.refreshButtonText}>Refresh</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Discover</Text>
+
+      <View style={styles.cardArea}>
+        <Animated.View style={{ opacity: fadeAnim, width: '100%' }}>
+          <TouchableOpacity
+            activeOpacity={0.95}
+            onPress={() => setExpandedProfile(currentProfile)}
+          >
+            <PublicProfileCard
+              imageUrls={currentProfile.photoUrls}
+              name={currentProfile.name}
+              age={currentProfile.age}
+              location={currentProfile.location}
+              bio={currentProfile.bio}
+              hobbies={currentProfile.hobbies}
+            />
+          </TouchableOpacity>
+          <Text style={styles.tapHint}>Tap card to view full profile</Text>
+        </Animated.View>
+      </View>
+
+      {/* Action buttons */}
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[styles.passButton, actionDisabled && styles.buttonDisabled]}
+          onPress={() => handleAction('pass')}
+          disabled={actionDisabled}
+        >
+          <Text style={styles.passIcon}>✕</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.likeButton, actionDisabled && styles.buttonDisabled]}
+          onPress={() => handleAction('like')}
+          disabled={actionDisabled}
+        >
+          <Text style={styles.likeIcon}>♥</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Full profile modal */}
+      <Modal visible={!!expandedProfile} animationType="slide" statusBarTranslucent>
+        {expandedProfile && (
+          <View style={styles.profileModal}>
+            <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
+              {/* Photo gallery */}
+              <ScrollView
+                horizontal
+                pagingEnabled
+                showsHorizontalScrollIndicator={false}
+                style={styles.photoScroll}
+              >
+                {expandedProfile.photoUrls.map((url, i) => (
+                  <Image
+                    key={i}
+                    source={{ uri: url }}
+                    style={[styles.fullPhoto, { width: SCREEN_WIDTH }]}
+                    resizeMode="cover"
+                  />
+                ))}
+              </ScrollView>
+
+              {/* Info */}
+              <View style={styles.profileInfo}>
+                <Text style={styles.profileName}>
+                  {expandedProfile.name}
+                  {expandedProfile.age ? `, ${expandedProfile.age}` : ''}
+                </Text>
+                {expandedProfile.location ? (
+                  <Text style={styles.profileLocation}>{expandedProfile.location}</Text>
+                ) : null}
+                {expandedProfile.bio ? (
+                  <Text style={styles.profileBio}>{expandedProfile.bio}</Text>
+                ) : null}
+                {expandedProfile.hobbies && expandedProfile.hobbies.length > 0 && (
+                  <>
+                    <Text style={styles.hobbiesLabel}>Interests</Text>
+                    <View style={styles.hobbiesRow}>
+                      {expandedProfile.hobbies.map((h, i) => (
+                        <View key={i} style={styles.hobbyChip}>
+                          <Text style={styles.hobbyChipText}>{h}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  </>
+                )}
+              </View>
+            </ScrollView>
+
+            {/* Bottom actions */}
+            <View style={styles.modalActions}>
+              <TouchableOpacity
+                style={styles.passButton}
+                onPress={() => {
+                  setExpandedProfile(null);
+                  handleAction('pass');
+                }}
+              >
+                <Text style={styles.passIcon}>✕</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.likeButton}
+                onPress={() => {
+                  setExpandedProfile(null);
+                  handleAction('like');
+                }}
+              >
+                <Text style={styles.likeIcon}>♥</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Close */}
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={() => setExpandedProfile(null)}
+            >
+              <Text style={styles.closeButtonText}>✕</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </Modal>
+
+      {/* Match modal */}
+      <Modal visible={!!matchName} transparent animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.matchCard}>
+            <Text style={styles.matchEmoji}>🎉</Text>
+            <Text style={styles.matchTitle}>It's a Match!</Text>
+            <Text style={styles.matchSub}>You and {matchName} both liked each other.</Text>
+            <TouchableOpacity style={styles.matchButton} onPress={() => setMatchName(null)}>
+              <Text style={styles.matchButtonText}>Keep Going</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.white,
+    paddingTop: 60,
+  },
+  header: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: COLORS.ink,
+    paddingHorizontal: 20,
+    marginBottom: 12,
+  },
+  cardArea: {
+    flex: 1,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  tapHint: {
+    textAlign: 'center',
+    marginTop: 10,
+    fontSize: 12,
+    color: COLORS.text,
+    opacity: 0.45,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 40,
+    paddingVertical: 24,
+    paddingBottom: 36,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 40,
+    paddingVertical: 20,
+    paddingBottom: 36,
+    backgroundColor: COLORS.white,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.border,
+  },
+  passButton: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: COLORS.white,
+    borderWidth: 2,
+    borderColor: '#E53935',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  passIcon: {
+    fontSize: 26,
+    color: '#E53935',
+  },
+  likeButton: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: COLORS.white,
+    borderWidth: 2,
+    borderColor: COLORS.green,
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  likeIcon: {
+    fontSize: 26,
+    color: COLORS.green,
+  },
+  buttonDisabled: {
+    opacity: 0.4,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    backgroundColor: COLORS.white,
+  },
+  emptyTitle: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: COLORS.ink,
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: COLORS.text,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  refreshButton: {
+    marginTop: 24,
+    backgroundColor: COLORS.blue,
+    paddingHorizontal: 28,
+    paddingVertical: 12,
+    borderRadius: 14,
+  },
+  refreshButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  profileModal: {
+    flex: 1,
+    backgroundColor: COLORS.white,
+  },
+  photoScroll: {
+    height: SCREEN_HEIGHT * 0.55,
+  },
+  fullPhoto: {
+    height: SCREEN_HEIGHT * 0.55,
+  },
+  profileInfo: {
+    padding: 24,
+    paddingBottom: 16,
+  },
+  profileName: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: COLORS.ink,
+  },
+  profileLocation: {
+    fontSize: 16,
+    color: COLORS.teal,
+    fontWeight: '500',
+    marginTop: 4,
+  },
+  profileBio: {
+    fontSize: 15,
+    color: COLORS.text,
+    lineHeight: 22,
+    marginTop: 16,
+  },
+  hobbiesLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: COLORS.text,
+    marginTop: 20,
+    marginBottom: 8,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  hobbiesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  hobbyChip: {
+    backgroundColor: 'rgba(24,154,162,0.12)',
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 16,
+  },
+  hobbyChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: COLORS.teal,
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 52,
+    right: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  matchCard: {
+    backgroundColor: COLORS.white,
+    borderRadius: 24,
+    padding: 32,
+    alignItems: 'center',
+    width: '80%',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  matchEmoji: { fontSize: 48, marginBottom: 12 },
+  matchTitle: {
+    fontSize: 28,
+    fontWeight: '900',
+    color: COLORS.ink,
+    marginBottom: 8,
+  },
+  matchSub: {
+    fontSize: 15,
+    color: COLORS.text,
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  matchButton: {
+    backgroundColor: COLORS.blue,
+    paddingHorizontal: 28,
+    paddingVertical: 12,
+    borderRadius: 14,
+  },
+  matchButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 15,
+  },
+});


### PR DESCRIPTION
## Swipe Discovery Experience

### Overview
Implements the core discover feature for RoomPear — users can now browse other profiles, like or pass, and get notified when they match.

---

### New Files
- `apps/mobile/lib/discover.ts` — Data layer for fetching profiles and recording swipes
- `apps/mobile/lib/matches.ts` — Data layer for fetching mutual matches (ready for Matches tab)
- `apps/mobile/screens/DiscoverScreen.tsx` — Full discover UI with profile cards, like/pass buttons, full profile modal, and match popup
- `apps/mobile/navigation/MainTabNavigator.tsx` — Bottom tab navigator (Discover, Matches, Messages, Profile)

### Modified Files
- `apps/mobile/App.tsx` — Routes authenticated users into the tab navigator after onboarding
- `apps/mobile/lib/storage.ts` — Merged in from main

### Database
- `backend/supabase/supabase/migrations/20260408000001_create_swipes_table.sql` — Creates `swipes` table with RLS policies and indexes

---

### How It Works
- After completing onboarding, users land on the Discover tab
- Profiles are fetched from Supabase, excluding users already swiped on
- Tap the card to open a full-screen profile view with scrollable photos, bio, and interests
- Press ✕ to pass or ♥ to like — the swipe is recorded in the database
- If both users like each other, a match popup appears (Not done yet need to add matches)
- When all profiles are viewed, an "all caught up" screen is shown with a refresh option

---

### Notes
- Matches and Messages tabs are placeholders — to be built in upcoming PRs
- Swipes table uses row level security so users can only read and write their own swipes
- Three database indexes added for performance at scale