### PR TITLE
Place listings

### DIFF
--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -115,12 +115,19 @@ export default function SwipeCard({ profile, onPress }: Props) {
           )}
         </View>
 
-        {/* Location */}
-        {!!profile.location && (
-          <Text style={styles.location} numberOfLines={1}>
-            📍 {profile.location}
-          </Text>
-        )}
+        {/* Location + listing badge */}
+        <View style={styles.locationRow}>
+          {!!profile.location && (
+            <Text style={styles.location} numberOfLines={1}>
+              📍 {profile.location}
+            </Text>
+          )}
+          {profile.hasListing && (
+            <View style={styles.listingBadge}>
+              <Text style={styles.listingBadgeText}>🏠 Has a place</Text>
+            </View>
+          )}
+        </View>
 
         {/* Bio */}
         {!!profile.bio && (
@@ -241,7 +248,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: '#189AA2',
     fontWeight: '500',
-    marginBottom: 6,
   },
   bio: {
     fontSize: 13,
@@ -271,5 +277,25 @@ const styles = StyleSheet.create({
     color: '#9AA',
     marginTop: 4,
     textAlign: 'right',
+  },
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 4,
+  },
+  listingBadge: {
+    backgroundColor: 'rgba(70,189,127,0.15)',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#46BD7F',
+  },
+  listingBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#46BD7F',
   },
 });

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -11,6 +11,7 @@ export type DiscoverProfile = {
   hobbies: string[] | null;
   photoUrls: string[];
   location: string;
+  hasListing: boolean;
 };
 
 export async function fetchDiscoverProfiles(
@@ -32,7 +33,7 @@ export async function fetchDiscoverProfiles(
   let query = supabase
     .from('profiles')
     .select(
-      'id, name, age, bio, hobbies, profile_photo_url, subscription_tier, created_at, updated_at, ' +
+      'id, name, age, bio, hobbies, has_listing, profile_photo_url, subscription_tier, created_at, updated_at, ' +
       'preferences(city, state, min_budget, max_budget, cleanliness_level, social_preference, ' +
       'work_schedule, interests, dealbreakers, pets_allowed, smoking_allowed)'
     )
@@ -106,6 +107,7 @@ export async function fetchDiscoverProfiles(
       bio: row.bio ?? null,
       hobbies,
       photoUrls: urls,
+      hasListing: row.has_listing === true,
       location,
     });
   }

--- a/apps/mobile/lib/listings.ts
+++ b/apps/mobile/lib/listings.ts
@@ -1,0 +1,72 @@
+import { supabase } from './supabase';
+
+export type Listing = {
+  id: string;
+  user_id: string;
+  rent: number | null;
+  room_type: string | null;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  zip_code: string | null;
+  move_in_date: string | null;
+};
+
+export type ListingInput = {
+  rent: number | null;
+  room_type: string | null;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  zip_code: string | null;
+  move_in_date: string | null;
+};
+
+export async function getListing(userId: string): Promise<Listing | null> {
+  const { data } = await supabase
+    .from('listings')
+    .select('id, user_id, rent, room_type, address, city, state, zip_code, move_in_date')
+    .eq('user_id', userId)
+    .maybeSingle();
+  return data ?? null;
+}
+
+export async function saveListing(
+  userId: string,
+  input: ListingInput
+): Promise<{ ok: boolean; error?: string }> {
+  // Upsert the listing
+  const { error: listErr } = await supabase
+    .from('listings')
+    .upsert({ user_id: userId, ...input }, { onConflict: 'user_id' });
+
+  if (listErr) return { ok: false, error: listErr.message };
+
+  // Mark has_listing = true on profile
+  const { error: profErr } = await supabase
+    .from('profiles')
+    .update({ has_listing: true })
+    .eq('id', userId);
+
+  if (profErr) return { ok: false, error: profErr.message };
+  return { ok: true };
+}
+
+export async function deleteListing(
+  userId: string
+): Promise<{ ok: boolean; error?: string }> {
+  const { error: delErr } = await supabase
+    .from('listings')
+    .delete()
+    .eq('user_id', userId);
+
+  if (delErr) return { ok: false, error: delErr.message };
+
+  const { error: profErr } = await supabase
+    .from('profiles')
+    .update({ has_listing: false })
+    .eq('id', userId);
+
+  if (profErr) return { ok: false, error: profErr.message };
+  return { ok: true };
+}

