### PR TITLE
feat: matches tab with mutual like detection

### DIFF
--- a/apps/mobile/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/navigation/MainTabNavigator.tsx
@@ -2,6 +2,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
 import { View, Text, StyleSheet } from 'react-native';
 import DiscoverScreen from '../screens/DiscoverScreen';
+import MatchesScreen from '../screens/MatchesScreen';
 import UserProfileScreen from '../screens/UserProfileScreen';
 
 export type MainTabParamList = {
@@ -60,7 +61,7 @@ export default function MainTabNavigator() {
       })}
     >
       <Tab.Screen name="Discover" component={DiscoverScreen} />
-      <Tab.Screen name="Matches" component={() => <Placeholder title="Matches" />} />
+      <Tab.Screen name="Matches" component={MatchesScreen} />
       <Tab.Screen name="Messages" component={() => <Placeholder title="Messages" />} />
       <Tab.Screen name="Profile" component={UserProfileScreen} />
     </Tab.Navigator>

--- a/apps/mobile/screens/MatchesScreen.tsx
+++ b/apps/mobile/screens/MatchesScreen.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { supabase } from '../lib/supabase';
+import { fetchMatches, type Match } from '../lib/matches';
+
+const COLORS = {
+  blue: '#0C5389',
+  teal: '#189AA2',
+  green: '#46BD7F',
+  white: '#FDFDFD',
+  ink: '#0B1B2B',
+  border: '#D9E1E6',
+  text: '#2B3A4A',
+  placeholder: '#D9E1E6',
+};
+
+export default function MatchesScreen() {
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      const uid = data.session?.user.id;
+      if (uid) load(uid);
+    });
+  }, []);
+
+  async function load(uid: string) {
+    setLoading(true);
+    const data = await fetchMatches(uid);
+    setMatches(data);
+    setLoading(false);
+  }
+
+  function formatDate(iso: string) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator color={COLORS.blue} />
+      </View>
+    );
+  }
+
+  if (matches.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyEmoji}>💚</Text>
+        <Text style={styles.emptyTitle}>No matches yet</Text>
+        <Text style={styles.emptyText}>
+          When you and someone both like each other, they'll show up here.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Matches</Text>
+      <FlatList
+        data={matches}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        renderItem={({ item }) => (
+          <TouchableOpacity style={styles.matchRow} activeOpacity={0.7}>
+            {item.photoUrls.length > 0 ? (
+              <Image source={{ uri: item.photoUrls[0] }} style={styles.avatar} />
+            ) : (
+              <View style={[styles.avatar, styles.avatarPlaceholder]} />
+            )}
+            <View style={styles.info}>
+              <Text style={styles.name}>
+                {item.name}{item.age ? `, ${item.age}` : ''}
+              </Text>
+              {item.location ? (
+                <Text style={styles.location}>{item.location}</Text>
+              ) : null}
+              <Text style={styles.matchedAt}>Matched {formatDate(item.matchedAt)}</Text>
+            </View>
+            <View style={styles.messageButton}>
+              <Text style={styles.messageIcon}>💬</Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.white,
+    paddingTop: 60,
+  },
+  header: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: COLORS.ink,
+    paddingHorizontal: 20,
+    marginBottom: 16,
+  },
+  list: {
+    paddingHorizontal: 20,
+    paddingBottom: 32,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: COLORS.border,
+  },
+  matchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    gap: 14,
+  },
+  avatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+  },
+  avatarPlaceholder: {
+    backgroundColor: COLORS.placeholder,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: COLORS.ink,
+  },
+  location: {
+    fontSize: 13,
+    color: COLORS.teal,
+    marginTop: 2,
+  },
+  matchedAt: {
+    fontSize: 12,
+    color: COLORS.text,
+    opacity: 0.5,
+    marginTop: 4,
+  },
+  messageButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    backgroundColor: '#F0F4F8',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  messageIcon: {
+    fontSize: 20,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    backgroundColor: COLORS.white,
+  },
+  emptyEmoji: {
+    fontSize: 48,
+    marginBottom: 12,
+  },
+  emptyTitle: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: COLORS.ink,
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: COLORS.text,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});

--- a/backend/supabase/supabase/migrations/20260408000001_create_swipes_table.sql
+++ b/backend/supabase/supabase/migrations/20260408000001_create_swipes_table.sql
@@ -1,0 +1,27 @@
+-- Create swipes table to record like/pass decisions between users
+create table if not exists public.swipes (
+  id          uuid        default gen_random_uuid() primary key,
+  swiper_id   uuid        not null references public.profiles(id) on delete cascade,
+  swiped_id   uuid        not null references public.profiles(id) on delete cascade,
+  direction   text        not null check (direction in ('like', 'pass')),
+  created_at  timestamptz not null default now(),
+  constraint swipes_unique_pair unique (swiper_id, swiped_id)
+);
+
+alter table public.swipes enable row level security;
+
+-- Users can record their own swipes
+create policy "users can insert own swipes"
+  on public.swipes for insert
+  with check (auth.uid() = swiper_id);
+
+-- Users can read swipes where they are swiper or target (needed for match detection)
+create policy "users can view relevant swipes"
+  on public.swipes for select
+  using (auth.uid() = swiper_id or auth.uid() = swiped_id);
+
+-- Indexes for fast lookups at scale
+create index on public.swipes (swiper_id);
+create index on public.swipes (swiped_id);
+-- Partial index: only index likes for fast match detection
+create index on public.swipes (swiped_id, swiper_id) where direction = 'like';


### PR DESCRIPTION
## Matches Tab

### Overview
Implements the Matches tab — users can now see everyone they've mutually liked with each other.

---

### New Files
- `apps/mobile/lib/matches.ts` — Data layer for fetching mutual matches from the swipes table
- `apps/mobile/screens/MatchesScreen.tsx` — Matches UI showing a list of matched users with their photo, name, age, and location

### Modified Files
- `apps/mobile/navigation/MainTabNavigator.tsx` — Wired in MatchesScreen to replace the placeholder

---

### How It Works
- Queries the swipes table to find everyone the current user liked
- Cross-references to find which of those users also liked them back
- Displays matches as a list sorted by most recent
- Each row shows the match's photo, name, age, location, and when they matched
- Message button is visible but inactive — will be connected when messaging is built

---

### Notes
- Message button is a placeholder for the upcoming messaging feature