### PR TITLE
Fix web bundling error and double profile fetch on load

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -15,4 +15,13 @@ config.resolver.nodeModulesPaths = [
   path.resolve(workspaceRoot, 'node_modules'),
 ];
 
+// Stub out @rnmapbox/maps on web — it requires mapbox-gl CSS which isn't installed
+// The app is mobile-only; web is used only for Expo dev server
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (platform === 'web' && moduleName === 'mapbox-gl/dist/mapbox-gl.css') {
+    return { type: 'empty' };
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = config;

--- a/apps/mobile/screens/UserProfileScreen.tsx
+++ b/apps/mobile/screens/UserProfileScreen.tsx
@@ -231,11 +231,6 @@ export default function UserProfileScreen({ route }: Props) {
   }, []);
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data: { user: u } }) => {
-      setUser(u ? { id: u.id, email: u.email } : null);
-      if (u) { loadProfile(u.id); loadListing(u.id); }
-    });
-
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {


### PR DESCRIPTION
- Stub out mapbox-gl CSS import on web platform in metro.config.js so the dev server doesn't fail when @rnmapbox/maps tries to resolve it
- Remove redundant getUser() call in UserProfileScreen; onAuthStateChange fires INITIAL_SESSION on mount, so the duplicate loadProfile triggered a race that logged "Error fetching profile" twice on startup