### PR TITLE
Chats tab redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,199 @@
+# RoomPear — Claude Code Context
+
+## What this app is
+RoomPear is a mobile roommate-matching app built like a dating app. Users swipe on profiles, match mutually, and chat. Think Hinge but for finding a compatible roommate. Starting at UCR, targeting college students.
+
+## Tech stack
+- Frontend: Expo (~54) + React Native + TypeScript
+- Backend: Supabase (auth, postgres, realtime, storage)
+- Testing: Jest + React Native Testing Library (Supabase mocked)
+- Dev: VSCode + Claude Code (MCP connected to Supabase)
+
+## Monorepo structure
+```
+RoomPear/
+├── apps/mobile/          # Expo app — all active development here
+│   ├── App.tsx           # Root state machine (loading→auth→onboarding→home)
+│   ├── index.ts          # Expo entry point
+│   ├── app.config.js     # Expo config, loads .env via dotenv
+│   ├── screens/          # All screens
+│   ├── navigation/       # MainTabNavigator + MessagesStack
+│   ├── components/       # PublicProfileCard, ProfileDetailsForm
+│   └── lib/              # Supabase data layer
+└── package.json          # npm workspaces root
+```
+
+The `.env` file lives at `apps/mobile/.env` (not the repo root).
+Run expo from `apps/mobile/` or via `npm run dev:mobile` from root.
+
+---
+
+## Locked decisions — do not change without discussion
+- Photos come last in onboarding (step 9) as the "reveal moment"
+- No user_type branching — one unified profile, `has_listing` boolean handles place listings
+- Dealbreakers have 3 states: hard (removes from deck), soft (ranks lower), none (ignored)
+- Matching weights: Lifestyle 35%, Interests 30%, Budget 20%, Dealbreakers 15%
+- Match flow is Hinge-style mutual — both notified simultaneously
+- Pear icon used in match modal, not a heart
+- No ads in any free tier, ever
+- RevenueCat for subscription management
+- Tappable chips only in onboarding — no typed forms except personality prompt answers
+
+---
+
+## Current database (Supabase — project ref: vppjzlyncbpkdarnqdwl)
+
+### Tables
+- **profiles** — id (FK auth.users), email, name, phone, age, gender, ethnicity, bio, occupation, hobbies[], profile_photo_url, subscription_tier (free/premium), created_at, updated_at
+- **preferences** — user_id, city, state, zip_code, location, min_budget, max_budget, room_type, move_in_date, lease_duration_months, pets_allowed, smoking_allowed, cleanliness_level (1–5), social_preference, work_schedule, must_haves[], created_at, updated_at
+- **swipes** — id, swiper_id, swiped_id, direction (like/pass), created_at
+- **conversations** — id, last_message_at, last_message_preview, created_at
+- **conversation_participants** — conversation_id + user_id (composite PK), joined_at, last_read_at
+- **messages** — id, conversation_id, sender_id, body, created_at
+
+### Database functions
+- `handle_new_user` — trigger: auto-creates profiles row on auth signup
+- `handle_updated_at` — trigger: auto-updates updated_at
+- `handle_new_message` — trigger: updates conversation last_message_at + preview
+- `user_in_conversation(id)` — RLS helper: is current user a participant?
+- `match_peers_without_messages()` — RPC: mutual likes with no conversation yet
+- `get_or_create_match_conversation(other_user_id)` — RPC: idempotent DM thread creation
+- `get_unread_counts(conversation_ids[])` — RPC: unread count per conversation
+
+### RLS summary
+- profiles: any authenticated user can SELECT (public discovery); own row for INSERT/UPDATE
+- preferences: own row only
+- swipes: own inserts; SELECT where swiper or swiped
+- conversations/participants/messages: participants only
+
+### New columns added (migrations applied 2026-04-12)
+- `profiles.has_listing` — boolean, default false ✅
+- `profiles.prompts` — jsonb, default [] (array of {question, answer}, max 3) ✅
+- `preferences.interests` — jsonb, default {} (grouped by category e.g. {lifestyle: ["Early bird"]}) ✅
+- `preferences.dealbreakers` — jsonb, default {} (e.g. {smoking: "hard", pets: "soft"}) ✅
+- `listings` table — id, user_id, rent, room_type, address, city, state, zip_code, move_in_date, listing_photos (jsonb), created_at, updated_at. RLS enabled (authenticated can view all, owner can insert/update/delete) ✅
+
+### Note on brief vs actual schema
+The original brief described a `matches` table (user1_id, user2_id, status). This does NOT exist — match logic is handled via the `swipes` table + `match_peers_without_messages()` RPC. The `messages` schema also differs from the brief (uses conversation_id, not match_id; column is `body` not `message`).
+
+---
+
+## What's built and working
+
+### Auth
+- Email + password signup/login via Supabase
+- OAuth buttons (Google/Apple/Facebook) exist in UI but are NOT wired up
+
+### Onboarding (current — does not match final spec)
+Currently split across 3 separate screens, not a unified 10-step flow:
+1. `OnboardingScreen` — 7 steps: about-you, location, budget, room-type, move-in-date, lifestyle, must-haves. Uses a mix of tappable chips (gender, room type, lifestyle) and TextInput fields (age, ethnicity, city/state/zip, budget numbers). The `must-haves` step is a placeholder — renders "this can be added later" text and immediately calls complete.
+2. `ProfileCompletionScreen` — bio, occupation, hobbies (text forms, skippable)
+3. `ProfileCardScreen` — photo upload (3–5 required)
+
+### App state gating (App.tsx)
+- No session → `auth`
+- No preferences row → `onboarding`
+- ≥3 photos → `home` (profile-completion/profile-card skipped entirely)
+- <3 photos AND no bio/occupation/hobbies → `profile-completion`
+- <3 photos AND has any profile detail → `profile-card`
+
+### Navigation (current — does not match final spec)
+4 bottom tabs: **Discover / Matches / Messages / Profile**
+
+### Discover
+- Card stack, like/pass buttons, match celebration modal (minimal — no pear icon, no shared interests)
+- No filtering by location, budget, or dealbreakers
+- No scoring or algorithm — returns any profile with a photo, excludes already-swiped
+
+### Matches
+- Lists mutual likes with no conversation yet
+- Inline first-message UI that creates a DM thread
+
+### Messages
+- Conversation list with unread counts
+- Full 1:1 realtime chat via Supabase Realtime
+
+### Profile
+- View own public card
+- Edit name, bio, occupation, hobbies
+- Manage photos (add/remove — no reorder, order is insertion order)
+- Sign out
+- No upgrade/paywall button
+
+---
+
+## What still needs to be built (priority order)
+
+### ✅ 1. New DB columns + listings table — DONE
+`has_listing`, `prompts`, `interests`, `dealbreakers` added. `listings` table created.
+
+### 2. Full 10-step onboarding flow (redesign)
+Replace the current 3-screen split with a single unified flow. One question per screen, progress bar, chips only.
+1. Name, age, gender, ethnicity
+2. Location (city, state, zip)
+3. Budget (min/max slider)
+4. Room type + move-in date
+5. Lifestyle (cleanliness, schedule, social vibe)
+6. Dealbreakers (hard/soft/none per item)
+7. Interests (5-category accordion, up to 5 per category, custom input)
+8. Personality prompts (pick 2 required + 1 optional from 24 prompts, inline answers)
+9. Photos (up to 4, framed as the reveal moment)
+10. Place listing (optional — has_listing toggle, address, up to 6 photos)
+
+### 3. Redesigned swipe card
+Split photo panel design (mockup exists). Pass / Like / Top Pick / Undo actions. Swipe counter.
+
+### 4. Matching algorithm
+4 layers:
+1. Hard filters — location overlap, budget overlap, hard dealbreakers
+2. Compatibility score — Lifestyle 35%, Interests 30%, Budget 20%, Dealbreakers 15%
+3. Boost factors — premium users, new users (48hr boost), recently active
+4. Wild card injection — 80% high scorers, 20% random lower-scored profiles
+
+### 5. Dopamine loop + Likes tab
+- "Someone liked your profile" notification
+- Blurred teaser grid (photo blurred, interests visible)
+- 4 free reveal paths: swipe naturally / complete profile / 1 daily free reveal / invite a friend
+- Match modal: pear icon, both avatars, shared interests, send message CTA
+- Premium: see all likers unblurred
+
+### 6. Redesigned Chats tab
+Replace current Matches + Messages separate tabs with a single **Chats** tab containing:
+- Sub-tab: Matched (mutual likes, not yet messaged) — grid with sort chips
+- Sub-tab: Messages (active conversations) — list view
+
+### 7. Paywall + monetization
+- Enforce: 10 swipes/day free, 1 Top Pick/day, 1 free reveal/day
+- Paywall screen: 3 tiers ($7.99 / $12.99 / $19.99), like count banner, free escape link
+- Paywall triggers: tap blurred like, hit swipe limit, upgrade button in Profile
+- RevenueCat integration for subscription management
+
+### 8. Push notifications
+- "Someone liked your profile"
+- Match notifications (simultaneous for both users)
+- New message notifications
+
+---
+
+## Key files reference
+
+| Path | Purpose |
+|------|---------|
+| `apps/mobile/App.tsx` | Root state machine + auth listener |
+| `apps/mobile/lib/supabase.ts` | Supabase client init |
+| `apps/mobile/lib/discover.ts` | Fetch profiles, record swipes, detect matches |
+| `apps/mobile/lib/matches.ts` | Fetch mutual matches via RPC |
+| `apps/mobile/lib/messaging.ts` | Conversations, messages, unread counts, realtime |
+| `apps/mobile/lib/preferences.ts` | Read/write housing preferences |
+| `apps/mobile/lib/storage.ts` | Photo upload/delete/signed URLs |
+| `apps/mobile/lib/profilePhotos.ts` | Photo array management (3–5 limit) |
+| `apps/mobile/lib/profileDisplay.ts` | Normalize location strings + photo paths |
+| `apps/mobile/lib/types.ts` | Core TypeScript types — mostly stale/unused. `Listing` type doesn't match planned schema. `Preference` type is missing city/state/zip/work_schedule/must_haves. `Message` type uses old receiver_id/listing_id/content fields, not the actual schema. |
+| `apps/mobile/navigation/MainTabNavigator.tsx` | 4-tab root navigator |
+| `apps/mobile/navigation/MessagesStack.tsx` | Messages stack (list + chat) |
+| `apps/mobile/components/PublicProfileCard.tsx` | Reusable profile card with photo carousel |
+| `apps/mobile/components/ProfileDetailsForm.tsx` | Reusable bio/occupation/hobbies form |
+
+## Security notes (known issues to fix)
+- `handle_new_user` and `handle_updated_at` DB functions have mutable search_path (SQL injection risk)
+- Leaked password protection disabled in Supabase Auth settings

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -4,16 +4,13 @@ import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { Session } from '@supabase/supabase-js';
 import { supabase } from './lib/supabase';
 import { hasPreferences } from './lib/preferences';
-import { profilePhotoPathsFromRow } from './lib/profileDisplay';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AuthScreen from './screens/AuthScreen';
 import OnboardingScreen from './screens/OnboardingScreen';
-import ProfileCompletionScreen from './screens/ProfileCompletionScreen';
-import ProfileCardScreen from './screens/ProfileCardScreen';
 import MainTabNavigator from './navigation/MainTabNavigator';
 
-type AppState = 'loading' | 'auth' | 'onboarding' | 'profile-completion' | 'profile-card' | 'home';
+type AppState = 'loading' | 'auth' | 'onboarding' | 'home';
 
 export default function App() {
   const [session, setSession] = useState<Session | null>(null);
@@ -45,54 +42,10 @@ export default function App() {
     }
 
     const hasPrefs = await hasPreferences(session.user.id);
-
-    if (!hasPrefs) {
-      setAppState('onboarding');
-      return;
-    }
-
-    const { data: profile, error: profileError } = await supabase
-      .from('profiles')
-      .select('bio, occupation, hobbies, profile_photo_url')
-      .eq('id', session.user.id)
-      .single();
-
-    if (profileError) {
-      console.error('checkUserState: profile fetch failed', profileError);
-    }
-
-    const photoPaths = profilePhotoPathsFromRow(profile?.profile_photo_url);
-    const hasProfileCardPhotos = photoPaths.length >= 3;
-
-    const hasProfileDetails = Boolean(
-      profile?.bio?.trim() ||
-        profile?.occupation?.trim() ||
-        (profile?.hobbies && profile.hobbies.length > 0)
-    );
-
-    if (hasProfileCardPhotos) {
-      setAppState('home');
-      return;
-    }
-
-    if (!hasProfileDetails) {
-      setAppState('profile-completion');
-    } else {
-      setAppState('profile-card');
-    }
+    setAppState(hasPrefs ? 'home' : 'onboarding');
   };
 