--- a/apps/mobile/lib/listings.ts
+++ b/apps/mobile/lib/listings.ts
@@ -10,6 +10,7 @@ export type Listing = {
   state: string | null;
   zip_code: string | null;
   move_in_date: string | null;
+  listing_photos: string[] | null;
 };
 
 export type ListingInput = {
@@ -20,12 +21,13 @@ export type ListingInput = {
   state: string | null;
   zip_code: string | null;
   move_in_date: string | null;
+  listing_photos?: string[] | null;
 };
 
 export async function getListing(userId: string): Promise<Listing | null> {
   const { data } = await supabase
     .from('listings')
-    .select('id, user_id, rent, room_type, address, city, state, zip_code, move_in_date')
+    .select('id, user_id, rent, room_type, address, city, state, zip_code, move_in_date, listing_photos')
     .eq('user_id', userId)
     .maybeSingle();
   return data ?? null;

--- a/apps/mobile/lib/storage.ts
+++ b/apps/mobile/lib/storage.ts
@@ -308,6 +308,64 @@ export async function pickImage(): Promise<string | null> {
 }
 
 /**
+ * Upload a listing photo for a user
+ * Stored under userId/listings/timestamp.ext in the profile-images bucket
+ */
+export async function uploadListingPhoto(
+  userId: string,
+  imageUri: string
+): Promise<{ path: string | null; error: string | null }> {
+  try {
+    const timestamp = Date.now();
+    const uriParts = imageUri.split('.');
+    const fileExt = uriParts.length > 1 ? uriParts.pop()?.toLowerCase() || 'jpg' : 'jpg';
+    const filePath = `${userId}/listings/${timestamp}.${fileExt}`;
+
+    const base64 = await FileSystem.readAsStringAsync(imageUri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    if (!base64 || base64.length === 0) throw new Error('File is empty');
+
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
+
+    const contentType = `image/${fileExt === 'jpg' ? 'jpeg' : fileExt}`;
+    const { data, error } = await supabase.storage
+      .from(PROFILE_IMAGES_BUCKET)
+      .upload(filePath, bytes.buffer, { contentType, upsert: true, cacheControl: '3600' });
+
+    if (error) return { path: null, error: error.message };
+    return { path: data?.path || filePath, error: null };
+  } catch (error: any) {
+    return { path: null, error: error.message || 'Failed to upload listing photo' };
+  }
+}
+
+/**
+ * Pick a listing photo (4:3 aspect ratio)
+ */
+export async function pickListingImage(): Promise<string | null> {
+  try {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permission needed', 'We need camera roll permissions to upload listing photos.');
+      return null;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 0.8,
+    });
+    if (result.canceled || !result.assets[0]) return null;
+    return result.assets[0].uri;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Take a photo with the camera
  * @returns The captured image URI, or null if cancelled/error
  */

--- a/apps/mobile/screens/UserProfileScreen.tsx
+++ b/apps/mobile/screens/UserProfileScreen.tsx
@@ -15,7 +15,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { supabase } from '../lib/supabase';
 import { useEffect, useState, useCallback } from 'react';
-import { getProfileImageUrls, pickImage } from '../lib/storage';
+import { getProfileImageUrls, getProfileImageUrl, pickImage, uploadListingPhoto, pickListingImage } from '../lib/storage';
 import { getPreferences, savePreferences, type Preferences } from '../lib/preferences';
 import { formatLocationLine, profilePhotoPathsFromRow } from '../lib/profileDisplay';
 import { appendProfilePhoto, removeProfilePhotoAt, replaceProfilePhotoAt, MAX_PROFILE_PHOTOS } from '../lib/profilePhotos';
@@ -63,6 +63,9 @@ const PROMPTS = [
   'After work I usually…',
   'The best thing about me as a roommate…',
 ];
+
+const MAX_LISTING_PHOTOS = 6;
+type ListingPhotoItem = { kind: 'path'; path: string; url: string } | { kind: 'local'; uri: string };
 
 type DealbreakerLevel = 'hard' | 'soft' | 'none';
 type PromptEntry = { question: string; answer: string };
@@ -113,6 +116,7 @@ export default function UserProfileScreen({ route }: Props) {
   const [editListingState, setEditListingState] = useState('');
   const [editListingZip, setEditListingZip] = useState('');
   const [editMoveInDate, setEditMoveInDate] = useState('');
+  const [editListingPhotos, setEditListingPhotos] = useState<ListingPhotoItem[]>([]);
 
   const [editName, setEditName] = useState('');
   const [editBio, setEditBio] = useState('');
@@ -125,7 +129,7 @@ export default function UserProfileScreen({ route }: Props) {
     setListing(l);
   }, []);
 
-  const openListingModal = () => {
+  const openListingModal = async () => {
     setEditRent(listing?.rent != null ? String(listing.rent) : '');
     setEditRoomType(listing?.room_type ?? '');
     setEditAddress(listing?.address ?? '');
@@ -133,13 +137,38 @@ export default function UserProfileScreen({ route }: Props) {
     setEditListingState(listing?.state ?? '');
     setEditListingZip(listing?.zip_code ?? '');
     setEditMoveInDate(listing?.move_in_date ?? '');
+    const paths = listing?.listing_photos ?? [];
+    const items: ListingPhotoItem[] = await Promise.all(
+      paths.map(async (path) => {
+        const url = await getProfileImageUrl(path);
+        return { kind: 'path' as const, path, url: url ?? '' };
+      })
+    );
+    setEditListingPhotos(items);
     setListingOpen(true);
+  };
+
+  const handleAddListingPhoto = async () => {
+    if (editListingPhotos.length >= MAX_LISTING_PHOTOS) return;
+    const uri = await pickListingImage();
+    if (!uri) return;
+    setEditListingPhotos((prev) => [...prev, { kind: 'local', uri }]);
   };
 
   const handleSaveListing = async () => {
     if (!user) return;
     setSavingListing(true);
     try {
+      const photoPaths: string[] = [];
+      for (const item of editListingPhotos) {
+        if (item.kind === 'path') {
+          photoPaths.push(item.path);
+        } else {
+          const { path, error } = await uploadListingPhoto(user.id, item.uri);
+          if (error || !path) { Alert.alert('Error', error ?? 'Photo upload failed'); return; }
+          photoPaths.push(path);
+        }
+      }
       const result = await saveListing(user.id, {
         rent: editRent ? parseFloat(editRent) : null,
         room_type: editRoomType.trim() || null,
@@ -148,6 +177,7 @@ export default function UserProfileScreen({ route }: Props) {
         state: editListingState.trim() || null,
         zip_code: editListingZip.trim() || null,
         move_in_date: editMoveInDate.trim() || null,
+        listing_photos: photoPaths,
       });
       if (!result.ok) { Alert.alert('Error', result.error); return; }
       setListingOpen(false);
@@ -868,6 +898,34 @@ export default function UserProfileScreen({ route }: Props) {
             </TouchableOpacity>
           </View>
           <ScrollView contentContainerStyle={styles.modalScrollContent} keyboardShouldPersistTaps="handled">
+
+            <Text style={styles.listingFieldLabel}>Photos ({editListingPhotos.length}/{MAX_LISTING_PHOTOS})</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginBottom: 16 }}>
+              <View style={{ flexDirection: 'row', gap: 8, paddingVertical: 4 }}>
+                {editListingPhotos.map((item, idx) => (
+                  <View key={idx} style={{ position: 'relative' }}>
+                    <Image
+                      source={{ uri: item.kind === 'path' ? item.url : item.uri }}
+                      style={{ width: 110, height: 82, borderRadius: 8, backgroundColor: '#ddd' }}
+                    />
+                    <TouchableOpacity
+                      style={{ position: 'absolute', top: 4, right: 4, backgroundColor: 'rgba(0,0,0,0.55)', borderRadius: 10, width: 20, height: 20, alignItems: 'center', justifyContent: 'center' }}
+                      onPress={() => setEditListingPhotos((prev) => prev.filter((_, i) => i !== idx))}
+                    >
+                      <Text style={{ color: '#fff', fontSize: 13, lineHeight: 18 }}>×</Text>
+                    </TouchableOpacity>
+                  </View>
+                ))}
+                {editListingPhotos.length < MAX_LISTING_PHOTOS && (
+                  <TouchableOpacity
+                    style={{ width: 110, height: 82, borderRadius: 8, borderWidth: 1.5, borderColor: '#189AA2', borderStyle: 'dashed', alignItems: 'center', justifyContent: 'center' }}
+                    onPress={handleAddListingPhoto}
+                  >
+                    <Text style={{ color: '#189AA2', fontSize: 26, lineHeight: 30 }}>+</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            </ScrollView>
 
             <Text style={styles.listingFieldLabel}>Monthly Rent ($)</Text>
             <TextInput

--- a/apps/mobile/screens/UserProfileScreen.tsx
+++ b/apps/mobile/screens/UserProfileScreen.tsx
@@ -23,6 +23,7 @@ import PublicProfileCard from '../components/PublicProfileCard';
 import ProfileDetailsForm from '../components/ProfileDetailsForm';
 import * as Clipboard from 'expo-clipboard';
 import { redeemReferralCode, redeemErrorMessage } from '../lib/referrals';
+import { getListing, saveListing, deleteListing, type Listing } from '../lib/listings';
 
 // ─── Shared constants ────────────────────────────────────────────────────────
 
@@ -101,11 +102,75 @@ export default function UserProfileScreen({ route }: Props) {
   const [editPrompts, setEditPrompts] = useState<PromptEntry[]>([]);
   const [promptPickerIndex, setPromptPickerIndex] = useState<number | null>(null);
 
+  // Listing state
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [listingOpen, setListingOpen] = useState(false);
+  const [savingListing, setSavingListing] = useState(false);
+  const [editRent, setEditRent] = useState('');
+  const [editRoomType, setEditRoomType] = useState('');
+  const [editAddress, setEditAddress] = useState('');
+  const [editListingCity, setEditListingCity] = useState('');
+  const [editListingState, setEditListingState] = useState('');
+  const [editListingZip, setEditListingZip] = useState('');
+  const [editMoveInDate, setEditMoveInDate] = useState('');
+
   const [editName, setEditName] = useState('');
   const [editBio, setEditBio] = useState('');
   const [editOccupation, setEditOccupation] = useState('');
   const [editHobbies, setEditHobbies] = useState<string[]>([]);
   const [editHobbyDraft, setEditHobbyDraft] = useState('');
+
+  const loadListing = useCallback(async (userId: string) => {
+    const l = await getListing(userId);
+    setListing(l);
+  }, []);
+
+  const openListingModal = () => {
+    setEditRent(listing?.rent != null ? String(listing.rent) : '');
+    setEditRoomType(listing?.room_type ?? '');
+    setEditAddress(listing?.address ?? '');
+    setEditListingCity(listing?.city ?? '');
+    setEditListingState(listing?.state ?? '');
+    setEditListingZip(listing?.zip_code ?? '');
+    setEditMoveInDate(listing?.move_in_date ?? '');
+    setListingOpen(true);
+  };
+
+  const handleSaveListing = async () => {
+    if (!user) return;
+    setSavingListing(true);
+    try {
+      const result = await saveListing(user.id, {
+        rent: editRent ? parseFloat(editRent) : null,
+        room_type: editRoomType.trim() || null,
+        address: editAddress.trim() || null,
+        city: editListingCity.trim() || null,
+        state: editListingState.trim() || null,
+        zip_code: editListingZip.trim() || null,
+        move_in_date: editMoveInDate.trim() || null,
+      });
+      if (!result.ok) { Alert.alert('Error', result.error); return; }
+      setListingOpen(false);
+      await loadListing(user.id);
+      await loadProfile(user.id);
+    } finally {
+      setSavingListing(false);
+    }
+  };
+
+  const handleDeleteListing = () => {
+    if (!user) return;
+    Alert.alert('Remove listing', 'Remove your place listing?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove', style: 'destructive', onPress: async () => {
+          await deleteListing(user.id);
+          setListing(null);
+          await loadProfile(user.id);
+        },
+      },
+    ]);
+  };
 
   const loadProfile = useCallback(async (userId: string) => {
     const { data, error } = await supabase
@@ -138,7 +203,7 @@ export default function UserProfileScreen({ route }: Props) {
   useEffect(() => {
     supabase.auth.getUser().then(({ data: { user: u } }) => {
       setUser(u ? { id: u.id, email: u.email } : null);
-      if (u) loadProfile(u.id);
+      if (u) { loadProfile(u.id); loadListing(u.id); }
     });
 
     const {
@@ -146,17 +211,18 @@ export default function UserProfileScreen({ route }: Props) {
     } = supabase.auth.onAuthStateChange((_event, session) => {
       const u = session?.user;
       setUser(u ? { id: u.id, email: u.email } : null);
-      if (u) loadProfile(u.id);
+      if (u) { loadProfile(u.id); loadListing(u.id); }
       else {
         setProfile(null);
         setPrefs(null);
         setImageUrls([]);
         setPhotoPaths([]);
+        setListing(null);
       }
     });
 
     return () => subscription.unsubscribe();
-  }, [loadProfile]);
+  }, [loadProfile, loadListing]);
 
   const openEditProfile = () => {
     if (!profile) return;
@@ -399,6 +465,41 @@ export default function UserProfileScreen({ route }: Props) {
               <TouchableOpacity style={styles.secondaryButton} onPress={openEditPrompts}>
                 <Text style={styles.secondaryButtonText}>Edit prompts</Text>
               </TouchableOpacity>
+            </View>
+
+            {/* ── My Listing ── */}
+            <View style={styles.listingCard}>
+              <Text style={styles.accountTitle}>My Place Listing</Text>
+              {listing ? (
+                <>
+                  <View style={styles.listingRow}>
+                    <Text style={styles.listingValue}>
+                      {listing.room_type ?? 'Room'}{listing.city ? ` · ${listing.city}${listing.state ? `, ${listing.state}` : ''}` : ''}
+                    </Text>
+                    {listing.rent != null && (
+                      <Text style={styles.listingRent}>${listing.rent}/mo</Text>
+                    )}
+                  </View>
+                  {listing.move_in_date && (
+                    <Text style={styles.listingSub}>Available {listing.move_in_date}</Text>
+                  )}
+                  <View style={styles.listingBtns}>
+                    <TouchableOpacity style={styles.listingEditBtn} onPress={openListingModal}>
+                      <Text style={styles.listingEditBtnText}>Edit listing</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.listingDeleteBtn} onPress={handleDeleteListing}>
+                      <Text style={styles.listingDeleteBtnText}>Remove</Text>
+                    </TouchableOpacity>
+                  </View>
+                </>
+              ) : (
+                <>
+                  <Text style={styles.listingSub}>Let others know you have a place available.</Text>
+                  <TouchableOpacity style={styles.primaryButton} onPress={openListingModal}>
+                    <Text style={styles.primaryButtonText}>Add a listing</Text>
+                  </TouchableOpacity>
+                </>
+              )}
             </View>
 
             <View style={styles.accountCard}>
@@ -747,6 +848,95 @@ export default function UserProfileScreen({ route }: Props) {
             </TouchableOpacity>
           </ScrollView>
         </View>
+      </Modal>
+
+      {/* ── Listing modal ── */}
+      <Modal
+        visible={listingOpen}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setListingOpen(false)}
+      >
+        <KeyboardAvoidingView style={styles.modalRoot} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+          <View style={styles.modalHeader}>
+            <TouchableOpacity onPress={() => setListingOpen(false)}>
+              <Text style={styles.modalCancel}>Cancel</Text>
+            </TouchableOpacity>
+            <Text style={styles.modalTitle}>{listing ? 'Edit Listing' : 'Add Listing'}</Text>
+            <TouchableOpacity onPress={handleSaveListing} disabled={savingListing}>
+              {savingListing ? <ActivityIndicator color="#189AA2" /> : <Text style={styles.modalSave}>Save</Text>}
+            </TouchableOpacity>
+          </View>
+          <ScrollView contentContainerStyle={styles.modalScrollContent} keyboardShouldPersistTaps="handled">
+
+            <Text style={styles.listingFieldLabel}>Monthly Rent ($)</Text>
+            <TextInput
+              style={styles.listingInput}
+              value={editRent}
+              onChangeText={setEditRent}
+              placeholder="e.g. 1200"
+              placeholderTextColor="#9AA"
+              keyboardType="numeric"
+            />
+
+            <Text style={styles.listingFieldLabel}>Room Type</Text>
+            <View style={styles.chipsWrap}>
+              {[
+                { label: 'Private room', value: 'private' },
+                { label: 'Shared room', value: 'shared' },
+                { label: 'Studio', value: 'studio' },
+                { label: 'Entire place', value: 'entire' },
+              ].map((t) => (
+                <TouchableOpacity
+                  key={t.value}
+                  style={[styles.chip, editRoomType === t.value && styles.chipOn]}
+                  onPress={() => setEditRoomType(t.value)}
+                >
+                  <Text style={[styles.chipText, editRoomType === t.value && styles.chipTextOn]}>{t.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            <Text style={styles.listingFieldLabel}>City</Text>
+            <TextInput
+              style={styles.listingInput}
+              value={editListingCity}
+              onChangeText={setEditListingCity}
+              placeholder="e.g. Riverside"
+              placeholderTextColor="#9AA"
+            />
+
+            <Text style={styles.listingFieldLabel}>State</Text>
+            <TextInput
+              style={styles.listingInput}
+              value={editListingState}
+              onChangeText={setEditListingState}
+              placeholder="e.g. CA"
+              placeholderTextColor="#9AA"
+              autoCapitalize="characters"
+              maxLength={2}
+            />
+
+            <Text style={styles.listingFieldLabel}>Address (optional)</Text>
+            <TextInput
+              style={styles.listingInput}
+              value={editAddress}
+              onChangeText={setEditAddress}
+              placeholder="Street address"
+              placeholderTextColor="#9AA"
+            />
+
+            <Text style={styles.listingFieldLabel}>Available From</Text>
+            <TextInput
+              style={styles.listingInput}
+              value={editMoveInDate}
+              onChangeText={setEditMoveInDate}
+              placeholder="YYYY-MM-DD"
+              placeholderTextColor="#9AA"
+            />
+
+          </ScrollView>
+        </KeyboardAvoidingView>
       </Modal>
     </View>
   );
@@ -1217,5 +1407,90 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
     color: '#189AA2',
+  },
+
+  // ── Listing card ────────────────────────────────────────────────────────────
+  listingCard: {
+    marginTop: 20,
+    backgroundColor: '#FDFDFD',
+    borderRadius: 14,
+    padding: 18,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+  },
+  listingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  listingValue: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0C5389',
+    flex: 1,
+  },
+  listingRent: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#189AA2',
+    marginLeft: 8,
+  },
+  listingSub: {
+    fontSize: 13,
+    color: '#4A6070',
+    marginBottom: 14,
+    lineHeight: 18,
+  },
+  listingBtns: {
+    flexDirection: 'row',
+    gap: 10,
+    marginTop: 12,
+  },
+  listingEditBtn: {
+    flex: 1,
+    backgroundColor: '#F4F7F9',
+    borderRadius: 10,
+    paddingVertical: 11,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#189AA2',
+  },
+  listingEditBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#0C5389',
+  },
+  listingDeleteBtn: {
+    paddingVertical: 11,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#E53935',
+  },
+  listingDeleteBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#E53935',
+  },
+  listingFieldLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#4A6070',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+    marginTop: 16,
+  },
+  listingInput: {
+    backgroundColor: '#F4F7F9',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '#0C5389',
   },
 });


### PR DESCRIPTION
Title: Place listings, listing photos, profile editing & match modal

Body:


## Summary

- **Profile editing** — users can edit interests, dealbreakers, and prompts from the Profile tab
- **Match modal redesign** — pear icon, both avatars, shared interests display
- **Place listing flow** — add/edit a listing (rent, room type, address, move-in date) from Profile tab
- **Listing photos** — up to 6 photos per listing, stored in Supabase Storage, add/remove in edit modal
- **metro.config.js** — fixes monorepo bundling (expo hoisted to root node_modules)

## Test plan

- [ ] Edit interests + dealbreakers from Profile tab — saves and reloads correctly
- [ ] Edit prompts — can pick questions and write answers
- [ ] Add a listing — fills all fields, saves, appears in Profile tab
- [ ] Edit listing photos — add up to 6, remove individual photos, persist after save
- [ ] Remove listing — clears has_listing flag
- [ ] Match modal shows pear icon and shared interests
- [ ] App bundles cleanly with npx expo start --clear