-  const handleOnboardingComplete = async () => {
-    if (session) setAppState('profile-completion');
-  };
-
-  const handleProfileComplete = async () => {
-    if (session) setAppState('profile-card');
-  };
-
-  const handleProfileCardComplete = async () => {
-    if (session) await checkUserState(session);
-  };
+  const handleOnboardingComplete = () => setAppState('home');
 
   if (loading || appState === 'loading') {
     return (
@@ -110,12 +63,6 @@ export default function App() {
       {appState === 'auth' && <AuthScreen />}
       {appState === 'onboarding' && (
         <OnboardingScreen onComplete={handleOnboardingComplete} />
-      )}
-      {appState === 'profile-completion' && (
-        <ProfileCompletionScreen onComplete={handleProfileComplete} />
-      )}
-      {appState === 'profile-card' && (
-        <ProfileCardScreen onComplete={handleProfileCardComplete} />
       )}
       {appState === 'home' && (
         <NavigationContainer>

--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -1,0 +1,275 @@
+/**
+ * SwipeCard — split-panel profile card for the Discover deck.
+ * Top 60%: photo carousel with dot indicators.
+ * Bottom 40%: info panel (name, age, location, bio, hobby chips).
+ */
+
+import { useState, useRef, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Image,
+  FlatList,
+  StyleSheet,
+  TouchableOpacity,
+  Dimensions,
+  type NativeSyntheticEvent,
+  type NativeScrollEvent,
+  type ListRenderItemInfo,
+} from 'react-native';
+import type { DiscoverProfile } from '../lib/discover';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+// Fixed card dimensions — computed once so FlatList getItemLayout works
+export const CARD_WIDTH = SCREEN_WIDTH - 32; // 16px padding each side
+export const CARD_HEIGHT = SCREEN_HEIGHT * 0.63;
+const PHOTO_HEIGHT = Math.round(CARD_HEIGHT * 0.60);
+
+interface Props {
+  profile: DiscoverProfile;
+  onPress: () => void;
+}
+
+export default function SwipeCard({ profile, onPress }: Props) {
+  const [photoIndex, setPhotoIndex] = useState(0);
+  const listRef = useRef<FlatList<string>>(null);
+
+  const onMomentumScrollEnd = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const idx = Math.round(e.nativeEvent.contentOffset.x / CARD_WIDTH);
+      setPhotoIndex(Math.max(0, Math.min(idx, profile.photoUrls.length - 1)));
+    },
+    [profile.photoUrls.length]
+  );
+
+  const renderPhoto = useCallback(
+    ({ item }: ListRenderItemInfo<string>) => (
+      <Image
+        source={{ uri: item }}
+        style={{ width: CARD_WIDTH, height: PHOTO_HEIGHT }}
+        resizeMode="cover"
+      />
+    ),
+    []
+  );
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.97}
+      onPress={onPress}
+      style={styles.card}
+    >
+      {/* ── Photo section ── */}
+      <View style={[styles.photoSection, { height: PHOTO_HEIGHT }]}>
+        <FlatList
+          ref={listRef}
+          data={profile.photoUrls}
+          keyExtractor={(_, i) => `p${i}`}
+          renderItem={renderPhoto}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          decelerationRate="fast"
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          getItemLayout={(_, index) => ({
+            length: CARD_WIDTH,
+            offset: CARD_WIDTH * index,
+            index,
+          })}
+          scrollEventThrottle={16}
+        />
+
+        {/* Dot indicators */}
+        {profile.photoUrls.length > 1 && (
+          <View style={styles.dots} pointerEvents="none">
+            {profile.photoUrls.map((_, i) => (
+              <View
+                key={i}
+                style={[styles.dot, i === photoIndex ? styles.dotActive : styles.dotInactive]}
+              />
+            ))}
+          </View>
+        )}
+
+        {/* Photo counter badge */}
+        {profile.photoUrls.length > 1 && (
+          <View style={styles.photoBadge} pointerEvents="none">
+            <Text style={styles.photoBadgeText}>
+              {photoIndex + 1} / {profile.photoUrls.length}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* ── Divider ── */}
+      <View style={styles.divider} />
+
+      {/* ── Info section ── */}
+      <View style={styles.infoSection}>
+        {/* Name + age row */}
+        <View style={styles.nameRow}>
+          <Text style={styles.name} numberOfLines={1}>{profile.name}</Text>
+          {profile.age != null && (
+            <Text style={styles.age}>{profile.age}</Text>
+          )}
+        </View>
+
+        {/* Location */}
+        {!!profile.location && (
+          <Text style={styles.location} numberOfLines={1}>
+            📍 {profile.location}
+          </Text>
+        )}
+
+        {/* Bio */}
+        {!!profile.bio && (
+          <Text style={styles.bio} numberOfLines={2}>
+            {profile.bio}
+          </Text>
+        )}
+
+        {/* Hobby chips */}
+        {profile.hobbies && profile.hobbies.length > 0 && (
+          <View style={styles.chipsRow}>
+            {profile.hobbies.slice(0, 5).map((h, i) => (
+              <View key={i} style={styles.chip}>
+                <Text style={styles.chipText}>{h}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Tap hint */}
+        <Text style={styles.tapHint}>Tap to view full profile</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 20,
+    backgroundColor: '#FDFDFD',
+    overflow: 'hidden',
+    shadowColor: '#0C5389',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.10,
+    shadowRadius: 18,
+    elevation: 8,
+  },
+
+  // Photo
+  photoSection: {
+    width: CARD_WIDTH,
+    overflow: 'hidden',
+    position: 'relative',
+    backgroundColor: '#D9E1E6',
+  },
+  dots: {
+    position: 'absolute',
+    bottom: 10,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 5,
+  },
+  dot: {
+    height: 5,
+    borderRadius: 3,
+  },
+  dotActive: {
+    width: 18,
+    backgroundColor: '#FDFDFD',
+  },
+  dotInactive: {
+    width: 5,
+    backgroundColor: 'rgba(253,253,253,0.5)',
+  },
+  photoBadge: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+  },
+  photoBadgeText: {
+    color: '#FDFDFD',
+    fontSize: 11,
+    fontWeight: '600',
+  },
+
+  // Divider
+  divider: {
+    height: 1,
+    backgroundColor: '#E8EEF2',
+  },
+
+  // Info
+  infoSection: {
+    flex: 1,
+    paddingHorizontal: 18,
+    paddingTop: 14,
+    paddingBottom: 10,
+    backgroundColor: '#FDFDFD',
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 8,
+    marginBottom: 4,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: '#0C5389',
+    flexShrink: 1,
+  },
+  age: {
+    fontSize: 20,
+    fontWeight: '400',
+    color: '#0C5389',
+    opacity: 0.7,
+  },
+  location: {
+    fontSize: 13,
+    color: '#189AA2',
+    fontWeight: '500',
+    marginBottom: 6,
+  },
+  bio: {
+    fontSize: 13,
+    color: '#4A6070',
+    lineHeight: 19,
+    marginBottom: 8,
+  },
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginBottom: 6,
+  },
+  chip: {
+    backgroundColor: 'rgba(24,154,162,0.10)',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#189AA2',
+  },
+  tapHint: {
+    fontSize: 11,
+    color: '#9AA',
+    marginTop: 4,
+    textAlign: 'right',
+  },
+});

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -1,5 +1,7 @@
 import { supabase } from './supabase';
 import { getProfileImageUrls } from './storage';
+import { getPreferences, type Preferences } from './preferences';
+import { passesHardFilters, scoreCompatibility, applyWildcardMix } from './matching';
 
 export type DiscoverProfile = {
   id: string;
@@ -15,6 +17,9 @@ export async function fetchDiscoverProfiles(
   userId: string,
   limit = 10
 ): Promise<DiscoverProfile[]> {
+  // Fetch viewer's own preferences for filtering + scoring
+  const myPrefs = await getPreferences(userId);
+
   // Get IDs the user has already swiped on
   const { data: swipedRows } = await supabase
     .from('swipes')
@@ -23,29 +28,69 @@ export async function fetchDiscoverProfiles(
 
   const swipedIds = swipedRows?.map((r: any) => r.swiped_id) ?? [];
 
-  // Fetch other profiles, excluding self and already-swiped
+  // Fetch a larger candidate pool so filtering still leaves enough results
   let query = supabase
     .from('profiles')
-    .select('id, name, age, bio, hobbies, profile_photo_url, preferences(city, state)')
+    .select(
+      'id, name, age, bio, hobbies, profile_photo_url, subscription_tier, created_at, updated_at, ' +
+      'preferences(city, state, min_budget, max_budget, cleanliness_level, social_preference, ' +
+      'work_schedule, interests, dealbreakers, pets_allowed, smoking_allowed)'
+    )
     .neq('id', userId)
     .not('profile_photo_url', 'is', null)
-    .limit(limit);
+    .limit(50);
 
   if (swipedIds.length > 0) {
     query = query.not('id', 'in', `(${swipedIds.join(',')})`);
   }
 
-  const { data: rows, error } = await query;
+  const { data: rows, error } = await query as any;
   if (error || !rows) return [];
 
-  const result: DiscoverProfile[] = [];
+  // Score each candidate, applying hard filters when we have preference data
+  type ScoredRow = { row: typeof rows[0]; score: number };
+  const scored: ScoredRow[] = [];
 
   for (const row of rows) {
+    const theirPrefs = (
+      Array.isArray(row.preferences) ? row.preferences[0] : row.preferences
+    ) as Preferences | null;
+
+    if (myPrefs && theirPrefs) {
+      if (!passesHardFilters(myPrefs, theirPrefs)) continue;
+      const score = scoreCompatibility(myPrefs, theirPrefs, {
+        subscription_tier: row.subscription_tier,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        name: row.name,
+        age: row.age,
+        bio: row.bio,
+        hobbies: row.hobbies,
+      });
+      scored.push({ row, score });
+    } else {
+      // No preferences data on one side — include with neutral score
+      scored.push({ row, score: 0.5 });
+    }
+  }
+
+  // 80% top scorers + 20% wildcards, capped at limit
+  const mixed = applyWildcardMix(
+    scored.map(s => ({ item: s.row, score: s.score })),
+    Math.min(limit, scored.length)
+  );
+
+  // Load photos and build the final list
+  const result: DiscoverProfile[] = [];
+
+  for (const row of mixed) {
     const urls = await getProfileImageUrls(row.profile_photo_url);
     if (!urls || urls.length === 0) continue;
 
-    // Supabase returns 1:many as array even for 1:1 relationships
-    const prefs = Array.isArray(row.preferences) ? row.preferences[0] : row.preferences;
+    const prefs = (
+      Array.isArray(row.preferences) ? row.preferences[0] : row.preferences
+    ) as Preferences | null;
+
     const city = prefs?.city?.trim() ?? '';
     const state = prefs?.state?.trim() ?? '';
     const location = city && state ? `${city}, ${state}` : city || state;
@@ -67,7 +112,7 @@ export async function fetchDiscoverProfiles(
 export async function recordSwipe(
   swiperId: string,
   swipedId: string,
-  direction: 'like' | 'pass'
+  direction: 'like' | 'pass' | 'top_pick'
 ): Promise<{ isMatch: boolean }> {
   await supabase.from('swipes').insert({
     swiper_id: swiperId,
@@ -75,15 +120,16 @@ export async function recordSwipe(
     direction,
   });
 
-  if (direction !== 'like') return { isMatch: false };
+  // top_pick counts as a like for match detection
+  if (direction !== 'like' && direction !== 'top_pick') return { isMatch: false };
 
-  // Check if the other person already liked us back
+  // Check if the other person already liked or top-picked us back
   const { data } = await supabase
     .from('swipes')
     .select('id')
     .eq('swiper_id', swipedId)
     .eq('swiped_id', swiperId)
-    .eq('direction', 'like')
+    .in('direction', ['like', 'top_pick'])
     .maybeSingle();
 
   const isMatch = !!data;

--- a/apps/mobile/lib/likes.ts
+++ b/apps/mobile/lib/likes.ts
@@ -1,0 +1,105 @@
+import { supabase } from './supabase';
+import { getProfileImageUrls } from './storage';
+
+export type Liker = {
+  id: string;
+  name: string;
+  age: number | null;
+  location: string;
+  photoUrls: string[];
+  likedAt: string;
+};
+
+/**
+ * Returns profiles of people who liked/top-picked you but you haven't swiped back on yet.
+ */
+export async function fetchLikers(userId: string): Promise<Liker[]> {
+  // Who liked me
+  const { data: likeRows } = await supabase
+    .from('swipes')
+    .select('swiper_id, created_at')
+    .eq('swiped_id', userId)
+    .in('direction', ['like', 'top_pick']);
+
+  if (!likeRows || likeRows.length === 0) return [];
+
+  // Who I've already swiped back on
+  const { data: mySwipes } = await supabase
+    .from('swipes')
+    .select('swiped_id')
+    .eq('swiper_id', userId);
+
+  const alreadySwiped = new Set((mySwipes ?? []).map((r: any) => r.swiped_id));
+  const pending = likeRows.filter((r: any) => !alreadySwiped.has(r.swiper_id));
+
+  if (pending.length === 0) return [];
+
+  const likerIds = pending.map((r: any) => r.swiper_id);
+
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, name, age, profile_photo_url, preferences(city, state)')
+    .in('id', likerIds);
+
+  if (!profiles) return [];
+
+  const result: Liker[] = [];
+
+  for (const profile of profiles) {
+    const urls = profile.profile_photo_url
+      ? (await getProfileImageUrls(profile.profile_photo_url)) ?? []
+      : [];
+
+    const prefs = Array.isArray(profile.preferences)
+      ? profile.preferences[0]
+      : profile.preferences;
+    const city = prefs?.city?.trim() ?? '';
+    const state = prefs?.state?.trim() ?? '';
+    const location = city && state ? `${city}, ${state}` : city || state;
+
+    const row = pending.find((r: any) => r.swiper_id === profile.id);
+
+    result.push({
+      id: profile.id,
+      name: profile.name ?? 'Unknown',
+      age: profile.age ?? null,
+      location,
+      photoUrls: urls,
+      likedAt: row?.created_at ?? '',
+    });
+  }
+
+  // Most recent first
+  result.sort((a, b) => b.likedAt.localeCompare(a.likedAt));
+
+  return result;
+}
+
+/**
+ * Attempts to use the daily free reveal.
+ * Returns { success: true } if the reveal was granted,
+ * or { success: false, reason: 'already_used' } if today's reveal is spent.
+ */
+export async function useDailyReveal(
+  userId: string
+): Promise<{ success: boolean; reason?: 'already_used' }> {
+  const { data } = await supabase
+    .from('profiles')
+    .select('last_free_reveal_at')
+    .eq('id', userId)
+    .single();
+
+  const lastReveal: string | null = data?.last_free_reveal_at ?? null;
+  const todayStr = new Date().toDateString();
+
+  if (lastReveal && new Date(lastReveal).toDateString() === todayStr) {
+    return { success: false, reason: 'already_used' };
+  }
+
+  await supabase
+    .from('profiles')
+    .update({ last_free_reveal_at: new Date().toISOString() })
+    .eq('id', userId);
+
+  return { success: true };
+}

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -1,0 +1,225 @@
+/**
+ * Matching algorithm for RoomPear.
+ *
+ * 4 layers:
+ *   1. Hard filters  — location (same state), budget overlap, hard dealbreakers
+ *   2. Compatibility — Lifestyle 35% | Interests 30% | Budget 20% | Dealbreakers 15%
+ *   3. Boost factors — profile completeness ×1.0–1.20 | premium ×1.10
+ *                      new user <48 h ×1.15 | recently active <7 d ×1.05
+ *   4. Wildcard mix  — 80% top scorers + 20% random from the rest
+ */
+
+import type { Preferences } from './preferences';
+
+export interface ProfileMeta {
+  subscription_tier?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  // profile fields used for completeness scoring
+  name?: string | null;
+  age?: number | null;
+  bio?: string | null;
+  hobbies?: string[] | null;
+}
+
+// ─── Hard filters ────────────────────────────────────────────────────────────
+
+/**
+ * Returns false if the candidate should be excluded from the deck entirely.
+ */
+export function passesHardFilters(mine: Preferences, theirs: Preferences): boolean {
+  // Same state required (flexible for a small user base)
+  if (mine.state && theirs.state) {
+    if (mine.state.trim().toLowerCase() !== theirs.state.trim().toLowerCase()) {
+      return false;
+    }
+  }
+
+  // Budget ranges must overlap
+  if (
+    mine.min_budget != null && mine.max_budget != null &&
+    theirs.min_budget != null && theirs.max_budget != null
+  ) {
+    const overlapMax = Math.min(mine.max_budget, theirs.max_budget);
+    const overlapMin = Math.max(mine.min_budget, theirs.min_budget);
+    if (overlapMax < overlapMin) return false;
+  }
+
+  // Hard dealbreakers
+  const myDealbreakers = mine.dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(myDealbreakers)) {
+    if (severity !== 'hard') continue;
+    if (key === 'smoking' && theirs.smoking_allowed === true) return false;
+    if (key === 'pets' && theirs.pets_allowed === true) return false;
+  }
+
+  return true;
+}
+
+// ─── Compatibility score ──────────────────────────────────────────────────────
+
+/**
+ * Returns a raw compatibility score (0–1, higher = better).
+ * Boost factors can push it above 1.
+ */
+export function scoreCompatibility(
+  mine: Preferences,
+  theirs: Preferences,
+  theirMeta: ProfileMeta
+): number {
+  let score = 0;
+
+  // ── Lifestyle (35%) ────────────────────────────────────────────────────────
+  let lifestyleRaw = 0;
+  let lifestyleWeightSum = 0;
+
+  if (mine.cleanliness_level != null && theirs.cleanliness_level != null) {
+    const diff = Math.abs(mine.cleanliness_level - theirs.cleanliness_level);
+    lifestyleRaw += (1 - diff / 4) * 0.40;
+    lifestyleWeightSum += 0.40;
+  }
+  if (mine.social_preference && theirs.social_preference) {
+    lifestyleRaw += (mine.social_preference === theirs.social_preference ? 1 : 0) * 0.35;
+    lifestyleWeightSum += 0.35;
+  }
+  if (mine.work_schedule && theirs.work_schedule) {
+    lifestyleRaw += (mine.work_schedule === theirs.work_schedule ? 1 : 0) * 0.25;
+    lifestyleWeightSum += 0.25;
+  }
+
+  // Neutral (0.5) when no lifestyle data available
+  score += (lifestyleWeightSum > 0 ? lifestyleRaw / lifestyleWeightSum : 0.5) * 0.35;
+
+  // ── Interests (30%) ────────────────────────────────────────────────────────
+  const myInterests = flattenInterests(mine.interests);
+  const theirInterests = flattenInterests(theirs.interests);
+
+  if (myInterests.size > 0 && theirInterests.size > 0) {
+    const intersection = new Set([...myInterests].filter(x => theirInterests.has(x)));
+    const union = new Set([...myInterests, ...theirInterests]);
+    score += (intersection.size / union.size) * 0.30;
+  } else {
+    score += 0.15; // neutral when no interests data
+  }
+
+  // ── Budget (20%) ───────────────────────────────────────────────────────────
+  if (
+    mine.min_budget != null && mine.max_budget != null &&
+    theirs.min_budget != null && theirs.max_budget != null
+  ) {
+    const overlapMin = Math.max(mine.min_budget, theirs.min_budget);
+    const overlapMax = Math.min(mine.max_budget, theirs.max_budget);
+    const rangeMin = Math.min(mine.min_budget, theirs.min_budget);
+    const rangeMax = Math.max(mine.max_budget, theirs.max_budget);
+    const overlap = Math.max(0, overlapMax - overlapMin);
+    const range = rangeMax - rangeMin;
+    score += (range > 0 ? overlap / range : 1) * 0.20;
+  } else {
+    score += 0.10; // neutral
+  }
+
+  // ── Dealbreakers (15%) ─────────────────────────────────────────────────────
+  let dealScore = 0.15;
+  const myDealbreakers = mine.dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(myDealbreakers)) {
+    if (severity !== 'soft') continue;
+    if (key === 'smoking' && theirs.smoking_allowed === true) dealScore -= 0.05;
+    if (key === 'pets' && theirs.pets_allowed === true) dealScore -= 0.05;
+  }
+  score += Math.max(0, dealScore);
+
+  // ── City match bonus ────────────────────────────────────────────────────────
+  if (
+    mine.city && theirs.city &&
+    mine.city.trim().toLowerCase() === theirs.city.trim().toLowerCase()
+  ) {
+    score += 0.05;
+  }
+
+  // ── Boost factors ──────────────────────────────────────────────────────────
+
+  // Profile completeness (like Hinge/CMB — rewards users who filled out their profile)
+  // Max boost: ×1.20 for a fully completed profile
+  const completeness = profileCompletenessBoost(theirMeta, theirs);
+  score *= completeness;
+
+  if (theirMeta.subscription_tier === 'premium') {
+    score *= 1.10;
+  }
+  if (theirMeta.created_at) {
+    const ageHours = (Date.now() - new Date(theirMeta.created_at).getTime()) / 3_600_000;
+    if (ageHours < 48) score *= 1.15;
+  }
+  if (theirMeta.updated_at) {
+    const idleDays = (Date.now() - new Date(theirMeta.updated_at).getTime()) / 86_400_000;
+    if (idleDays < 7) score *= 1.05;
+  }
+
+  return score;
+}
+
+// ─── Profile completeness boost ──────────────────────────────────────────────
+
+/**
+ * Returns a multiplier between 1.0 and 1.20 based on how complete the profile is.
+ * Incentivises users to fill out their profile — same signal Hinge/CMB use.
+ *
+ * Fields checked (each worth equal share of the 0.20 range):
+ *   Profile: bio, hobbies (≥1), age
+ *   Preferences: city/state, budget, cleanliness, social_preference, work_schedule, interests (≥1 category)
+ */
+function profileCompletenessBoost(meta: ProfileMeta, prefs: Preferences): number {
+  const checks = [
+    !!meta.bio?.trim(),
+    Array.isArray(meta.hobbies) && meta.hobbies.length > 0,
+    meta.age != null,
+    !!(prefs.city?.trim()),
+    prefs.min_budget != null && prefs.max_budget != null,
+    prefs.cleanliness_level != null,
+    !!prefs.social_preference,
+    !!prefs.work_schedule,
+    prefs.interests != null && Object.values(prefs.interests).some(v => v.length > 0),
+  ];
+
+  const filled = checks.filter(Boolean).length;
+  const ratio = filled / checks.length; // 0 to 1
+  return 1.0 + ratio * 0.20;            // 1.0 to 1.20
+}
+
+// ─── Wildcard mix ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns `count` items: 80% from the top scorers, 20% random from the rest.
+ * Prevents filter-bubble lock-in.
+ */
+export function applyWildcardMix<T>(
+  scored: Array<{ item: T; score: number }>,
+  count: number
+): T[] {
+  if (scored.length === 0) return [];
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const topCount = Math.ceil(count * 0.8);
+  const wildcardCount = count - topCount;
+
+  const top = scored.slice(0, topCount).map(x => x.item);
+  const rest = scored
+    .slice(topCount)
+    .sort(() => Math.random() - 0.5)
+    .slice(0, wildcardCount)
+    .map(x => x.item);
+
+  return [...top, ...rest];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function flattenInterests(interests?: Record<string, string[]>): Set<string> {
+  if (!interests) return new Set();
+  const all: string[] = [];
+  for (const items of Object.values(interests)) {
+    all.push(...items.map(s => s.toLowerCase().trim()));
+  }
+  return new Set(all);
+}

--- a/apps/mobile/lib/preferences.ts
+++ b/apps/mobile/lib/preferences.ts
@@ -21,6 +21,8 @@ export interface Preferences {
   social_preference?: 'social' | 'quiet' | 'balanced';
   work_schedule?: string;
   must_haves?: string[];
+  interests?: Record<string, string[]>;
+  dealbreakers?: Record<string, 'hard' | 'soft' | 'none'>;
   created_at?: string;
   updated_at?: string;
 }

--- a/apps/mobile/navigation/ChatsStack.tsx
+++ b/apps/mobile/navigation/ChatsStack.tsx
@@ -21,9 +21,13 @@ export default function ChatsStack() {
       <Stack.Screen
         name="ChatsHome"
         component={ChatsScreen}
-        options={{ headerShown: false }}
+        options={{ headerShown: false, title: 'Chats' }}
       />
-      <Stack.Screen name="Chat" component={ChatScreen} />
+      <Stack.Screen
+        name="Chat"
+        component={ChatScreen}
+        options={{ headerBackTitle: 'Chats' }}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/mobile/navigation/ChatsStack.tsx
+++ b/apps/mobile/navigation/ChatsStack.tsx
@@ -1,0 +1,29 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ChatsScreen from '../screens/ChatsScreen';
+import ChatScreen from '../screens/ChatScreen';
+
+export type ChatsStackParamList = {
+  ChatsHome: undefined;
+  Chat: { conversationId?: string; otherUserId?: string; title: string };
+};
+
+const Stack = createNativeStackNavigator<ChatsStackParamList>();
+
+export default function ChatsStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerTintColor: '#0C5389',
+        headerTitleStyle: { fontWeight: '600' },
+        contentStyle: { backgroundColor: '#E8EEF2' },
+      }}
+    >
+      <Stack.Screen
+        name="ChatsHome"
+        component={ChatsScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen name="Chat" component={ChatScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/apps/mobile/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/navigation/MainTabNavigator.tsx
@@ -2,14 +2,14 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import type { NavigatorScreenParams } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import DiscoverScreen from '../screens/DiscoverScreen';
-import MatchesScreen from '../screens/MatchesScreen';
+import LikesScreen from '../screens/LikesScreen';
 import UserProfileScreen from '../screens/UserProfileScreen';
-import MessagesStack, { type MessagesStackParamList } from './MessagesStack';
+import ChatsStack, { type ChatsStackParamList } from './ChatsStack';
 
 export type MainTabParamList = {
   Discover: undefined;
-  Matches: undefined;
-  Messages: NavigatorScreenParams<MessagesStackParamList>;
+  Likes: undefined;
+  Chats: NavigatorScreenParams<ChatsStackParamList>;
   Profile: undefined;
 };
 
@@ -17,15 +17,15 @@ const Tab = createBottomTabNavigator<MainTabParamList>();
 
 const TAB_ICON: Record<keyof MainTabParamList, keyof typeof Ionicons.glyphMap> = {
   Discover: 'home-outline',
-  Matches: 'heart-outline',
-  Messages: 'chatbubble-outline',
+  Likes: 'heart-outline',
+  Chats: 'chatbubbles-outline',
   Profile: 'person-outline',
 };
 
 const TAB_ICON_FOCUSED: Record<keyof MainTabParamList, keyof typeof Ionicons.glyphMap> = {
   Discover: 'home',
-  Matches: 'heart',
-  Messages: 'chatbubble',
+  Likes: 'heart',
+  Chats: 'chatbubbles',
   Profile: 'person',
 };
 
@@ -54,8 +54,8 @@ export default function MainTabNavigator() {
       })}
     >
       <Tab.Screen name="Discover" component={DiscoverScreen} />
-      <Tab.Screen name="Matches" component={MatchesScreen} />
-      <Tab.Screen name="Messages" component={MessagesStack} />
+      <Tab.Screen name="Likes" component={LikesScreen} />
+      <Tab.Screen name="Chats" component={ChatsStack} />
       <Tab.Screen name="Profile" component={UserProfileScreen} />
     </Tab.Navigator>
   );

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^17.2.3",
     "expo": "~54.0.30",
     "expo-constants": "^18.0.12",
+    "expo-image-picker": "^55.0.18",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/apps/mobile/screens/ChatScreen.tsx
+++ b/apps/mobile/screens/ChatScreen.tsx
@@ -11,7 +11,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { MessagesStackParamList } from '../navigation/MessagesStack';
+import type { ChatsStackParamList } from '../navigation/ChatsStack';
 import { supabase } from '../lib/supabase';
 import {
   fetchMessages,
@@ -21,7 +21,7 @@ import {
   type ChatMessageRow,
 } from '../lib/messaging';
 
-type Props = NativeStackScreenProps<MessagesStackParamList, 'Chat'>;
+type Props = NativeStackScreenProps<ChatsStackParamList, 'Chat'>;
 
 export default function ChatScreen({ navigation, route }: Props) {
   const { conversationId: initialConversationId, otherUserId, title } = route.params;
@@ -50,6 +50,8 @@ export default function ChatScreen({ navigation, route }: Props) {
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!cancelled && user) setMyUserId(user.id);
     });
+
+    if (!conversationId) return;
 
     (async () => {
       const { data, error } = await fetchMessages(conversationId);

--- a/apps/mobile/screens/ChatsScreen.tsx
+++ b/apps/mobile/screens/ChatsScreen.tsx
@@ -1,0 +1,515 @@
+import { useCallback, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import {
+  View,
+  Text,
+  FlatList,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  RefreshControl,
+  ActivityIndicator,
+  Dimensions,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ChatsStackParamList } from '../navigation/ChatsStack';
+import { fetchMatches, type Match } from '../lib/matches';
+import { fetchConversationSummaries, type ConversationSummary } from '../lib/messaging';
+import { supabase } from '../lib/supabase';
+
+type Props = NativeStackScreenProps<ChatsStackParamList, 'ChatsHome'>;
+type SubTab = 'matched' | 'messages';
+type SortBy = 'recent' | 'name';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const GRID_PADDING = 16;
+const GRID_GAP = 12;
+const CARD_WIDTH = (SCREEN_WIDTH - GRID_PADDING * 2 - GRID_GAP) / 2;
+
+function formatMatchDate(iso: string) {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatConvTime(iso: string | null) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay =
+    d.getDate() === now.getDate() &&
+    d.getMonth() === now.getMonth() &&
+    d.getFullYear() === now.getFullYear();
+  if (sameDay) return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export default function ChatsScreen({ navigation }: Props) {
+  const [subTab, setSubTab] = useState<SubTab>('matched');
+  const [sortBy, setSortBy] = useState<SortBy>('recent');
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    const { data: sessionData } = await supabase.auth.getSession();
+    const uid = sessionData.session?.user.id;
+    if (!uid) {
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    const [matchData, { data: convData }] = await Promise.all([
+      fetchMatches(uid),
+      fetchConversationSummaries(),
+    ]);
+
+    setMatches(matchData);
+    setConversations(convData ?? []);
+    setLoading(false);
+    setRefreshing(false);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const sortedMatches = [...matches].sort((a, b) => {
+    if (sortBy === 'name') return a.name.localeCompare(b.name);
+    return b.matchedAt.localeCompare(a.matchedAt);
+  });
+
+  const totalUnread = conversations.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0);
+
+  function renderMatchItem({ item }: { item: Match }) {
+    return (
+      <TouchableOpacity
+        style={styles.gridCard}
+        activeOpacity={0.85}
+        onPress={() =>
+          navigation.navigate('Chat', { otherUserId: item.id, title: item.name })
+        }
+      >
+        {item.photoUrls.length > 0 ? (
+          <Image
+            source={{ uri: item.photoUrls[0] }}
+            style={styles.gridPhoto}
+            resizeMode="cover"
+          />
+        ) : (
+          <View style={[styles.gridPhoto, styles.gridPhotoPlaceholder]}>
+            <Text style={styles.gridPhotoInitial}>{item.name.slice(0, 1)}</Text>
+          </View>
+        )}
+        <View style={styles.gridInfo}>
+          <Text style={styles.gridName} numberOfLines={1}>
+            {item.name}{item.age ? `, ${item.age}` : ''}
+          </Text>
+          {!!item.location && (
+            <Text style={styles.gridLocation} numberOfLines={1}>{item.location}</Text>
+          )}
+          <Text style={styles.gridMatched}>Matched {formatMatchDate(item.matchedAt)}</Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+
+  function renderConvItem({ item }: { item: ConversationSummary }) {
+    return (
+      <TouchableOpacity
+        style={styles.convRow}
+        activeOpacity={0.7}
+        onPress={() =>
+          navigation.navigate('Chat', {
+            conversationId: item.conversationId,
+            title: item.otherDisplayName,
+          })
+        }
+      >
+        <View style={styles.convAvatar}>
+          {item.otherAvatarUrl ? (
+            <Image
+              source={{ uri: item.otherAvatarUrl }}
+              style={styles.convAvatarImg}
+              resizeMode="cover"
+            />
+          ) : (
+            <Text style={styles.convAvatarText}>
+              {item.otherDisplayName.slice(0, 1).toUpperCase()}
+            </Text>
+          )}
+        </View>
+        <View style={styles.convBody}>
+          <View style={styles.convTop}>
+            <Text style={styles.convName} numberOfLines={1}>{item.otherDisplayName}</Text>
+            <Text style={styles.convTime}>
+              {formatConvTime(item.lastMessageAt ?? item.conversationCreatedAt)}
+            </Text>
+          </View>
+          <View style={styles.convPreviewRow}>
+            <Text style={styles.convPreview} numberOfLines={1}>
+              {item.lastMessagePreview ?? 'No messages yet'}
+            </Text>
+            {item.unreadCount > 0 && (
+              <View style={styles.unreadBadge}>
+                <Text style={styles.unreadBadgeText}>
+                  {item.unreadCount > 99 ? '99+' : String(item.unreadCount)}
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.root} edges={['top']}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Chats</Text>
+      </View>
+
+      {/* Sub-tab pills */}
+      <View style={styles.tabRow}>
+        <TouchableOpacity
+          style={[styles.tabPill, subTab === 'matched' && styles.tabPillActive]}
+          onPress={() => setSubTab('matched')}
+        >
+          <Text style={[styles.tabPillText, subTab === 'matched' && styles.tabPillTextActive]}>
+            Matched{matches.length > 0 ? ` (${matches.length})` : ''}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tabPill, subTab === 'messages' && styles.tabPillActive]}
+          onPress={() => setSubTab('messages')}
+        >
+          <Text style={[styles.tabPillText, subTab === 'messages' && styles.tabPillTextActive]}>
+            Messages
+          </Text>
+          {totalUnread > 0 && subTab !== 'messages' && (
+            <View style={styles.tabBadge}>
+              <Text style={styles.tabBadgeText}>
+                {totalUnread > 99 ? '99+' : String(totalUnread)}
+              </Text>
+            </View>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color="#0C5389" />
+        </View>
+      ) : subTab === 'matched' ? (
+        <>
+          {sortedMatches.length > 0 && (
+            <View style={styles.sortRow}>
+              <TouchableOpacity
+                style={[styles.sortChip, sortBy === 'recent' && styles.sortChipActive]}
+                onPress={() => setSortBy('recent')}
+              >
+                <Text style={[styles.sortChipText, sortBy === 'recent' && styles.sortChipTextActive]}>
+                  Recent
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.sortChip, sortBy === 'name' && styles.sortChipActive]}
+                onPress={() => setSortBy('name')}
+              >
+                <Text style={[styles.sortChipText, sortBy === 'name' && styles.sortChipTextActive]}>
+                  Name
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+          <FlatList
+            data={sortedMatches}
+            keyExtractor={(item) => item.id}
+            numColumns={2}
+            columnWrapperStyle={styles.gridRow}
+            contentContainerStyle={styles.gridContent}
+            refreshControl={
+              <RefreshControl refreshing={refreshing} onRefresh={() => load(true)} tintColor="#0C5389" />
+            }
+            ListEmptyComponent={
+              <View style={styles.emptyWrap}>
+                <Text style={styles.emptyEmoji}>🎉</Text>
+                <Text style={styles.emptyTitle}>No matches yet</Text>
+                <Text style={styles.emptyText}>
+                  When you and someone both like each other, they'll show up here.
+                </Text>
+              </View>
+            }
+            renderItem={renderMatchItem}
+          />
+        </>
+      ) : (
+        <FlatList
+          data={conversations}
+          keyExtractor={(item) => item.conversationId}
+          contentContainerStyle={conversations.length === 0 ? styles.emptyList : undefined}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={() => load(true)} tintColor="#0C5389" />
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyWrap}>
+              <Text style={styles.emptyEmoji}>💬</Text>
+              <Text style={styles.emptyTitle}>No messages yet</Text>
+              <Text style={styles.emptyText}>
+                Match with someone and send them the first message!
+              </Text>
+            </View>
+          }
+          renderItem={renderConvItem}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#F4F7F9',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 12,
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#0C5389',
+  },
+  tabRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    marginBottom: 12,
+    gap: 8,
+  },
+  tabPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: '#E8EEF2',
+    gap: 6,
+  },
+  tabPillActive: {
+    backgroundColor: '#0C5389',
+  },
+  tabPillText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#4A6070',
+  },
+  tabPillTextActive: {
+    color: '#FDFDFD',
+  },
+  tabBadge: {
+    minWidth: 18,
+    height: 18,
+    paddingHorizontal: 5,
+    borderRadius: 9,
+    backgroundColor: '#E53935',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tabBadgeText: {
+    color: '#FDFDFD',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  sortRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    marginBottom: 12,
+    gap: 8,
+  },
+  sortChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
+  },
+  sortChipActive: {
+    backgroundColor: '#189AA2',
+    borderColor: '#189AA2',
+  },
+  sortChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#4A6070',
+  },
+  sortChipTextActive: {
+    color: '#FDFDFD',
+  },
+  gridContent: {
+    paddingHorizontal: GRID_PADDING,
+    paddingBottom: 32,
+  },
+  gridRow: {
+    justifyContent: 'space-between',
+    marginBottom: GRID_GAP,
+  },
+  gridCard: {
+    width: CARD_WIDTH,
+    borderRadius: 16,
+    backgroundColor: '#FDFDFD',
+    overflow: 'hidden',
+    shadowColor: '#0C5389',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  gridPhoto: {
+    width: CARD_WIDTH,
+    height: CARD_WIDTH,
+    backgroundColor: '#D9E1E6',
+  },
+  gridPhotoPlaceholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gridPhotoInitial: {
+    fontSize: 36,
+    fontWeight: '700',
+    color: '#FDFDFD',
+  },
+  gridInfo: {
+    padding: 10,
+  },
+  gridName: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#0C5389',
+    marginBottom: 2,
+  },
+  gridLocation: {
+    fontSize: 12,
+    color: '#189AA2',
+    marginBottom: 4,
+  },
+  gridMatched: {
+    fontSize: 11,
+    color: '#4A6070',
+    opacity: 0.6,
+  },
+  emptyList: {
+    flexGrow: 1,
+  },
+  convRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    backgroundColor: '#FDFDFD',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E8EEF2',
+  },
+  convAvatar: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: '#189AA2',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+    overflow: 'hidden',
+  },
+  convAvatarImg: {
+    width: 50,
+    height: 50,
+  },
+  convAvatarText: {
+    color: '#FDFDFD',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  convBody: {
+    flex: 1,
+    minWidth: 0,
+  },
+  convTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    gap: 8,
+  },
+  convName: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#0C5389',
+  },
+  convTime: {
+    fontSize: 12,
+    color: '#189AA2',
+  },
+  convPreviewRow: {
+    marginTop: 3,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  convPreview: {
+    flex: 1,
+    fontSize: 14,
+    color: '#4A6070',
+    lineHeight: 19,
+  },
+  unreadBadge: {
+    minWidth: 20,
+    height: 20,
+    paddingHorizontal: 6,
+    borderRadius: 10,
+    backgroundColor: '#0C5389',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  unreadBadgeText: {
+    color: '#FDFDFD',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  emptyWrap: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    paddingTop: 60,
+  },
+  emptyEmoji: {
+    fontSize: 48,
+    marginBottom: 12,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#0C5389',
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: '#4A6070',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -294,13 +294,16 @@ export default function DiscoverScreen() {
       <Modal visible={!!matchName} transparent animationType="fade">
         <View style={styles.matchOverlay}>
           <View style={styles.matchCard}>
-            <Text style={styles.matchEmoji}>🎉</Text>
+            <Text style={styles.matchEmoji}>🍐</Text>
             <Text style={styles.matchTitle}>It's a Match!</Text>
             <Text style={styles.matchSub}>
-              You and {matchName} both liked each other.
+              You and {matchName} both liked each other.{'\n'}Start the conversation!
             </Text>
-            <TouchableOpacity style={styles.matchBtn} onPress={() => setMatchName(null)}>
-              <Text style={styles.matchBtnText}>Keep Going</Text>
+            <TouchableOpacity
+              style={styles.matchBtn}
+              onPress={() => setMatchName(null)}
+            >
+              <Text style={styles.matchBtnText}>Keep Swiping</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -10,33 +10,28 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { supabase } from '../lib/supabase';
 import { fetchDiscoverProfiles, recordSwipe, type DiscoverProfile } from '../lib/discover';
-import PublicProfileCard from '../components/PublicProfileCard';
+import SwipeCard from '../components/SwipeCard';
 
-const SCREEN_WIDTH = Dimensions.get('window').width;
-const SCREEN_HEIGHT = Dimensions.get('window').height;
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
-const COLORS = {
-  blue: '#0C5389',
-  teal: '#189AA2',
-  green: '#46BD7F',
-  white: '#FDFDFD',
-  ink: '#0B1B2B',
-  border: '#D9E1E6',
-  text: '#2B3A4A',
-};
+type Action = 'like' | 'pass' | 'top_pick';
 
 export default function DiscoverScreen() {
   const [userId, setUserId] = useState<string | null>(null);
   const [profiles, setProfiles] = useState<DiscoverProfile[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [loading, setLoading] = useState(true);
+  const [actionDisabled, setActionDisabled] = useState(false);
   const [matchName, setMatchName] = useState<string | null>(null);
   const [expandedProfile, setExpandedProfile] = useState<DiscoverProfile | null>(null);
-  const [actionDisabled, setActionDisabled] = useState(false);
+  const [loading, setLoading] = useState(true);
 
-  const fadeAnim = useRef(new Animated.Value(1)).current;
+  // Animation values for the front card
+  const translateX = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(0)).current;
+  const cardOpacity = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
@@ -51,144 +46,214 @@ export default function DiscoverScreen() {
     const data = await fetchDiscoverProfiles(uid);
     setProfiles(data);
     setCurrentIndex(0);
+    translateX.setValue(0);
+    translateY.setValue(0);
+    cardOpacity.setValue(1);
     setLoading(false);
   }
 
-  async function handleAction(direction: 'like' | 'pass') {
+  // Animate the card flying off in the given direction, then advance to next
+  function animateOut(direction: Action, onDone: () => void) {
+    const toX =
+      direction === 'like' ? SCREEN_WIDTH * 1.5
+      : direction === 'pass' ? -SCREEN_WIDTH * 1.5
+      : 0;
+    const toY = direction === 'top_pick' ? -SCREEN_HEIGHT : 0;
+
+    Animated.parallel([
+      Animated.timing(translateX, {
+        toValue: toX,
+        duration: 280,
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateY, {
+        toValue: toY,
+        duration: 280,
+        useNativeDriver: true,
+      }),
+      Animated.timing(cardOpacity, {
+        toValue: 0,
+        duration: 220,
+        useNativeDriver: true,
+      }),
+    ]).start(() => {
+      // Reset values before content changes so new card appears at origin
+      translateX.setValue(0);
+      translateY.setValue(0);
+      cardOpacity.setValue(1);
+      onDone();
+    });
+  }
+
+  async function handleAction(direction: Action) {
     if (actionDisabled) return;
     setActionDisabled(true);
 
-    // Fade out current card
-    Animated.timing(fadeAnim, {
-      toValue: 0,
-      duration: 200,
-      useNativeDriver: true,
-    }).start(async () => {
-      const current = profiles[currentIndex];
+    const current = profiles[currentIndex];
+
+    animateOut(direction, async () => {
       if (current && userId) {
         const { isMatch } = await recordSwipe(userId, current.id, direction);
         if (isMatch) setMatchName(current.name);
       }
-
       setCurrentIndex((prev) => prev + 1);
-
-      // Fade in next card
-      Animated.timing(fadeAnim, {
-        toValue: 1,
-        duration: 200,
-        useNativeDriver: true,
-      }).start(() => setActionDisabled(false));
+      setActionDisabled(false);
     });
   }
 
+  function handleUndo() {
+    if (actionDisabled || currentIndex === 0) return;
+    setActionDisabled(true);
+    cardOpacity.setValue(0);
+    setCurrentIndex((prev) => prev - 1);
+    Animated.timing(cardOpacity, {
+      toValue: 1,
+      duration: 220,
+      useNativeDriver: true,
+    }).start(() => setActionDisabled(false));
+  }
+
   const currentProfile = profiles[currentIndex];
-  const hasMore = currentIndex < profiles.length;
+  const nextProfile = profiles[currentIndex + 1];
+  const remaining = profiles.length - currentIndex;
 
   if (loading) {
     return (
       <View style={styles.centered}>
-        <Text style={styles.emptyText}>Finding roommates...</Text>
+        <Text style={styles.emptyText}>Finding roommates…</Text>
       </View>
     );
   }
 
-  if (!hasMore) {
+  if (!currentProfile) {
     return (
       <View style={styles.centered}>
         <Text style={styles.emptyTitle}>You're all caught up</Text>
         <Text style={styles.emptyText}>No more profiles right now.{'\n'}Check back later!</Text>
         <TouchableOpacity
-          style={styles.refreshButton}
+          style={styles.refreshBtn}
           onPress={() => userId && loadProfiles(userId)}
         >
-          <Text style={styles.refreshButtonText}>Refresh</Text>
+          <Text style={styles.refreshBtnText}>Refresh</Text>
         </TouchableOpacity>
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.header}>Discover</Text>
+    <SafeAreaView style={styles.root} edges={['top']}>
+      {/* ── Header ── */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Discover</Text>
+        <Text style={styles.headerCount}>
+          {remaining} {remaining === 1 ? 'person' : 'people'} nearby
+        </Text>
+      </View>
 
+      {/* ── Card stack ── */}
       <View style={styles.cardArea}>
-        <Animated.View style={{ opacity: fadeAnim, width: '100%' }}>
-          <TouchableOpacity
-            activeOpacity={0.95}
+        {/* Back card — static, slightly smaller */}
+        {nextProfile && (
+          <View style={styles.backCardWrap} pointerEvents="none">
+            <SwipeCard profile={nextProfile} onPress={() => {}} />
+          </View>
+        )}
+
+        {/* Front card — animated */}
+        <Animated.View
+          style={[
+            styles.frontCardWrap,
+            {
+              transform: [{ translateX }, { translateY }],
+              opacity: cardOpacity,
+            },
+          ]}
+        >
+          <SwipeCard
+            profile={currentProfile}
             onPress={() => setExpandedProfile(currentProfile)}
-          >
-            <PublicProfileCard
-              imageUrls={currentProfile.photoUrls}
-              name={currentProfile.name}
-              age={currentProfile.age}
-              location={currentProfile.location}
-              bio={currentProfile.bio}
-              hobbies={currentProfile.hobbies}
-            />
-          </TouchableOpacity>
-          <Text style={styles.tapHint}>Tap card to view full profile</Text>
+          />
         </Animated.View>
       </View>
 
-      {/* Action buttons */}
+      {/* ── Action buttons ── */}
       <View style={styles.actions}>
+        {/* Undo */}
         <TouchableOpacity
-          style={[styles.passButton, actionDisabled && styles.buttonDisabled]}
+          style={[styles.btn, styles.btnUndo, (actionDisabled || currentIndex === 0) && styles.btnDisabled]}
+          onPress={handleUndo}
+          disabled={actionDisabled || currentIndex === 0}
+        >
+          <Text style={[styles.btnIcon, styles.btnIconUndo]}>↩</Text>
+        </TouchableOpacity>
+
+        {/* Pass */}
+        <TouchableOpacity
+          style={[styles.btn, styles.btnPass, actionDisabled && styles.btnDisabled]}
           onPress={() => handleAction('pass')}
           disabled={actionDisabled}
         >
-          <Text style={styles.passIcon}>✕</Text>
+          <Text style={[styles.btnIcon, styles.btnIconPass]}>✕</Text>
         </TouchableOpacity>
+
+        {/* Top Pick */}
         <TouchableOpacity
-          style={[styles.likeButton, actionDisabled && styles.buttonDisabled]}
+          style={[styles.btn, styles.btnTop, actionDisabled && styles.btnDisabled]}
+          onPress={() => handleAction('top_pick')}
+          disabled={actionDisabled}
+        >
+          <Text style={[styles.btnIcon, styles.btnIconTop]}>★</Text>
+        </TouchableOpacity>
+
+        {/* Like */}
+        <TouchableOpacity
+          style={[styles.btn, styles.btnLike, actionDisabled && styles.btnDisabled]}
           onPress={() => handleAction('like')}
           disabled={actionDisabled}
         >
-          <Text style={styles.likeIcon}>♥</Text>
+          <Text style={[styles.btnIcon, styles.btnIconLike]}>♥</Text>
         </TouchableOpacity>
       </View>
 
-      {/* Full profile modal */}
+      {/* ── Full profile modal ── */}
       <Modal visible={!!expandedProfile} animationType="slide" statusBarTranslucent>
         {expandedProfile && (
           <View style={styles.profileModal}>
             <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
-              {/* Photo gallery */}
               <ScrollView
                 horizontal
                 pagingEnabled
                 showsHorizontalScrollIndicator={false}
-                style={styles.photoScroll}
+                style={{ height: SCREEN_HEIGHT * 0.55 }}
               >
                 {expandedProfile.photoUrls.map((url, i) => (
                   <Image
                     key={i}
                     source={{ uri: url }}
-                    style={[styles.fullPhoto, { width: SCREEN_WIDTH }]}
+                    style={{ width: SCREEN_WIDTH, height: SCREEN_HEIGHT * 0.55 }}
                     resizeMode="cover"
                   />
                 ))}
               </ScrollView>
 
-              {/* Info */}
               <View style={styles.profileInfo}>
                 <Text style={styles.profileName}>
                   {expandedProfile.name}
                   {expandedProfile.age ? `, ${expandedProfile.age}` : ''}
                 </Text>
                 {expandedProfile.location ? (
-                  <Text style={styles.profileLocation}>{expandedProfile.location}</Text>
+                  <Text style={styles.profileLocation}>📍 {expandedProfile.location}</Text>
                 ) : null}
                 {expandedProfile.bio ? (
                   <Text style={styles.profileBio}>{expandedProfile.bio}</Text>
                 ) : null}
                 {expandedProfile.hobbies && expandedProfile.hobbies.length > 0 && (
                   <>
-                    <Text style={styles.hobbiesLabel}>Interests</Text>
-                    <View style={styles.hobbiesRow}>
+                    <Text style={styles.profileSectionLabel}>Interests</Text>
+                    <View style={styles.profileChips}>
                       {expandedProfile.hobbies.map((h, i) => (
-                        <View key={i} style={styles.hobbyChip}>
-                          <Text style={styles.hobbyChipText}>{h}</Text>
+                        <View key={i} style={styles.profileChip}>
+                          <Text style={styles.profileChipText}>{h}</Text>
                         </View>
                       ))}
                     </View>
@@ -197,180 +262,162 @@ export default function DiscoverScreen() {
               </View>
             </ScrollView>
 
-            {/* Bottom actions */}
             <View style={styles.modalActions}>
               <TouchableOpacity
-                style={styles.passButton}
-                onPress={() => {
-                  setExpandedProfile(null);
-                  handleAction('pass');
-                }}
+                style={[styles.btn, styles.btnPass]}
+                onPress={() => { setExpandedProfile(null); handleAction('pass'); }}
               >
-                <Text style={styles.passIcon}>✕</Text>
+                <Text style={[styles.btnIcon, styles.btnIconPass]}>✕</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={styles.likeButton}
-                onPress={() => {
-                  setExpandedProfile(null);
-                  handleAction('like');
-                }}
+                style={[styles.btn, styles.btnTop]}
+                onPress={() => { setExpandedProfile(null); handleAction('top_pick'); }}
               >
-                <Text style={styles.likeIcon}>♥</Text>
+                <Text style={[styles.btnIcon, styles.btnIconTop]}>★</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.btn, styles.btnLike]}
+                onPress={() => { setExpandedProfile(null); handleAction('like'); }}
+              >
+                <Text style={[styles.btnIcon, styles.btnIconLike]}>♥</Text>
               </TouchableOpacity>
             </View>
 
-            {/* Close */}
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={() => setExpandedProfile(null)}
-            >
-              <Text style={styles.closeButtonText}>✕</Text>
+            <TouchableOpacity style={styles.closeBtn} onPress={() => setExpandedProfile(null)}>
+              <Text style={styles.closeBtnText}>✕</Text>
             </TouchableOpacity>
           </View>
         )}
       </Modal>
 
-      {/* Match modal */}
+      {/* ── Match modal ── */}
       <Modal visible={!!matchName} transparent animationType="fade">
-        <View style={styles.modalOverlay}>
+        <View style={styles.matchOverlay}>
           <View style={styles.matchCard}>
             <Text style={styles.matchEmoji}>🎉</Text>
             <Text style={styles.matchTitle}>It's a Match!</Text>
-            <Text style={styles.matchSub}>You and {matchName} both liked each other.</Text>
-            <TouchableOpacity style={styles.matchButton} onPress={() => setMatchName(null)}>
-              <Text style={styles.matchButtonText}>Keep Going</Text>
+            <Text style={styles.matchSub}>
+              You and {matchName} both liked each other.
+            </Text>
+            <TouchableOpacity style={styles.matchBtn} onPress={() => setMatchName(null)}>
+              <Text style={styles.matchBtnText}>Keep Going</Text>
             </TouchableOpacity>
           </View>
         </View>
       </Modal>
-    </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  root: {
     flex: 1,
-    backgroundColor: COLORS.white,
-    paddingTop: 60,
-  },
-  header: {
-    fontSize: 28,
-    fontWeight: '800',
-    color: COLORS.ink,
-    paddingHorizontal: 20,
-    marginBottom: 12,
-  },
-  cardArea: {
-    flex: 1,
-    paddingHorizontal: 16,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  tapHint: {
-    textAlign: 'center',
-    marginTop: 10,
-    fontSize: 12,
-    color: COLORS.text,
-    opacity: 0.45,
-  },
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 40,
-    paddingVertical: 24,
-    paddingBottom: 36,
-  },
-  modalActions: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 40,
-    paddingVertical: 20,
-    paddingBottom: 36,
-    backgroundColor: COLORS.white,
-    borderTopWidth: 1,
-    borderTopColor: COLORS.border,
-  },
-  passButton: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    backgroundColor: COLORS.white,
-    borderWidth: 2,
-    borderColor: '#E53935',
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  passIcon: {
-    fontSize: 26,
-    color: '#E53935',
-  },
-  likeButton: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    backgroundColor: COLORS.white,
-    borderWidth: 2,
-    borderColor: COLORS.green,
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  likeIcon: {
-    fontSize: 26,
-    color: COLORS.green,
-  },
-  buttonDisabled: {
-    opacity: 0.4,
+    backgroundColor: '#F4F7F9',
   },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: 32,
-    backgroundColor: COLORS.white,
+    backgroundColor: '#F4F7F9',
   },
   emptyTitle: {
     fontSize: 22,
     fontWeight: '800',
-    color: COLORS.ink,
+    color: '#0C5389',
     marginBottom: 8,
   },
   emptyText: {
     fontSize: 15,
-    color: COLORS.text,
+    color: '#4A6070',
     textAlign: 'center',
     lineHeight: 22,
   },
-  refreshButton: {
+  refreshBtn: {
     marginTop: 24,
-    backgroundColor: COLORS.blue,
+    backgroundColor: '#0C5389',
     paddingHorizontal: 28,
     paddingVertical: 12,
     borderRadius: 14,
   },
-  refreshButtonText: {
-    color: '#fff',
+  refreshBtnText: {
+    color: '#FDFDFD',
     fontWeight: '700',
     fontSize: 15,
   },
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 12,
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#0C5389',
+  },
+  headerCount: {
+    fontSize: 13,
+    color: '#189AA2',
+    fontWeight: '600',
+  },
+
+  // Card area
+  cardArea: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+  },
+  backCardWrap: {
+    position: 'absolute',
+    transform: [{ scale: 0.96 }, { translateY: 10 }],
+    opacity: 0.7,
+  },
+  frontCardWrap: {
+    position: 'absolute',
+  },
+
+  // Action buttons
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+    paddingVertical: 20,
+    paddingBottom: 28,
+    backgroundColor: '#F4F7F9',
+  },
+  btn: {
+    borderRadius: 100,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FDFDFD',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 3 },
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  btnDisabled: { opacity: 0.35 },
+  btnUndo: { width: 52, height: 52, borderWidth: 1.5, borderColor: '#C0CDD6' },
+  btnPass: { width: 64, height: 64, borderWidth: 2, borderColor: '#E53935' },
+  btnTop:  { width: 64, height: 64, borderWidth: 2, borderColor: '#F59E0B' },
+  btnLike: { width: 72, height: 72, borderWidth: 2, borderColor: '#189AA2' },
+  btnIcon: { fontSize: 24 },
+  btnIconUndo: { color: '#9AA', fontSize: 20 },
+  btnIconPass: { color: '#E53935' },
+  btnIconTop:  { color: '#F59E0B' },
+  btnIconLike: { color: '#189AA2', fontSize: 26 },
+
+  // Full profile modal
   profileModal: {
     flex: 1,
-    backgroundColor: COLORS.white,
-  },
-  photoScroll: {
-    height: SCREEN_HEIGHT * 0.55,
-  },
-  fullPhoto: {
-    height: SCREEN_HEIGHT * 0.55,
+    backgroundColor: '#FDFDFD',
   },
   profileInfo: {
     padding: 24,
@@ -379,46 +426,57 @@ const styles = StyleSheet.create({
   profileName: {
     fontSize: 28,
     fontWeight: '800',
-    color: COLORS.ink,
+    color: '#0C5389',
   },
   profileLocation: {
-    fontSize: 16,
-    color: COLORS.teal,
+    fontSize: 15,
+    color: '#189AA2',
     fontWeight: '500',
     marginTop: 4,
   },
   profileBio: {
     fontSize: 15,
-    color: COLORS.text,
+    color: '#4A6070',
     lineHeight: 22,
     marginTop: 16,
   },
-  hobbiesLabel: {
-    fontSize: 13,
+  profileSectionLabel: {
+    fontSize: 12,
     fontWeight: '700',
-    color: COLORS.text,
+    color: '#4A6070',
     marginTop: 20,
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.8,
   },
-  hobbiesRow: {
+  profileChips: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 8,
   },
-  hobbyChip: {
+  profileChip: {
     backgroundColor: 'rgba(24,154,162,0.12)',
     paddingHorizontal: 14,
     paddingVertical: 7,
     borderRadius: 16,
   },
-  hobbyChipText: {
+  profileChipText: {
     fontSize: 13,
     fontWeight: '600',
-    color: COLORS.teal,
+    color: '#189AA2',
   },
-  closeButton: {
+  modalActions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 20,
+    paddingVertical: 20,
+    paddingBottom: 36,
+    backgroundColor: '#FDFDFD',
+    borderTopWidth: 1,
+    borderTopColor: '#E8EEF2',
+  },
+  closeBtn: {
     position: 'absolute',
     top: 52,
     right: 16,
@@ -429,19 +487,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  closeButtonText: {
-    color: '#fff',
+  closeBtnText: {
+    color: '#FDFDFD',
     fontSize: 16,
     fontWeight: '700',
   },
-  modalOverlay: {
+
+  // Match modal
+  matchOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0,0,0,0.55)',
     justifyContent: 'center',
     alignItems: 'center',
   },
   matchCard: {
-    backgroundColor: COLORS.white,
+    backgroundColor: '#FDFDFD',
     borderRadius: 24,
     padding: 32,
     alignItems: 'center',
@@ -455,24 +515,24 @@ const styles = StyleSheet.create({
   matchTitle: {
     fontSize: 28,
     fontWeight: '900',
-    color: COLORS.ink,
+    color: '#0C5389',
     marginBottom: 8,
   },
   matchSub: {
     fontSize: 15,
-    color: COLORS.text,
+    color: '#4A6070',
     textAlign: 'center',
     lineHeight: 22,
     marginBottom: 24,
   },
-  matchButton: {
-    backgroundColor: COLORS.blue,
+  matchBtn: {
+    backgroundColor: '#0C5389',
     paddingHorizontal: 28,
     paddingVertical: 12,
     borderRadius: 14,
   },
-  matchButtonText: {
-    color: '#fff',
+  matchBtnText: {
+    color: '#FDFDFD',
     fontWeight: '700',
     fontSize: 15,
   },

--- a/apps/mobile/screens/LikesScreen.tsx
+++ b/apps/mobile/screens/LikesScreen.tsx
@@ -1,0 +1,471 @@
+import { useCallback, useState } from 'react';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import {
+  View,
+  Text,
+  FlatList,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  RefreshControl,
+  Dimensions,
+  Alert,
+  Modal,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { supabase } from '../lib/supabase';
+import { fetchLikers, useDailyReveal, type Liker } from '../lib/likes';
+import { recordSwipe } from '../lib/discover';
+import type { MainTabParamList } from '../navigation/MainTabNavigator';
+
+type NavProp = BottomTabNavigationProp<MainTabParamList>;
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const GRID_PADDING = 16;
+const GRID_GAP = 12;
+const CARD_WIDTH = (SCREEN_WIDTH - GRID_PADDING * 2 - GRID_GAP) / 2;
+
+export default function LikesScreen() {
+  const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
+  const [userId, setUserId] = useState<string | null>(null);
+  const [likers, setLikers] = useState<Liker[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [revealedIds, setRevealedIds] = useState<Set<string>>(new Set());
+  const [likedBackIds, setLikedBackIds] = useState<Set<string>>(new Set());
+  const [revealUsed, setRevealUsed] = useState(false);
+  const [matchName, setMatchName] = useState<string | null>(null);
+
+  const load = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    const { data: sessionData } = await supabase.auth.getSession();
+    const uid = sessionData.session?.user.id;
+    if (!uid) {
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+    setUserId(uid);
+
+    // Check if daily reveal is already used today
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('last_free_reveal_at')
+      .eq('id', uid)
+      .single();
+
+    const lastReveal: string | null = profile?.last_free_reveal_at ?? null;
+    const usedToday = !!lastReveal && new Date(lastReveal).toDateString() === new Date().toDateString();
+    setRevealUsed(usedToday);
+
+    const data = await fetchLikers(uid);
+    setLikers(data);
+    setLoading(false);
+    setRefreshing(false);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  async function handleLikeBack(liker: Liker) {
+    if (!userId || likedBackIds.has(liker.id)) return;
+    setLikedBackIds((prev) => new Set([...prev, liker.id]));
+    const { isMatch } = await recordSwipe(userId, liker.id, 'like');
+    if (isMatch) {
+      setMatchName(liker.name);
+    }
+  }
+
+  async function handleReveal(liker: Liker) {
+    if (revealedIds.has(liker.id)) return;
+
+    if (revealUsed) {
+      Alert.alert(
+        'No reveals left',
+        'You\'ve used your free reveal for today. Come back tomorrow, or go Premium for unlimited reveals.',
+        [{ text: 'OK' }]
+      );
+      return;
+    }
+
+    if (!userId) return;
+
+    const result = await useDailyReveal(userId);
+    if (result.success) {
+      setRevealedIds((prev) => new Set([...prev, liker.id]));
+      setRevealUsed(true);
+    } else {
+      Alert.alert(
+        'No reveals left',
+        'You\'ve used your free reveal for today. Come back tomorrow, or go Premium for unlimited reveals.',
+        [{ text: 'OK' }]
+      );
+    }
+  }
+
+  function renderItem({ item }: { item: Liker }) {
+    const isRevealed = revealedIds.has(item.id);
+    const photo = item.photoUrls[0];
+
+    return (
+      <View style={styles.card}>
+        {/* Photo — blurred unless revealed */}
+        <View style={styles.photoWrap}>
+          {photo ? (
+            <Image
+              source={{ uri: photo }}
+              style={styles.photo}
+              resizeMode="cover"
+              blurRadius={isRevealed ? 0 : 18}
+            />
+          ) : (
+            <View style={[styles.photo, styles.photoPlaceholder]}>
+              <Text style={styles.photoInitial}>
+                {isRevealed ? item.name.slice(0, 1) : '?'}
+              </Text>
+            </View>
+          )}
+
+          {/* Lock overlay on blurred photos */}
+          {!isRevealed && (
+            <View style={styles.lockOverlay} pointerEvents="none">
+              <Text style={styles.lockIcon}>🔒</Text>
+            </View>
+          )}
+        </View>
+
+        {/* Info — always visible */}
+        <View style={styles.info}>
+          <Text style={styles.name} numberOfLines={1}>
+            {item.name}{item.age ? `, ${item.age}` : ''}
+          </Text>
+          {!!item.location && (
+            <Text style={styles.location} numberOfLines={1}>{item.location}</Text>
+          )}
+
+          {isRevealed ? (
+            <TouchableOpacity
+              style={[styles.revealBtn, likedBackIds.has(item.id) && styles.revealBtnDim]}
+              onPress={() => handleLikeBack(item)}
+              disabled={likedBackIds.has(item.id)}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.revealBtnText}>
+                {likedBackIds.has(item.id) ? '✓ Liked back' : '💚 Like Back'}
+              </Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              style={[styles.revealBtn, revealUsed && styles.revealBtnDim]}
+              onPress={() => handleReveal(item)}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.revealBtnText}>
+                {revealUsed ? '🔒 Premium' : '✨ Reveal'}
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.root} edges={['top']}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Likes</Text>
+        {!loading && likers.length > 0 && (
+          <Text style={styles.headerCount}>
+            {likers.length} {likers.length === 1 ? 'person' : 'people'} liked you
+          </Text>
+        )}
+      </View>
+
+      {/* Daily reveal banner */}
+      {!loading && likers.length > 0 && (
+        <View style={[styles.banner, revealUsed && styles.bannerUsed]}>
+          <Text style={styles.bannerText}>
+            {revealUsed
+              ? '🔒 Free reveal used — come back tomorrow'
+              : '✨ You have 1 free reveal today'}
+          </Text>
+        </View>
+      )}
+
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color="#0C5389" />
+        </View>
+      ) : (
+        <FlatList
+          data={likers}
+          keyExtractor={(item) => item.id}
+          numColumns={2}
+          columnWrapperStyle={styles.gridRow}
+          contentContainerStyle={likers.length === 0 ? styles.emptyList : styles.gridContent}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => load(true)}
+              tintColor="#0C5389"
+            />
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyWrap}>
+              <Text style={styles.emptyEmoji}>💛</Text>
+              <Text style={styles.emptyTitle}>No likes yet</Text>
+              <Text style={styles.emptyText}>
+                When someone likes your profile, they'll appear here.{'\n'}Keep swiping!
+              </Text>
+            </View>
+          }
+          renderItem={renderItem}
+        />
+      )}
+      {/* Match modal */}
+      <Modal visible={!!matchName} transparent animationType="fade">
+        <View style={styles.matchOverlay}>
+          <View style={styles.matchCard}>
+            <Text style={styles.matchEmoji}>🍐</Text>
+            <Text style={styles.matchTitle}>It's a Match!</Text>
+            <Text style={styles.matchSub}>
+              You and {matchName} both liked each other.
+            </Text>
+            <TouchableOpacity
+              style={styles.matchBtn}
+              onPress={() => {
+                setMatchName(null);
+                navigation.navigate('Chats', { screen: 'ChatsHome' });
+              }}
+            >
+              <Text style={styles.matchBtnText}>Send Message</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => setMatchName(null)}>
+              <Text style={styles.matchSkip}>Keep Browsing</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#F4F7F9',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 12,
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#0C5389',
+  },
+  headerCount: {
+    fontSize: 13,
+    color: '#189AA2',
+    fontWeight: '600',
+  },
+
+  // Banner
+  banner: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: 'rgba(24,154,162,0.12)',
+  },
+  bannerUsed: {
+    backgroundColor: 'rgba(74,96,112,0.10)',
+  },
+  bannerText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#189AA2',
+    textAlign: 'center',
+  },
+
+  // Grid
+  gridContent: {
+    paddingHorizontal: GRID_PADDING,
+    paddingBottom: 32,
+  },
+  gridRow: {
+    justifyContent: 'space-between',
+    marginBottom: GRID_GAP,
+  },
+
+  // Card
+  card: {
+    width: CARD_WIDTH,
+    borderRadius: 16,
+    backgroundColor: '#FDFDFD',
+    overflow: 'hidden',
+    shadowColor: '#0C5389',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  photoWrap: {
+    position: 'relative',
+  },
+  photo: {
+    width: CARD_WIDTH,
+    height: CARD_WIDTH,
+    backgroundColor: '#D9E1E6',
+  },
+  photoPlaceholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#C0CDD6',
+  },
+  photoInitial: {
+    fontSize: 40,
+    fontWeight: '700',
+    color: '#FDFDFD',
+  },
+  lockOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lockIcon: {
+    fontSize: 28,
+  },
+  info: {
+    padding: 10,
+  },
+  name: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#0C5389',
+    marginBottom: 2,
+  },
+  location: {
+    fontSize: 12,
+    color: '#189AA2',
+    marginBottom: 8,
+  },
+  revealBtn: {
+    backgroundColor: '#0C5389',
+    borderRadius: 10,
+    paddingVertical: 7,
+    alignItems: 'center',
+  },
+  revealBtnDim: {
+    backgroundColor: '#C0CDD6',
+  },
+  revealBtnText: {
+    color: '#FDFDFD',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+
+  // Empty
+  emptyList: {
+    flexGrow: 1,
+  },
+  emptyWrap: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    paddingTop: 60,
+  },
+  emptyEmoji: {
+    fontSize: 48,
+    marginBottom: 12,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#0C5389',
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: '#4A6070',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+
+  // Match modal
+  matchOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  matchCard: {
+    backgroundColor: '#FDFDFD',
+    borderRadius: 24,
+    padding: 32,
+    alignItems: 'center',
+    width: '80%',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  matchEmoji: { fontSize: 48, marginBottom: 12 },
+  matchTitle: {
+    fontSize: 26,
+    fontWeight: '900',
+    color: '#0C5389',
+    marginBottom: 8,
+  },
+  matchSub: {
+    fontSize: 15,
+    color: '#4A6070',
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  matchBtn: {
+    backgroundColor: '#0C5389',
+    paddingHorizontal: 28,
+    paddingVertical: 12,
+    borderRadius: 14,
+    marginBottom: 12,
+    width: '100%',
+    alignItems: 'center',
+  },
+  matchBtnText: {
+    color: '#FDFDFD',
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  matchSkip: {
+    fontSize: 14,
+    color: '#4A6070',
+    opacity: 0.7,
+  },
+});

--- a/apps/mobile/screens/OnboardingScreen.tsx
+++ b/apps/mobile/screens/OnboardingScreen.tsx
@@ -1,685 +1,950 @@
 /**
- * Onboarding screen with step-by-step modal popups
- * Each preference is collected one at a time in a seamless flow
+ * OnboardingScreen — unified 10-step full-screen onboarding flow.
+ *
+ * Steps:
+ *  0  About You       (name, age, gender, ethnicity → profiles)
+ *  1  Location        (city, state, zip → preferences)
+ *  2  Budget          (min/max → preferences)
+ *  3  Room + Move-in  (room_type, move_in_date → preferences)
+ *  4  Lifestyle       (cleanliness, schedule, social, pets, smoking → preferences)
+ *  5  Dealbreakers    (hard/soft/none per item → preferences.dealbreakers)
+ *  6  Interests       (category chips → preferences.interests)
+ *  7  Prompts         (pick 2–3, answer them → profiles.prompts)
+ *  8  Photos          (upload photos → profiles.profile_photo_url)
+ *  9  Listing         (optional → listings + profiles.has_listing)
  */
 
 import { useState, useEffect } from 'react';
 import {
   View,
   Text,
-  Modal,
+  StyleSheet,
   TextInput,
   TouchableOpacity,
-  TouchableWithoutFeedback,
-  StyleSheet,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
   Alert,
   ActivityIndicator,
-  ScrollView,
-  Keyboard,
-  Platform,
+  Image,
+  Dimensions,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import * as ImagePicker from 'expo-image-picker';
 import { supabase } from '../lib/supabase';
-import { savePreferences, Preferences } from '../lib/preferences';
+import { savePreferences } from '../lib/preferences';
+import { uploadStagedPhotosAndMerge } from '../lib/profilePhotos';
+import { uploadProfileImage } from '../lib/storage';
+import PublicProfileCard from '../components/PublicProfileCard';
 
-interface OnboardingScreenProps {
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TOTAL_STEPS = 10;
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const PHOTO_THUMB = (SCREEN_WIDTH - 40 - 10) / 2; // 2-col grid, 20px padding each side, 10px gap
+
+const GENDER_OPTIONS = ['Man', 'Woman', 'Non-binary', 'Other', 'Prefer not to say'];
+
+const ETHNICITY_OPTIONS = [
+  'Asian',
+  'Black / African American',
+  'Hispanic / Latino',
+  'Middle Eastern',
+  'Native American',
+  'Pacific Islander',
+  'White / Caucasian',
+  'Multiracial',
+  'Prefer not to say',
+];
+
+const DEALBREAKER_ITEMS = [
+  { key: 'smoking',    label: 'Smoking indoors' },
+  { key: 'pets',       label: 'Pets in the unit' },
+  { key: 'parties',    label: 'Frequent parties' },
+  { key: 'early_bird', label: 'Noise before 8 am' },
+  { key: 'night_owl',  label: 'Noise after 11 pm' },
+  { key: 'guests',     label: 'Overnight guests' },
+  { key: 'messy',      label: 'Messy common areas' },
+];
+
+const INTEREST_CATEGORIES = [
+  {
+    key: 'fitness',
+    label: '🏃 Fitness',
+    options: ['Running', 'Yoga', 'Gym', 'Hiking', 'Swimming', 'Cycling', 'Rock Climbing'],
+  },
+  {
+    key: 'food',
+    label: '🍕 Food & Drink',
+    options: ['Cooking', 'Baking', 'Coffee', 'Wine & Cocktails', 'Foodie Adventures', 'Meal Prep'],
+  },
+  {
+    key: 'arts',
+    label: '🎨 Arts & Culture',
+    options: ['Movies', 'Music', 'Reading', 'Photography', 'Art Galleries', 'Theater'],
+  },
+  {
+    key: 'outdoors',
+    label: '🌿 Outdoors',
+    options: ['Camping', 'Travel', 'Beach', 'Gardening', 'Road Trips', 'Surfing'],
+  },
+  {
+    key: 'tech',
+    label: '🎮 Tech & Gaming',
+    options: ['Gaming', 'Coding', 'Podcasts', 'Anime', 'Board Games', 'VR / AR'],
+  },
+];
+
+const PROMPTS = [
+  'My ideal Saturday morning looks like…',
+  "I'm looking for a roommate who…",
+  "Don't room with me if you hate…",
+  'My morning routine is…',
+  "On weeknights you'll find me…",
+  'Weekends are for…',
+  'I clean the apartment…',
+  'My noise level is…',
+  'Overnight guests are…',
+  'My kitchen rule is…',
+  'My sleep schedule is…',
+  "I've lived with roommates before and learned…",
+  'A quirk about living with me…',
+  'My ideal apartment vibe…',
+  'After work I usually…',
+  'The best thing about me as a roommate…',
+  'My work-from-home setup is…',
+  'Two truths and a lie about my living habits…',
+  'I stay up until…',
+  'I wake up at…',
+  'My relationship with mess is…',
+  'The soundtrack of my home is…',
+  'My go-to snack situation…',
+  'I unwind by…',
+];
+
+const STEP_TITLES = [
+  'Tell us about you',
+  'Where are you looking?',
+  "What's your budget?",
+  'What kind of room?',
+  'Your lifestyle',
+  'Any dealbreakers?',
+  'Your interests',
+  'In your own words',
+  'Add your photos',
+  'Do you have a place?',
+];
+
+const STEP_SUBTITLES = [
+  'This helps us find compatible roommates.',
+  "We'll show you people in your area.",
+  "We'll match you within your range.",
+  'Pick what works for you.',
+  'Helps us find someone compatible.',
+  'Hard = never · Soft = prefer not · None = fine.',
+  'Select up to 5 per category.',
+  'Pick 2–3 prompts to answer.',
+  'Your first impression — make it count.',
+  'Optional — skip if you are not listing a place.',
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDateYMD(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// ─── Chip component ───────────────────────────────────────────────────────────
+
+function Chip({
+  label,
+  selected,
+  onPress,
+  disabled,
+}: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <TouchableOpacity
+      style={[styles.chip, selected && styles.chipSelected, disabled && styles.chipDisabled]}
+      onPress={onPress}
+      disabled={disabled}
+      activeOpacity={0.75}
+    >
+      <Text style={[styles.chipText, selected && styles.chipTextSelected]}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type PromptEntry = { question: string; answer: string };
+type DealbreakerLevel = 'hard' | 'soft' | 'none';
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface Props {
   onComplete: () => void;
 }
 
-type OnboardingStep =
-  | 'about-you'
-  | 'location'
-  | 'budget'
-  | 'room-type'
-  | 'move-in-date'
-  | 'lifestyle'
-  | 'must-haves'
-  | 'complete';
+export default function OnboardingScreen({ onComplete }: Props) {
+  // Core
+  const [step, setStep] = useState(0);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
-export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
-  const [currentStep, setCurrentStep] = useState<OnboardingStep>('about-you');
-  const [loading, setLoading] = useState(false);
-  const [preferences, setPreferences] = useState<Partial<Preferences>>({});
-
-  // Profile state (age, gender, ethnicity)
+  // Step 0: About You
+  const [name, setName] = useState('');
   const [age, setAge] = useState('');
-  const [gender, setGender] = useState<string>('');
-  const [ethnicity, setEthnicity] = useState<string>('');
+  const [gender, setGender] = useState('');
+  const [ethnicity, setEthnicity] = useState('');
 
-  // Form state
+  // Step 1: Location
   const [city, setCity] = useState('');
-  const [state, setState] = useState('');
+  const [locationState, setLocationState] = useState('');
   const [zipCode, setZipCode] = useState('');
+
+  // Step 2: Budget
   const [minBudget, setMinBudget] = useState('');
   const [maxBudget, setMaxBudget] = useState('');
-  const [budgetError, setBudgetError] = useState('');
-  const [roomType, setRoomType] = useState<'private' | 'shared' | 'either Private or Shared' | ''>('');
+
+  // Step 3: Room + Move-in
+  const [roomType, setRoomType] = useState('');
   const [moveInDate, setMoveInDate] = useState<Date | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);
+
+  // Step 4: Lifestyle
+  const [cleanliness, setCleanliness] = useState<number | null>(null);
+  const [workSchedule, setWorkSchedule] = useState('');
+  const [socialPref, setSocialPref] = useState('');
   const [petsAllowed, setPetsAllowed] = useState<boolean | null>(null);
   const [smokingAllowed, setSmokingAllowed] = useState<boolean | null>(null);
-  const [cleanlinessLevel, setCleanlinessLevel] = useState<number | null>(null);
-  const [socialPreference, setSocialPreference] = useState<'social' | 'quiet' | 'balanced' | ''>('');
 
-  const [userId, setUserId] = useState<string | null>(null);
+  // Step 5: Dealbreakers
+  const [dealbreakers, setDealbreakers] = useState<Record<string, DealbreakerLevel>>(
+    Object.fromEntries(DEALBREAKER_ITEMS.map((d) => [d.key, 'none' as DealbreakerLevel]))
+  );
+
+  // Step 6: Interests
+  const [interests, setInterests] = useState<Record<string, string[]>>(
+    Object.fromEntries(INTEREST_CATEGORIES.map((c) => [c.key, [] as string[]]))
+  );
+  const [expandedCategory, setExpandedCategory] = useState<string | null>('fitness');
+  const [customInputs, setCustomInputs] = useState<Record<string, string>>(
+    Object.fromEntries(INTEREST_CATEGORIES.map((c) => [c.key, '']))
+  );
+
+  // Step 7: Prompts
+  const [promptAnswers, setPromptAnswers] = useState<PromptEntry[]>([]);
+
+  // Step 8: Photos
+  const [stagingUris, setStagingUris] = useState<string[]>([]);
+
+  // Step 9: Listing
+  const [hasListing, setHasListing] = useState(false);
+  const [listingRent, setListingRent] = useState('');
+  const [listingRoomType, setListingRoomType] = useState('');
+  const [listingAddress, setListingAddress] = useState('');
+  const [listingCity, setListingCity] = useState('');
+  const [listingStateVal, setListingStateVal] = useState('');
+  const [listingZip, setListingZip] = useState('');
+  const [listingPhotos, setListingPhotos] = useState<string[]>([]);
 
   useEffect(() => {
-    // Get current user
     supabase.auth.getUser().then(({ data: { user } }) => {
-      if (user) {
-        setUserId(user.id);
-      }
+      if (user) setUserId(user.id);
     });
   }, []);
 
-  const ensureProfileExists = async () => {
+  // ── Save helpers ───────────────────────────────────────────────────────────
+
+  const ensureProfile = async (uid: string): Promise<boolean> => {
+    const { data } = await supabase.from('profiles').select('id').eq('id', uid).single();
+    if (data) return true;
+    const { data: authData } = await supabase.auth.getUser();
+    const user = authData?.user;
+    if (!user) return false;
+    const { error } = await supabase.from('profiles').insert({
+      id: uid,
+      email: user.email ?? '',
+      name: user.user_metadata?.name ?? user.email ?? 'User',
+      phone: user.user_metadata?.phone ?? '000-000-0000',
+    });
+    return !error;
+  };
+
+  const saveAboutYou = async (): Promise<boolean> => {
     if (!userId) return false;
+    if (!(await ensureProfile(userId))) return false;
+    const updates: Record<string, unknown> = {};
+    if (name.trim()) updates.name = name.trim();
+    if (age.trim()) updates.age = parseInt(age, 10);
+    if (gender) updates.gender = gender;
+    if (ethnicity) updates.ethnicity = ethnicity;
+    if (Object.keys(updates).length === 0) return true;
+    const { error } = await supabase.from('profiles').update(updates).eq('id', userId);
+    if (error) console.warn('saveAboutYou', error.message);
+    return !error;
+  };
 
-    try {
-      // Check if profile exists
-      const { data: existingProfile } = await supabase
-        .from('profiles')
-        .select('id')
-        .eq('id', userId)
-        .single();
+  const savePrompts = async (): Promise<void> => {
+    if (!userId) return;
+    const filtered = promptAnswers.filter((p) => p.answer.trim());
+    if (filtered.length === 0) return;
+    const { error } = await supabase
+      .from('profiles')
+      .update({ prompts: filtered })
+      .eq('id', userId);
+    if (error) console.warn('savePrompts', error.message);
+  };
 
-      // If profile doesn't exist, create it
-      if (!existingProfile) {
-        // Get user email from auth
-        const { data: { user } } = await supabase.auth.getUser();
-        if (!user) return false;
-
-        const { error: insertError } = await supabase
-          .from('profiles')
-          .insert({
-            id: userId,
-            email: user.email || '',
-            name: user.user_metadata?.name || user.email || 'User',
-            phone: user.user_metadata?.phone || '000-000-0000',
-          });
-
-        if (insertError) {
-          console.error('Error creating profile:', insertError);
-          return false;
-        }
-      }
-      return true;
-    } catch (error) {
-      console.error('Error ensuring profile exists:', error);
+  const uploadPhotos = async (): Promise<boolean> => {
+    if (!userId || stagingUris.length === 0) return true;
+    const { ok, error } = await uploadStagedPhotosAndMerge(userId, stagingUris);
+    if (!ok) {
+      Alert.alert('Upload failed', error ?? 'Could not upload photos. Please try again.');
       return false;
     }
-  };
-
-  const saveProfileInfo = async () => {
-    if (!userId) return;
-
-    try {
-      // Ensure profile exists first
-      const profileExists = await ensureProfileExists();
-      if (!profileExists) {
-        console.error('Failed to ensure profile exists');
-        return;
-      }
-
-      const updates: any = {};
-      if (age) updates.age = parseInt(age);
-      if (gender) updates.gender = gender;
-      if (ethnicity) updates.ethnicity = ethnicity;
-
-      if (Object.keys(updates).length > 0) {
-        const { error } = await supabase
-          .from('profiles')
-          .update(updates)
-          .eq('id', userId);
-
-        if (error) {
-          console.error('Error updating profile:', error);
-        }
-      }
-    } catch (error) {
-      console.error('Error saving profile info:', error);
-    }
-  };
-
-  const handleNext = async () => {
-    // Save current step data
-    switch (currentStep) {
-      case 'about-you':
-        await saveProfileInfo();
-        setCurrentStep('location');
-        break;
-      case 'location':
-        setPreferences({
-          ...preferences,
-          city: city.trim() || undefined,
-          state: state.trim() || undefined,
-          zip_code: zipCode.trim() || undefined,
-        });
-        setBudgetError(''); // Clear any previous budget error
-        setCurrentStep('budget');
-        break;
-      case 'budget':
-        // Validate budget before proceeding
-        if (minBudget && maxBudget && parseFloat(minBudget) > parseFloat(maxBudget)) {
-          Alert.alert('Invalid Budget', 'Min budget cannot be higher than max budget');
-          return;
-        }
-        setPreferences({
-          ...preferences,
-          min_budget: minBudget ? parseFloat(minBudget) : undefined,
-          max_budget: maxBudget ? parseFloat(maxBudget) : undefined,
-        });
-        setCurrentStep('room-type');
-        break;
-      case 'room-type':
-        // Map 'either Private or Shared' to 'flexible' for database
-        const mappedRoomType = roomType === 'either Private or Shared' ? 'flexible' : roomType;
-        setPreferences({
-          ...preferences,
-          room_type: mappedRoomType || undefined,
-        });
-        setCurrentStep('move-in-date');
-        break;
-      case 'move-in-date':
-        setPreferences({
-          ...preferences,
-          move_in_date: moveInDate ? moveInDate.toISOString().split('T')[0] : undefined,
-        });
-        setCurrentStep('lifestyle');
-        break;
-      case 'lifestyle':
-        setPreferences({
-          ...preferences,
-          pets_allowed: petsAllowed ?? undefined,
-          smoking_allowed: smokingAllowed ?? undefined,
-          cleanliness_level: cleanlinessLevel ?? undefined,
-          social_preference: socialPreference || undefined,
-        });
-        setCurrentStep('must-haves');
-        break;
-      case 'must-haves':
-        // Skip must-haves for now (can add later)
-        handleComplete();
-        break;
-    }
-  };
-
-  const handlePrevious = () => {
-    // Clear budget error when leaving budget step
-    if (currentStep === 'budget') {
-      setBudgetError('');
-    }
-    // Navigate to previous step
-    switch (currentStep) {
-      case 'location':
-        setCurrentStep('about-you');
-        break;
-      case 'budget':
-        setCurrentStep('location');
-        break;
-      case 'room-type':
-        setCurrentStep('budget');
-        break;
-      case 'move-in-date':
-        setCurrentStep('room-type');
-        break;
-      case 'lifestyle':
-        setCurrentStep('move-in-date');
-        break;
-      case 'must-haves':
-        setCurrentStep('lifestyle');
-        break;
-      default:
-        break;
-    }
-  };
-
-  const handleSkip = () => {
-    // Allow skipping optional steps
-    if (currentStep === 'about-you') {
-      setCurrentStep('location');
-    } else if (currentStep === 'location') {
-      setCurrentStep('budget');
-    } else if (currentStep === 'budget') {
-      setCurrentStep('room-type');
-    } else if (currentStep === 'room-type') {
-      setCurrentStep('move-in-date');
-    } else if (currentStep === 'move-in-date') {
-      setCurrentStep('lifestyle');
-    } else if (currentStep === 'lifestyle') {
-      setCurrentStep('must-haves');
-    } else {
-      handleComplete();
-    }
+    return true;
   };
 
   const handleComplete = async () => {
     if (!userId) {
-      Alert.alert('Error', 'User not found');
+      Alert.alert('Error', 'Not signed in. Please restart the app.');
+      setSaving(false);
       return;
     }
-
-    setLoading(true);
     try {
-      // Ensure profile exists before saving preferences
-      const profileExists = await ensureProfileExists();
-      if (!profileExists) {
-        Alert.alert('Error', 'Failed to create user profile. Please try again.');
-        setLoading(false);
+      // Save listing if opted in
+      if (hasListing) {
+        const photoPaths: string[] = [];
+        for (const uri of listingPhotos) {
+          const { path, error } = await uploadProfileImage(userId, uri);
+          if (error || !path) {
+            Alert.alert('Upload failed', 'Could not upload a listing photo. Please try again.');
+            setSaving(false);
+            return;
+          }
+          photoPaths.push(path);
+        }
+        const { error: listErr } = await supabase.from('listings').insert({
+          user_id: userId,
+          rent: listingRent ? parseFloat(listingRent) : null,
+          room_type: listingRoomType || null,
+          address: listingAddress || null,
+          city: listingCity || null,
+          state: listingStateVal || null,
+          zip_code: listingZip || null,
+          listing_photos: photoPaths,
+        });
+        if (listErr) console.warn('saveListing', listErr.message);
+        await supabase.from('profiles').update({ has_listing: true }).eq('id', userId);
+      }
+
+      // Map social preference label to DB value
+      const socialPrefMapped =
+        socialPref === 'Social Butterfly' ? 'social'
+        : socialPref === 'Homebody' ? 'quiet'
+        : socialPref === 'Balanced' ? 'balanced'
+        : undefined;
+
+      const result = await savePreferences(userId, {
+        city: city.trim() || undefined,
+        state: locationState.trim() || undefined,
+        zip_code: zipCode.trim() || undefined,
+        min_budget: minBudget ? parseFloat(minBudget) : undefined,
+        max_budget: maxBudget ? parseFloat(maxBudget) : undefined,
+        room_type: (['private', 'shared', 'flexible', 'entire'] as const).includes(roomType as any)
+          ? (roomType as 'private' | 'shared' | 'flexible' | 'entire')
+          : undefined,
+        move_in_date: moveInDate ? formatDateYMD(moveInDate) : undefined,
+        pets_allowed: petsAllowed ?? undefined,
+        smoking_allowed: smokingAllowed ?? undefined,
+        cleanliness_level: cleanliness ?? undefined,
+        work_schedule: workSchedule || undefined,
+        social_preference: socialPrefMapped as any,
+        interests: Object.values(interests).some((v) => v.length > 0) ? interests : undefined,
+        dealbreakers,
+      });
+
+      if (!result.success) {
+        Alert.alert('Error', result.error ?? 'Could not save preferences.');
+        setSaving(false);
         return;
       }
 
-      console.log('📤 [OnboardingScreen] About to save preferences:', JSON.stringify(preferences, null, 2));
-      console.log('📤 [OnboardingScreen] room_type value:', preferences.room_type);
-      
-      const result = await savePreferences(userId, preferences);
-      if (result.success) {
-        onComplete();
-      } else {
-        Alert.alert('Error', result.error || 'Failed to save preferences');
+      onComplete();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Something went wrong';
+      Alert.alert('Error', msg);
+      setSaving(false);
+    }
+  };
+
+  // ── Navigation ─────────────────────────────────────────────────────────────
+
+  const advance = () => setStep((s) => Math.min(s + 1, TOTAL_STEPS - 1));
+
+  const handleBack = () => {
+    if (saving) return;
+    setStep((s) => Math.max(s - 1, 0));
+  };
+
+  const handleSkip = () => {
+    if (saving) return;
+    if (step === TOTAL_STEPS - 1) {
+      setSaving(true);
+      handleComplete();
+    } else {
+      advance();
+    }
+  };
+
+  const handleNext = async () => {
+    if (saving) return;
+
+    if (step === TOTAL_STEPS - 1) {
+      setSaving(true);
+      await handleComplete();
+      return;
+    }
+
+    setSaving(true);
+    try {
+      if (step === 0) {
+        const ok = await saveAboutYou();
+        if (!ok) {
+          Alert.alert('Error', 'Could not save your info. Please try again.');
+          return;
+        }
+      } else if (step === 7) {
+        await savePrompts();
+      } else if (step === 8) {
+        const ok = await uploadPhotos();
+        if (!ok) return;
       }
-    } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to save preferences');
+      advance();
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   };
 
-  const getStepTitle = () => {
-    switch (currentStep) {
-      case 'about-you':
-        return 'Tell us about yourself';
-      case 'location':
-        return 'Where are you looking?';
-      case 'budget':
-        return 'What\'s your budget?';
-      case 'room-type':
-        return 'What type of room?';
-      case 'move-in-date':
-        return 'When do you want to move in?';
-      case 'lifestyle':
-        return 'Tell us about your lifestyle';
-      case 'must-haves':
-        return 'Any must-haves?';
-      default:
-        return 'Welcome!';
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  const canAdvance = (): boolean => {
+    if (step === 0) return name.trim().length > 0;
+    if (step === 2 && minBudget && maxBudget) {
+      return parseFloat(minBudget) <= parseFloat(maxBudget);
+    }
+    return true;
+  };
+
+  // ── Photo pickers ──────────────────────────────────────────────────────────
+
+  const pickProfilePhoto = async () => {
+    if (stagingUris.length >= 4) return;
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permission needed', 'Please allow photo library access.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      quality: 0.85,
+      allowsEditing: true,
+      aspect: [4, 5],
+    });
+    if (!result.canceled && result.assets[0]) {
+      setStagingUris((prev) => [...prev, result.assets[0].uri].slice(0, 4));
     }
   };
 
-  const getStepNumber = () => {
-    const steps: OnboardingStep[] = ['about-you', 'location', 'budget', 'room-type', 'move-in-date', 'lifestyle', 'must-haves'];
-    return steps.indexOf(currentStep) + 1;
+  const pickListingPhoto = async () => {
+    if (listingPhotos.length >= 6) return;
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permission needed', 'Please allow photo library access.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      quality: 0.85,
+    });
+    if (!result.canceled && result.assets[0]) {
+      setListingPhotos((prev) => [...prev, result.assets[0].uri].slice(0, 6));
+    }
   };
 
-  const getTotalSteps = () => 7;
+  // ── Prompt helpers ─────────────────────────────────────────────────────────
 
-  const renderStepContent = () => {
-    switch (currentStep) {
-      case 'about-you':
+  const isPromptSelected = (q: string) => promptAnswers.some((p) => p.question === q);
+
+  const togglePrompt = (q: string) => {
+    if (isPromptSelected(q)) {
+      setPromptAnswers((prev) => prev.filter((p) => p.question !== q));
+    } else if (promptAnswers.length < 3) {
+      setPromptAnswers((prev) => [...prev, { question: q, answer: '' }]);
+    }
+  };
+
+  const setPromptAnswer = (q: string, answer: string) => {
+    setPromptAnswers((prev) =>
+      prev.map((p) => (p.question === q ? { ...p, answer } : p))
+    );
+  };
+
+  // ── Step renders ───────────────────────────────────────────────────────────
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
         return (
-          <ScrollView
-            style={styles.stepContent}
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-          >
-            <Text style={styles.stepDescription}>
-              Help us get to know you better
-            </Text>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
             <TextInput
               style={styles.input}
-              placeholder="Age"
+              placeholder="Your name"
+              placeholderTextColor="#9AA"
+              value={name}
+              onChangeText={setName}
+              autoCapitalize="words"
+              returnKeyType="next"
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="Age (optional)"
+              placeholderTextColor="#9AA"
               value={age}
               onChangeText={setAge}
               keyboardType="numeric"
+              maxLength={3}
             />
-            <Text style={styles.questionLabel}>Gender</Text>
-            {['Male', 'Female', 'Non-binary', 'Prefer not to say', 'Other'].map((option) => (
-              <TouchableOpacity
-                key={option}
-                style={[
-                  styles.optionButton,
-                  gender === option && styles.optionButtonSelected,
-                ]}
-                onPress={() => setGender(option)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    gender === option && styles.optionTextSelected,
-                  ]}
-                >
-                  {option}
-                </Text>
-              </TouchableOpacity>
-            ))}
-            <Text style={styles.questionLabel}>Ethnicity (optional)</Text>
-            <TextInput
-              style={styles.input}
-              placeholder="Ethnicity"
-              value={ethnicity}
-              onChangeText={setEthnicity}
-            />
-            <Text style={styles.hint}>
-              This helps us create better matches
-            </Text>
+            <Text style={styles.sectionLabel}>Gender</Text>
+            <View style={styles.chipRow}>
+              {GENDER_OPTIONS.map((g) => (
+                <Chip
+                  key={g}
+                  label={g}
+                  selected={gender === g}
+                  onPress={() => setGender(gender === g ? '' : g)}
+                />
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Ethnicity (optional)</Text>
+            <View style={styles.chipRow}>
+              {ETHNICITY_OPTIONS.map((e) => (
+                <Chip
+                  key={e}
+                  label={e}
+                  selected={ethnicity === e}
+                  onPress={() => setEthnicity(ethnicity === e ? '' : e)}
+                />
+              ))}
+            </View>
           </ScrollView>
         );
 
-      case 'location':
+      case 1:
         return (
-          <View style={styles.stepContent}>
-            <Text style={styles.stepDescription}>
-              Help us find the perfect place for you
-            </Text>
+          <View style={styles.stepBody}>
             <TextInput
               style={styles.input}
               placeholder="City"
+              placeholderTextColor="#9AA"
               value={city}
               onChangeText={setCity}
             />
             <TextInput
               style={styles.input}
-              placeholder="State"
-              value={state}
-              onChangeText={setState}
+              placeholder="State (e.g. CA)"
+              placeholderTextColor="#9AA"
+              value={locationState}
+              onChangeText={setLocationState}
+              autoCapitalize="characters"
+              maxLength={2}
             />
             <TextInput
               style={styles.input}
-              placeholder="ZIP Code (optional)"
+              placeholder="ZIP code (optional)"
+              placeholderTextColor="#9AA"
               value={zipCode}
               onChangeText={setZipCode}
               keyboardType="numeric"
+              maxLength={5}
             />
           </View>
         );
 
-      case 'budget':
+      case 2: {
+        const budgetError =
+          minBudget && maxBudget && parseFloat(minBudget) > parseFloat(maxBudget)
+            ? 'Min budget cannot exceed max budget'
+            : '';
         return (
-          <View style={styles.stepContent}>
-            <Text style={styles.stepDescription}>
-              What's your monthly rent budget?
-            </Text>
+          <View style={styles.stepBody}>
             <TextInput
               style={styles.input}
-              placeholder="Min budget ($)"
+              placeholder="Min / month ($)"
+              placeholderTextColor="#9AA"
               value={minBudget}
-              onChangeText={(text) => {
-                setMinBudget(text);
-                if (text && maxBudget && parseFloat(text) > parseFloat(maxBudget)) {
-                  setBudgetError('Min budget cannot be higher than max budget');
-                } else {
-                  setBudgetError('');
-                }
-              }}
+              onChangeText={setMinBudget}
               keyboardType="numeric"
             />
             <TextInput
               style={styles.input}
-              placeholder="Max budget ($)"
+              placeholder="Max / month ($)"
+              placeholderTextColor="#9AA"
               value={maxBudget}
-              onChangeText={(text) => {
-                setMaxBudget(text);
-                if (text && minBudget && parseFloat(minBudget) > parseFloat(text)) {
-                  setBudgetError('Min budget cannot be higher than max budget');
-                } else {
-                  setBudgetError('');
-                }
-              }}
+              onChangeText={setMaxBudget}
               keyboardType="numeric"
             />
-            {budgetError ? (
-              <Text style={styles.errorText}>{budgetError}</Text>
-            ) : null}
+            {!!budgetError && <Text style={styles.errorText}>{budgetError}</Text>}
           </View>
         );
+      }
 
-      case 'room-type':
+      case 3: {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        tomorrow.setHours(0, 0, 0, 0);
         return (
-          <View style={styles.stepContent}>
-            <Text style={styles.stepDescription}>
-              What type of room are you looking for?
-            </Text>
-            {['private', 'shared', 'either Private or Shared'].map((type) => (
-              <TouchableOpacity
-                key={type}
-                style={[
-                  styles.optionButton,
-                  roomType === type && styles.optionButtonSelected,
-                ]}
-                onPress={() => setRoomType(type as any)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    roomType === type && styles.optionTextSelected,
-                  ]}
-                >
-                  {type.charAt(0).toUpperCase() + type.slice(1)} Room
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
-        );
-
-      case 'move-in-date':
-        const formatDate = (date: Date | null): string => {
-          if (!date) return '';
-          const year = date.getFullYear();
-          const month = String(date.getMonth() + 1).padStart(2, '0');
-          const day = String(date.getDate()).padStart(2, '0');
-          return `${year}-${month}-${day}`;
-        };
-
-        // Get tomorrow's date (minimum selectable date)
-        const getTomorrow = () => {
-          const tomorrow = new Date();
-          tomorrow.setDate(tomorrow.getDate() + 1);
-          tomorrow.setHours(0, 0, 0, 0); // Set to start of day
-          return tomorrow;
-        };
-
-        const displayDate = moveInDate ? formatDate(moveInDate) : '';
-        const tomorrow = getTomorrow();
-
-        return (
-          <View style={styles.stepContent}>
-            <Text style={styles.stepDescription}>
-              When would you like to move in?
-            </Text>
-            <TouchableOpacity
-              style={styles.datePickerButton}
-              onPress={() => setShowDatePicker(true)}
-            >
-              <Text style={[styles.datePickerText, !moveInDate && styles.datePickerPlaceholder]}>
-                {displayDate || 'Select a date'}
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false}>
+            <Text style={styles.sectionLabel}>Room type</Text>
+            <View style={styles.chipRow}>
+              {[
+                { val: 'private',  label: 'Private Room' },
+                { val: 'shared',   label: 'Shared Room' },
+                { val: 'flexible', label: 'Either' },
+                { val: 'entire',   label: 'Entire Place' },
+              ].map(({ val, label }) => (
+                <Chip
+                  key={val}
+                  label={label}
+                  selected={roomType === val}
+                  onPress={() => setRoomType(roomType === val ? '' : val)}
+                />
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Move-in date (optional)</Text>
+            <TouchableOpacity style={styles.dateBtn} onPress={() => setShowDatePicker(true)}>
+              <Text style={[styles.dateBtnText, !moveInDate && styles.dateBtnPlaceholder]}>
+                {moveInDate ? formatDateYMD(moveInDate) : 'Select a date'}
               </Text>
             </TouchableOpacity>
             {showDatePicker && (
               <DateTimePicker
-                value={moveInDate || tomorrow}
+                value={moveInDate ?? tomorrow}
                 mode="date"
                 display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                onChange={(event, selectedDate) => {
+                minimumDate={tomorrow}
+                onChange={(event, date) => {
                   if (Platform.OS === 'android') {
                     setShowDatePicker(false);
-                    if (event.type === 'set' && selectedDate) {
-                      // Ensure selected date is after today
-                      const today = new Date();
-                      today.setHours(0, 0, 0, 0);
-                      const selected = new Date(selectedDate);
-                      selected.setHours(0, 0, 0, 0);
-                      if (selected > today) {
-                        setMoveInDate(selectedDate);
-                      }
+                    if (event.type === 'set' && date) {
+                      const d = new Date(date);
+                      d.setHours(0, 0, 0, 0);
+                      if (d > new Date()) setMoveInDate(date);
                     }
-                  } else {
-                    // iOS - keep picker open, user will tap Done
-                    if (selectedDate) {
-                      // Ensure selected date is after today
-                      const today = new Date();
-                      today.setHours(0, 0, 0, 0);
-                      const selected = new Date(selectedDate);
-                      selected.setHours(0, 0, 0, 0);
-                      if (selected > today) {
-                        setMoveInDate(selectedDate);
-                      }
-                    }
+                  } else if (date) {
+                    setMoveInDate(date);
                   }
                 }}
-                minimumDate={tomorrow}
               />
             )}
             {Platform.OS === 'ios' && showDatePicker && (
-              <View style={styles.iosDatePickerActions}>
-                <TouchableOpacity
-                  style={styles.datePickerActionButton}
-                  onPress={() => setShowDatePicker(false)}
-                >
-                  <Text style={styles.datePickerActionText}>Done</Text>
-                </TouchableOpacity>
-              </View>
+              <TouchableOpacity style={styles.dateDoneBtn} onPress={() => setShowDatePicker(false)}>
+                <Text style={styles.dateDoneBtnText}>Done</Text>
+              </TouchableOpacity>
             )}
-            <Text style={styles.hint}>
-              You can update this later
-            </Text>
-          </View>
+          </ScrollView>
         );
+      }
 
-      case 'lifestyle':
+      case 4:
         return (
-          <ScrollView style={styles.stepContent} keyboardShouldPersistTaps="handled">
-            <Text style={styles.stepDescription}>
-              A few questions about your lifestyle
-            </Text>
-
-            <Text style={styles.questionLabel}>Do you have pets or allow pets?</Text>
-            <View style={styles.booleanOptions}>
-              <TouchableOpacity
-                style={[
-                  styles.optionButton,
-                  petsAllowed === true && styles.optionButtonSelected,
-                ]}
-                onPress={() => setPetsAllowed(true)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    petsAllowed === true && styles.optionTextSelected,
-                  ]}
-                >
-                  Yes
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[
-                  styles.optionButton,
-                  petsAllowed === false && styles.optionButtonSelected,
-                ]}
-                onPress={() => setPetsAllowed(false)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    petsAllowed === false && styles.optionTextSelected,
-                  ]}
-                >
-                  No
-                </Text>
-              </TouchableOpacity>
-            </View>
-
-            <Text style={styles.questionLabel}>Do you smoke or allow smoking?</Text>
-            <View style={styles.booleanOptions}>
-              <TouchableOpacity
-                style={[
-                  styles.optionButton,
-                  smokingAllowed === true && styles.optionButtonSelected,
-                ]}
-                onPress={() => setSmokingAllowed(true)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    smokingAllowed === true && styles.optionTextSelected,
-                  ]}
-                >
-                  Yes
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[
-                  styles.optionButton,
-                  smokingAllowed === false && styles.optionButtonSelected,
-                ]}
-                onPress={() => setSmokingAllowed(false)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    smokingAllowed === false && styles.optionTextSelected,
-                  ]}
-                >
-                  No
-                </Text>
-              </TouchableOpacity>
-            </View>
-
-            <Text style={styles.questionLabel}>Cleanliness level (1-5)</Text>
-            <View style={styles.cleanlinessOptions}>
-              {[1, 2, 3, 4, 5].map((level) => (
-                <TouchableOpacity
-                  key={level}
-                  style={[
-                    styles.cleanlinessButton,
-                    cleanlinessLevel === level && styles.optionButtonSelected,
-                  ]}
-                  onPress={() => setCleanlinessLevel(level)}
-                >
-                  <Text
-                    style={[
-                      styles.cleanlinessText,
-                      cleanlinessLevel === level && styles.optionTextSelected,
-                    ]}
-                  >
-                    {level}
-                  </Text>
-                </TouchableOpacity>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.sectionLabel}>Cleanliness (1 = relaxed · 5 = spotless)</Text>
+            <View style={styles.chipRow}>
+              {[1, 2, 3, 4, 5].map((n) => (
+                <Chip
+                  key={n}
+                  label={String(n)}
+                  selected={cleanliness === n}
+                  onPress={() => setCleanliness(cleanliness === n ? null : n)}
+                />
               ))}
             </View>
+            <Text style={styles.sectionLabel}>Work schedule</Text>
+            <View style={styles.chipRow}>
+              {['9-to-5', 'Remote', 'Night Shift', 'Flexible'].map((s) => (
+                <Chip
+                  key={s}
+                  label={s}
+                  selected={workSchedule === s}
+                  onPress={() => setWorkSchedule(workSchedule === s ? '' : s)}
+                />
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Social vibe</Text>
+            <View style={styles.chipRow}>
+              {['Social Butterfly', 'Balanced', 'Homebody'].map((s) => (
+                <Chip
+                  key={s}
+                  label={s}
+                  selected={socialPref === s}
+                  onPress={() => setSocialPref(socialPref === s ? '' : s)}
+                />
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Pets</Text>
+            <View style={styles.chipRow}>
+              <Chip label="Yes" selected={petsAllowed === true} onPress={() => setPetsAllowed(petsAllowed === true ? null : true)} />
+              <Chip label="No"  selected={petsAllowed === false} onPress={() => setPetsAllowed(petsAllowed === false ? null : false)} />
+            </View>
+            <Text style={styles.sectionLabel}>Smoking</Text>
+            <View style={styles.chipRow}>
+              <Chip label="Yes" selected={smokingAllowed === true} onPress={() => setSmokingAllowed(smokingAllowed === true ? null : true)} />
+              <Chip label="No"  selected={smokingAllowed === false} onPress={() => setSmokingAllowed(smokingAllowed === false ? null : false)} />
+            </View>
+          </ScrollView>
+        );
 
-            <Text style={styles.questionLabel}>Social preference</Text>
-            {['social', 'quiet', 'balanced'].map((pref) => (
-              <TouchableOpacity
-                key={pref}
-                style={[
-                  styles.optionButton,
-                  socialPreference === pref && styles.optionButtonSelected,
-                ]}
-                onPress={() => setSocialPreference(pref as any)}
-              >
-                <Text
-                  style={[
-                    styles.optionText,
-                    socialPreference === pref && styles.optionTextSelected,
-                  ]}
-                >
-                  {pref.charAt(0).toUpperCase() + pref.slice(1)}
-                </Text>
-              </TouchableOpacity>
+      case 5:
+        return (
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false}>
+            <Text style={styles.hint}>Tap each row to set your preference.</Text>
+            {DEALBREAKER_ITEMS.map(({ key, label }) => (
+              <View key={key} style={styles.dbRow}>
+                <Text style={styles.dbLabel}>{label}</Text>
+                <View style={styles.dbChips}>
+                  {(['hard', 'soft', 'none'] as DealbreakerLevel[]).map((level) => {
+                    const selected = dealbreakers[key] === level;
+                    return (
+                      <TouchableOpacity
+                        key={level}
+                        style={[
+                          styles.dbChip,
+                          selected && level === 'hard' && styles.dbChipHard,
+                          selected && level === 'soft' && styles.dbChipSoft,
+                          selected && level === 'none' && styles.dbChipNone,
+                        ]}
+                        onPress={() => setDealbreakers((prev) => ({ ...prev, [key]: level }))}
+                      >
+                        <Text style={[styles.dbChipText, selected && styles.dbChipTextSelected]}>
+                          {level.charAt(0).toUpperCase() + level.slice(1)}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              </View>
             ))}
           </ScrollView>
         );
 
-      case 'must-haves':
+      case 6:
         return (
-          <View style={styles.stepContent}>
-            <Text style={styles.stepDescription}>
-              Any must-have features?
-            </Text>
-            <Text style={styles.hint}>
-              (This can be added later - you can skip for now)
-            </Text>
-          </View>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            {INTEREST_CATEGORIES.map(({ key, label, options }) => {
+              const isOpen = expandedCategory === key;
+              const selected = interests[key] ?? [];
+              return (
+                <View key={key} style={styles.catBlock}>
+                  <TouchableOpacity
+                    style={styles.catHeader}
+                    onPress={() => setExpandedCategory(isOpen ? null : key)}
+                  >
+                    <Text style={styles.catLabel}>
+                      {label}{selected.length > 0 ? `  (${selected.length})` : ''}
+                    </Text>
+                    <Text style={styles.catChevron}>{isOpen ? '▲' : '▼'}</Text>
+                  </TouchableOpacity>
+                  {isOpen && (
+                    <View style={styles.catContent}>
+                      <View style={styles.chipRow}>
+                        {options.map((opt) => (
+                          <Chip
+                            key={opt}
+                            label={opt}
+                            selected={selected.includes(opt)}
+                            disabled={!selected.includes(opt) && selected.length >= 5}
+                            onPress={() => {
+                              setInterests((prev) => {
+                                const cur = prev[key] ?? [];
+                                if (cur.includes(opt)) return { ...prev, [key]: cur.filter((i) => i !== opt) };
+                                if (cur.length >= 5) return prev;
+                                return { ...prev, [key]: [...cur, opt] };
+                              });
+                            }}
+                          />
+                        ))}
+                      </View>
+                      <View style={styles.customInputRow}>
+                        <TextInput
+                          style={styles.customInput}
+                          placeholder="+ Add custom"
+                          placeholderTextColor="#9AA"
+                          value={customInputs[key]}
+                          onChangeText={(t) => setCustomInputs((prev) => ({ ...prev, [key]: t }))}
+                          returnKeyType="done"
+                          onSubmitEditing={() => {
+                            const val = customInputs[key].trim();
+                            if (!val) return;
+                            setInterests((prev) => {
+                              const cur = prev[key] ?? [];
+                              if (cur.includes(val) || cur.length >= 5) return prev;
+                              return { ...prev, [key]: [...cur, val] };
+                            });
+                            setCustomInputs((prev) => ({ ...prev, [key]: '' }));
+                          }}
+                        />
+                      </View>
+                    </View>
+                  )}
+                </View>
+              );
+            })}
+          </ScrollView>
+        );
+
+      case 7:
+        return (
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.hint}>Tap a prompt to select it, then write your answer.</Text>
+            <Text style={styles.promptCount}>{promptAnswers.length} / 3 selected</Text>
+            {PROMPTS.map((q) => {
+              const selected = isPromptSelected(q);
+              const entry = promptAnswers.find((p) => p.question === q);
+              const maxReached = !selected && promptAnswers.length >= 3;
+              return (
+                <View key={q} style={styles.promptBlock}>
+                  <TouchableOpacity
+                    style={[styles.promptRow, selected && styles.promptRowSelected, maxReached && styles.promptRowDimmed]}
+                    onPress={() => !maxReached && togglePrompt(q)}
+                    activeOpacity={maxReached ? 1 : 0.7}
+                  >
+                    <Text style={[styles.promptText, selected && styles.promptTextSelected]}>{q}</Text>
+                    {selected && <Text style={styles.promptCheck}>✓</Text>}
+                  </TouchableOpacity>
+                  {selected && (
+                    <TextInput
+                      style={styles.promptInput}
+                      placeholder="Your answer…"
+                      placeholderTextColor="#9AA"
+                      value={entry?.answer ?? ''}
+                      onChangeText={(t) => setPromptAnswer(q, t)}
+                      multiline
+                      maxLength={300}
+                    />
+                  )}
+                </View>
+              );
+            })}
+          </ScrollView>
+        );
+
+      case 8:
+        return (
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false}>
+            <PublicProfileCard
+              imageUrls={stagingUris}
+              name={name.trim() || 'Your name'}
+              age={age ? parseInt(age, 10) : null}
+              location={[city.trim(), locationState.trim()].filter(Boolean).join(', ')}
+            />
+            <Text style={[styles.hint, { marginTop: 16 }]}>Add up to 4 photos. Tap + to add more.</Text>
+            <View style={styles.photoGrid}>
+              {stagingUris.map((uri, i) => (
+                <View key={i} style={[styles.photoThumb, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}>
+                  <Image source={{ uri }} style={styles.photoImg} />
+                  <TouchableOpacity style={styles.photoRemove} onPress={() => setStagingUris((p) => p.filter((_, idx) => idx !== i))}>
+                    <Text style={styles.photoRemoveText}>✕</Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+              {stagingUris.length < 4 && (
+                <TouchableOpacity
+                  style={[styles.photoAdd, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}
+                  onPress={pickProfilePhoto}
+                >
+                  <Text style={styles.photoAddIcon}>+</Text>
+                  <Text style={styles.photoAddLabel}>Add photo</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            <Text style={styles.photoCount}>{stagingUris.length} / 4 photos</Text>
+          </ScrollView>
+        );
+
+      case 9:
+        return (
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.hint}>Only fill this in if you have a room or place to offer.</Text>
+            <View style={styles.chipRow}>
+              <Chip
+                label="I have a place to list"
+                selected={hasListing}
+                onPress={() => setHasListing(!hasListing)}
+              />
+            </View>
+            {hasListing && (
+              <View>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Monthly rent ($)"
+                  placeholderTextColor="#9AA"
+                  value={listingRent}
+                  onChangeText={setListingRent}
+                  keyboardType="numeric"
+                />
+                <Text style={styles.sectionLabel}>Room type</Text>
+                <View style={styles.chipRow}>
+                  {[
+                    { val: 'private', label: 'Private Room' },
+                    { val: 'shared',  label: 'Shared Room' },
+                    { val: 'entire',  label: 'Entire Place' },
+                  ].map(({ val, label }) => (
+                    <Chip
+                      key={val}
+                      label={label}
+                      selected={listingRoomType === val}
+                      onPress={() => setListingRoomType(listingRoomType === val ? '' : val)}
+                    />
+                  ))}
+                </View>
+                <TextInput style={styles.input} placeholder="Address" placeholderTextColor="#9AA" value={listingAddress} onChangeText={setListingAddress} />
+                <TextInput style={styles.input} placeholder="City" placeholderTextColor="#9AA" value={listingCity} onChangeText={setListingCity} />
+                <TextInput style={styles.input} placeholder="State (e.g. CA)" placeholderTextColor="#9AA" value={listingStateVal} onChangeText={setListingStateVal} autoCapitalize="characters" maxLength={2} />
+                <TextInput style={styles.input} placeholder="ZIP code" placeholderTextColor="#9AA" value={listingZip} onChangeText={setListingZip} keyboardType="numeric" maxLength={5} />
+                <Text style={styles.sectionLabel}>Photos (up to 6)</Text>
+                <View style={styles.photoGrid}>
+                  {listingPhotos.map((uri, i) => (
+                    <View key={i} style={[styles.photoThumb, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}>
+                      <Image source={{ uri }} style={styles.photoImg} />
+                      <TouchableOpacity style={styles.photoRemove} onPress={() => setListingPhotos((p) => p.filter((_, idx) => idx !== i))}>
+                        <Text style={styles.photoRemoveText}>✕</Text>
+                      </TouchableOpacity>
+                    </View>
+                  ))}
+                  {listingPhotos.length < 6 && (
+                    <TouchableOpacity
+                      style={[styles.photoAdd, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}
+                      onPress={pickListingPhoto}
+                    >
+                      <Text style={styles.photoAddIcon}>+</Text>
+                      <Text style={styles.photoAddLabel}>Add photo</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              </View>
+            )}
+          </ScrollView>
         );
 
       default:
@@ -687,282 +952,469 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
     }
   };
 
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const isLastStep = step === TOTAL_STEPS - 1;
+  const progress = (step + 1) / TOTAL_STEPS;
+
   return (
-    <View style={styles.container}>
-      <Modal
-        visible={true}
-        animationType="slide"
-        transparent={true}
-        onRequestClose={() => {}}
+    <SafeAreaView style={styles.root} edges={['top', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-          <View style={styles.modalOverlay}>
-            <View style={styles.modalContent}>
-              {/* Progress indicator */}
-              <View style={styles.progressContainer}>
-                <View style={styles.progressBar}>
-                  <View
-                    style={[
-                      styles.progressFill,
-                      { width: `${(getStepNumber() / getTotalSteps()) * 100}%` },
-                    ]}
-                  />
-                </View>
-                <Text style={styles.progressText}>
-                  Step {getStepNumber()} of {getTotalSteps()}
-                </Text>
-              </View>
-
-              {/* Step title */}
-              <Text style={styles.stepTitle}>{getStepTitle()}</Text>
-
-              {/* Step content */}
-              {renderStepContent()}
-
-              {/* Action buttons */}
-              <View style={styles.buttonContainer}>
-                {currentStep !== 'about-you' && (
-                  <TouchableOpacity
-                    style={[styles.button, styles.previousButton]}
-                    onPress={handlePrevious}
-                    disabled={loading}
-                  >
-                    <Text style={styles.previousButtonText}>Previous</Text>
-                  </TouchableOpacity>
-                )}
-                <TouchableOpacity
-                  style={[styles.button, styles.skipButton]}
-                  onPress={handleSkip}
-                  disabled={loading}
-                >
-                  <Text style={styles.skipButtonText}>Skip</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.button, styles.nextButton]}
-                  onPress={handleNext}
-                  disabled={loading}
-                >
-                  {loading ? (
-                    <ActivityIndicator color="#fff" />
-                  ) : (
-                    <Text style={styles.nextButtonText}>
-                      {currentStep === 'must-haves' ? 'Complete' : 'Next'}
-                    </Text>
-                  )}
-                </TouchableOpacity>
-              </View>
+        {/* Header: back arrow + progress bar */}
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.backBtn}
+            onPress={handleBack}
+            disabled={step === 0 || saving}
+          >
+            {step > 0 && <Text style={styles.backBtnText}>←</Text>}
+          </TouchableOpacity>
+          <View style={styles.progressWrap}>
+            <View style={styles.progressTrack}>
+              <View style={[styles.progressFill, { width: `${progress * 100}%` as any }]} />
             </View>
+            <Text style={styles.progressLabel}>{step + 1} of {TOTAL_STEPS}</Text>
           </View>
-        </TouchableWithoutFeedback>
-      </Modal>
-    </View>
+          <View style={styles.backBtn} />
+        </View>
+
+        {/* Step title + subtitle */}
+        <View style={styles.titleBlock}>
+          <Text style={styles.stepTitle}>{STEP_TITLES[step]}</Text>
+          <Text style={styles.stepSubtitle}>{STEP_SUBTITLES[step]}</Text>
+        </View>
+
+        {/* Step content */}
+        {renderStep()}
+
+        {/* Footer buttons */}
+        <View style={styles.footer}>
+          <TouchableOpacity style={styles.skipBtn} onPress={handleSkip} disabled={saving}>
+            <Text style={styles.skipBtnText}>{isLastStep ? 'Finish' : 'Skip'}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.nextBtn, (!canAdvance() || saving) && styles.nextBtnDisabled]}
+            onPress={handleNext}
+            disabled={!canAdvance() || saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#FDFDFD" />
+            ) : (
+              <Text style={styles.nextBtnText}>{isLastStep ? 'Done' : 'Next'}</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
-  container: {
+  root: {
     flex: 1,
-    backgroundColor: '#D9E1E6', // Light Cool Gray
+    backgroundColor: '#E8EEF2',
   },
-  modalOverlay: {
+  flex: {
     flex: 1,
-    backgroundColor: 'rgba(12, 83, 137, 0.5)', // Deep Blue with transparency
+  },
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  backBtn: {
+    width: 40,
+    height: 40,
     justifyContent: 'center',
+  },
+  backBtnText: {
+    fontSize: 24,
+    color: '#0C5389',
+  },
+  progressWrap: {
+    flex: 1,
     alignItems: 'center',
   },
-  modalContent: {
-    backgroundColor: '#FDFDFD', // Pure White
-    borderRadius: 20,
-    padding: 24,
-    width: '90%',
-    maxWidth: 400,
-    maxHeight: '80%',
-    shadowColor: '#0C5389', // Deep Blue
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
-    elevation: 5,
-  },
-  progressContainer: {
-    marginBottom: 20,
-  },
-  progressBar: {
+  progressTrack: {
     height: 4,
-    backgroundColor: '#D9E1E6', // Light Cool Gray
+    width: '100%',
+    backgroundColor: '#D9E1E6',
     borderRadius: 2,
     overflow: 'hidden',
-    marginBottom: 8,
   },
   progressFill: {
     height: '100%',
-    backgroundColor: '#189AA2', // Teal / Blue-Green
+    backgroundColor: '#189AA2',
     borderRadius: 2,
   },
-  progressText: {
-    fontSize: 12,
-    color: '#0C5389', // Deep Blue
-    textAlign: 'center',
+  progressLabel: {
+    fontSize: 11,
+    color: '#0C5389',
+    marginTop: 4,
+  },
+
+  // Title block
+  titleBlock: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 8,
   },
   stepTitle: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#0C5389', // Deep Blue
-    marginBottom: 12,
-    textAlign: 'center',
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#0C5389',
+    marginBottom: 4,
   },
-  stepDescription: {
-    fontSize: 16,
-    color: '#0C5389', // Deep Blue
-    marginBottom: 20,
-    textAlign: 'center',
+  stepSubtitle: {
+    fontSize: 14,
+    color: '#7A8FA0',
+    lineHeight: 20,
   },
-  stepContent: {
-    minHeight: 200,
-    maxHeight: 400,
+
+  // Step body
+  stepBody: {
+    flex: 1,
+    paddingHorizontal: 20,
   },
+
+  // Inputs
   input: {
-    backgroundColor: '#FDFDFD', // Pure White
-    borderRadius: 8,
-    padding: 15,
-    marginBottom: 15,
-    fontSize: 16,
+    backgroundColor: '#FDFDFD',
+    borderRadius: 10,
     borderWidth: 1,
-    borderColor: '#D9E1E6', // Light Cool Gray
-    color: '#0C5389', // Deep Blue
-  },
-  optionButton: {
-    backgroundColor: '#FDFDFD', // Pure White
-    borderRadius: 8,
-    padding: 15,
-    marginBottom: 12,
-    borderWidth: 2,
-    borderColor: '#D9E1E6', // Light Cool Gray
-  },
-  optionButtonSelected: {
-    backgroundColor: '#189AA2', // Teal / Blue-Green
-    borderColor: '#189AA2', // Teal / Blue-Green
-  },
-  optionText: {
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 14,
+    paddingVertical: 13,
     fontSize: 16,
-    color: '#0C5389', // Deep Blue
-    textAlign: 'center',
-  },
-  optionTextSelected: {
-    color: '#FDFDFD', // Pure White
-    fontWeight: '600',
-  },
-  booleanOptions: {
-    flexDirection: 'row',
-    gap: 12,
-    marginBottom: 20,
-  },
-  cleanlinessOptions: {
-    flexDirection: 'row',
-    gap: 12,
-    marginBottom: 20,
-    justifyContent: 'center',
-  },
-  cleanlinessButton: {
-    width: 50,
-    height: 50,
-    borderRadius: 25,
-    backgroundColor: '#FDFDFD', // Pure White
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: '#D9E1E6', // Light Cool Gray
-  },
-  cleanlinessText: {
-    fontSize: 18,
-    color: '#0C5389', // Deep Blue
-    fontWeight: '600',
-  },
-  questionLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#0C5389', // Deep Blue
-    marginTop: 20,
+    color: '#0C5389',
     marginBottom: 12,
+  },
+  sectionLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0C5389',
+    marginTop: 16,
+    marginBottom: 8,
   },
   hint: {
-    fontSize: 14,
-    color: '#189AA2', // Teal / Blue-Green
-    textAlign: 'center',
-    marginTop: 10,
+    fontSize: 13,
+    color: '#7A8FA0',
+    lineHeight: 18,
+    marginBottom: 12,
+    marginTop: 4,
   },
   errorText: {
+    fontSize: 13,
+    color: '#E53E3E',
+    marginBottom: 8,
+  },
+
+  // Chips
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 4,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  chipSelected: {
+    backgroundColor: '#189AA2',
+    borderColor: '#189AA2',
+  },
+  chipDisabled: {
+    opacity: 0.4,
+  },
+  chipText: {
     fontSize: 14,
-    color: '#FF6B6B', // Red for errors
-    textAlign: 'center',
-    marginTop: 10,
-    marginBottom: 10,
+    color: '#0C5389',
   },
-  datePickerButton: {
-    backgroundColor: '#FDFDFD', // Pure White
-    borderRadius: 8,
-    padding: 15,
-    marginBottom: 15,
+  chipTextSelected: {
+    color: '#FDFDFD',
+    fontWeight: '600',
+  },
+
+  // Date picker
+  dateBtn: {
+    backgroundColor: '#FDFDFD',
+    borderRadius: 10,
     borderWidth: 1,
-    borderColor: '#D9E1E6', // Light Cool Gray
+    borderColor: '#D9E1E6',
+    padding: 14,
+    marginBottom: 12,
     alignItems: 'center',
   },
-  datePickerText: {
+  dateBtnText: {
     fontSize: 16,
-    color: '#0C5389', // Deep Blue
+    color: '#0C5389',
   },
-  datePickerPlaceholder: {
-    color: '#999', // Gray for placeholder
+  dateBtnPlaceholder: {
+    color: '#9AA',
   },
-  iosDatePickerActions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    marginTop: 10,
-    marginBottom: 15,
-  },
-  datePickerActionButton: {
-    padding: 10,
+  dateDoneBtn: {
+    alignSelf: 'flex-end',
     paddingHorizontal: 20,
-    backgroundColor: '#46BD7F', // Primary Green
+    paddingVertical: 8,
+    backgroundColor: '#189AA2',
     borderRadius: 8,
+    marginTop: 8,
+    marginBottom: 8,
   },
-  datePickerActionText: {
-    color: '#FDFDFD', // Pure White
-    fontSize: 16,
+  dateDoneBtnText: {
+    color: '#FDFDFD',
+    fontSize: 14,
     fontWeight: '600',
   },
-  buttonContainer: {
-    flexDirection: 'row',
-    gap: 12,
-    marginTop: 24,
+
+  // Dealbreakers
+  dbRow: {
+    marginBottom: 14,
   },
-  button: {
+  dbLabel: {
+    fontSize: 15,
+    color: '#0C5389',
+    fontWeight: '500',
+    marginBottom: 6,
+  },
+  dbChips: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  dbChip: {
     flex: 1,
+    paddingVertical: 8,
     borderRadius: 8,
-    padding: 15,
+    borderWidth: 1.5,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
     alignItems: 'center',
   },
-  previousButton: {
-    backgroundColor: '#D9E1E6', // Light Cool Gray
+  dbChipHard: {
+    backgroundColor: '#E53E3E',
+    borderColor: '#E53E3E',
   },
-  previousButtonText: {
-    color: '#0C5389', // Deep Blue
-    fontSize: 16,
+  dbChipSoft: {
+    backgroundColor: '#F6AD55',
+    borderColor: '#F6AD55',
+  },
+  dbChipNone: {
+    backgroundColor: '#189AA2',
+    borderColor: '#189AA2',
+  },
+  dbChipText: {
+    fontSize: 13,
+    color: '#0C5389',
+    fontWeight: '500',
+  },
+  dbChipTextSelected: {
+    color: '#FDFDFD',
     fontWeight: '600',
   },
-  skipButton: {
-    backgroundColor: '#D9E1E6', // Light Cool Gray
+
+  // Interests accordion
+  catBlock: {
+    borderBottomWidth: 1,
+    borderBottomColor: '#D9E1E6',
+    marginBottom: 0,
   },
-  skipButtonText: {
-    color: '#0C5389', // Deep Blue
+  catHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 14,
+  },
+  catLabel: {
     fontSize: 16,
     fontWeight: '600',
+    color: '#0C5389',
   },
-  nextButton: {
-    backgroundColor: '#46BD7F', // Primary Green
+  catChevron: {
+    fontSize: 12,
+    color: '#189AA2',
   },
-  nextButtonText: {
-    color: '#FDFDFD', // Pure White
+  catContent: {
+    paddingBottom: 8,
+  },
+  customInputRow: {
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  customInput: {
+    backgroundColor: '#FDFDFD',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    color: '#0C5389',
+  },
+
+  // Prompts
+  promptCount: {
+    fontSize: 13,
+    color: '#189AA2',
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  promptBlock: {
+    marginBottom: 8,
+  },
+  promptRow: {
+    padding: 14,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  promptRowSelected: {
+    borderColor: '#189AA2',
+    backgroundColor: '#EDF8F9',
+  },
+  promptRowDimmed: {
+    opacity: 0.45,
+  },
+  promptText: {
+    fontSize: 14,
+    color: '#0C5389',
+    flex: 1,
+    lineHeight: 20,
+  },
+  promptTextSelected: {
+    fontWeight: '500',
+  },
+  promptCheck: {
+    fontSize: 16,
+    color: '#189AA2',
+    marginLeft: 8,
+    fontWeight: '700',
+  },
+  promptInput: {
+    backgroundColor: '#FDFDFD',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: '#0C5389',
+    marginTop: 4,
+    minHeight: 70,
+    textAlignVertical: 'top',
+  },
+
+  // Photos
+  photoGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  photoThumb: {
+    borderRadius: 12,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  photoImg: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+  photoRemove: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  photoRemoveText: {
+    color: '#FDFDFD',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  photoAdd: {
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: '#D9E1E6',
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FDFDFD',
+  },
+  photoAddIcon: {
+    fontSize: 32,
+    color: '#D9E1E6',
+  },
+  photoAddLabel: {
+    fontSize: 12,
+    color: '#7A8FA0',
+    marginTop: 4,
+  },
+  photoCount: {
+    fontSize: 13,
+    color: '#7A8FA0',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+
+  // Footer
+  footer: {
+    flexDirection: 'row',
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+    paddingTop: 12,
+    gap: 12,
+    backgroundColor: '#E8EEF2',
+  },
+  skipBtn: {
+    flex: 1,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    backgroundColor: '#D9E1E6',
+  },
+  skipBtnText: {
     fontSize: 16,
     fontWeight: '600',
+    color: '#0C5389',
+  },
+  nextBtn: {
+    flex: 2,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    backgroundColor: '#0C5389',
+  },
+  nextBtnDisabled: {
+    opacity: 0.4,
+  },
+  nextBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FDFDFD',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "dotenv": "^17.2.3",
         "expo": "~54.0.30",
         "expo-constants": "^18.0.12",
+        "expo-image-picker": "^55.0.18",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -6605,6 +6606,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.18.tgz",
+      "integrity": "sha512-lGpPGRu+7mE8qN0ma2boRsCmfOGbdHZ2bXTpWVeWly0JCZdogGlTrYFnhTqgS8+lmiRb/UCOs7iTm2P5Rra6kw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
Chats Tab Redesign + Likes Tab

Merges the separate Matches and Messages tabs into a single unified Chats tab, and adds a new Likes tab for the dopamine loop.

Chats tab

Two sub-tabs: Matched (2-column grid of mutual likes) and Messages (conversation list)
Sort chips on Matched grid: Recent / Name
Unread message badge on Messages pill when there are unread conversations
Tapping a match opens a chat, lazily creating the conversation on first message
Likes tab

Shows everyone who liked your profile with blurred photos
1 free reveal per day (tracked in DB via last_free_reveal_at on profiles)
After revealing: photo unblurs and "Like Back" button appears
Liking back triggers match detection — if mutual, shows match modal with Send Message CTA
