### PR TITLE
Add profile view from Likes and Chats tabs

### DIFF
--- a/apps/mobile/navigation/ChatsStack.tsx
+++ b/apps/mobile/navigation/ChatsStack.tsx
@@ -1,10 +1,12 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import ChatsScreen from '../screens/ChatsScreen';
 import ChatScreen from '../screens/ChatScreen';
+import PublicUserProfileScreen from '../screens/PublicUserProfileScreen';
 
 export type ChatsStackParamList = {
   ChatsHome: undefined;
   Chat: { conversationId?: string; otherUserId?: string; title: string };
+  ProfileView: { userId: string; name: string };
 };
 
 const Stack = createNativeStackNavigator<ChatsStackParamList>();
@@ -27,6 +29,11 @@ export default function ChatsStack() {
         name="Chat"
         component={ChatScreen}
         options={{ headerBackTitle: 'Chats' }}
+      />
+      <Stack.Screen
+        name="ProfileView"
+        component={PublicUserProfileScreen}
+        options={{ headerShown: false }}
       />
     </Stack.Navigator>
   );

--- a/apps/mobile/navigation/LikesStack.tsx
+++ b/apps/mobile/navigation/LikesStack.tsx
@@ -1,0 +1,24 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LikesScreen from '../screens/LikesScreen';
+import PublicUserProfileScreen from '../screens/PublicUserProfileScreen';
+
+export type LikesStackParamList = {
+  LikesHome: undefined;
+  ProfileView: { userId: string; name: string };
+};
+
+const Stack = createNativeStackNavigator<LikesStackParamList>();
+
+export default function LikesStack() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: '#F4F7F9' },
+      }}
+    >
+      <Stack.Screen name="LikesHome" component={LikesScreen} />
+      <Stack.Screen name="ProfileView" component={PublicUserProfileScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/apps/mobile/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/navigation/MainTabNavigator.tsx
@@ -2,13 +2,13 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import type { NavigatorScreenParams } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import DiscoverScreen from '../screens/DiscoverScreen';
-import LikesScreen from '../screens/LikesScreen';
+import LikesStack, { type LikesStackParamList } from './LikesStack';
 import UserProfileScreen from '../screens/UserProfileScreen';
 import ChatsStack, { type ChatsStackParamList } from './ChatsStack';
 
 export type MainTabParamList = {
   Discover: undefined;
-  Likes: undefined;
+  Likes: NavigatorScreenParams<LikesStackParamList>;
   Chats: NavigatorScreenParams<ChatsStackParamList>;
   Profile: { onDevShowOnboarding?: () => void } | undefined;
 };
@@ -58,7 +58,7 @@ export default function MainTabNavigator({ onDevShowOnboarding }: Props) {
       })}
     >
       <Tab.Screen name="Discover" component={DiscoverScreen} />
-      <Tab.Screen name="Likes" component={LikesScreen} />
+      <Tab.Screen name="Likes" component={LikesStack} />
       <Tab.Screen name="Chats" component={ChatsStack} />
       <Tab.Screen
         name="Profile"

--- a/apps/mobile/screens/ChatsScreen.tsx
+++ b/apps/mobile/screens/ChatsScreen.tsx
@@ -90,34 +90,37 @@ export default function ChatsScreen({ navigation }: Props) {
 
   function renderMatchItem({ item }: { item: Match }) {
     return (
-      <TouchableOpacity
-        style={styles.gridCard}
-        activeOpacity={0.85}
-        onPress={() =>
-          navigation.navigate('Chat', { otherUserId: item.id, title: item.name })
-        }
-      >
-        {item.photoUrls.length > 0 ? (
-          <Image
-            source={{ uri: item.photoUrls[0] }}
-            style={styles.gridPhoto}
-            resizeMode="cover"
-          />
-        ) : (
-          <View style={[styles.gridPhoto, styles.gridPhotoPlaceholder]}>
-            <Text style={styles.gridPhotoInitial}>{item.name.slice(0, 1)}</Text>
-          </View>
-        )}
-        <View style={styles.gridInfo}>
+      <View style={styles.gridCard}>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          onPress={() => navigation.navigate('ProfileView', { userId: item.id, name: item.name })}
+        >
+          {item.photoUrls.length > 0 ? (
+            <Image
+              source={{ uri: item.photoUrls[0] }}
+              style={styles.gridPhoto}
+              resizeMode="cover"
+            />
+          ) : (
+            <View style={[styles.gridPhoto, styles.gridPhotoPlaceholder]}>
+              <Text style={styles.gridPhotoInitial}>{item.name.slice(0, 1)}</Text>
+            </View>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.gridInfo}
+          activeOpacity={0.7}
+          onPress={() => navigation.navigate('Chat', { otherUserId: item.id, title: item.name })}
+        >
           <Text style={styles.gridName} numberOfLines={1}>
             {item.name}{item.age ? `, ${item.age}` : ''}
           </Text>
           {!!item.location && (
             <Text style={styles.gridLocation} numberOfLines={1}>{item.location}</Text>
           )}
-          <Text style={styles.gridMatched}>Matched {formatMatchDate(item.matchedAt)}</Text>
-        </View>
-      </TouchableOpacity>
+          <Text style={styles.gridMatched}>Tap to message · {formatMatchDate(item.matchedAt)}</Text>
+        </TouchableOpacity>
+      </View>
     );
   }
 
@@ -133,19 +136,24 @@ export default function ChatsScreen({ navigation }: Props) {
           })
         }
       >
-        <View style={styles.convAvatar}>
-          {item.otherAvatarUrl ? (
-            <Image
-              source={{ uri: item.otherAvatarUrl }}
-              style={styles.convAvatarImg}
-              resizeMode="cover"
-            />
-          ) : (
-            <Text style={styles.convAvatarText}>
-              {item.otherDisplayName.slice(0, 1).toUpperCase()}
-            </Text>
-          )}
-        </View>
+        <TouchableOpacity
+          onPress={() => navigation.navigate('ProfileView', { userId: item.otherUserId, name: item.otherDisplayName })}
+          activeOpacity={0.8}
+        >
+          <View style={styles.convAvatar}>
+            {item.otherAvatarUrl ? (
+              <Image
+                source={{ uri: item.otherAvatarUrl }}
+                style={styles.convAvatarImg}
+                resizeMode="cover"
+              />
+            ) : (
+              <Text style={styles.convAvatarText}>
+                {item.otherDisplayName.slice(0, 1).toUpperCase()}
+              </Text>
+            )}
+          </View>
+        </TouchableOpacity>
         <View style={styles.convBody}>
           <View style={styles.convTop}>
             <Text style={styles.convName} numberOfLines={1}>{item.otherDisplayName}</Text>

--- a/apps/mobile/screens/LikesScreen.tsx
+++ b/apps/mobile/screens/LikesScreen.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { CompositeNavigationProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import {
   View,
@@ -26,8 +28,12 @@ import {
 } from '../lib/likes';
 import { recordSwipe } from '../lib/discover';
 import type { MainTabParamList } from '../navigation/MainTabNavigator';
+import type { LikesStackParamList } from '../navigation/LikesStack';
 
-type NavProp = BottomTabNavigationProp<MainTabParamList>;
+type NavProp = CompositeNavigationProp<
+  NativeStackNavigationProp<LikesStackParamList>,
+  BottomTabNavigationProp<MainTabParamList>
+>;
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const GRID_PADDING = 16;
@@ -35,7 +41,7 @@ const GRID_GAP = 12;
 const CARD_WIDTH = (SCREEN_WIDTH - GRID_PADDING * 2 - GRID_GAP) / 2;
 
 export default function LikesScreen() {
-  const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
+  const navigation = useNavigation<NavProp>();
   const [userId, setUserId] = useState<string | null>(null);
   const [likers, setLikers] = useState<Liker[]>([]);
   const [loading, setLoading] = useState(true);
@@ -147,7 +153,13 @@ export default function LikesScreen() {
     const photo = item.photoUrls[0];
 
     return (
-      <View style={styles.card}>
+      <TouchableOpacity
+        style={styles.card}
+        activeOpacity={isRevealed ? 0.85 : 1}
+        onPress={() => {
+          if (isRevealed) navigation.navigate('ProfileView', { userId: item.id, name: item.name });
+        }}
+      >
         {/* Photo — blurred unless revealed */}
         <View style={styles.photoWrap}>
           {photo ? (
@@ -205,7 +217,7 @@ export default function LikesScreen() {
             </TouchableOpacity>
           )}
         </View>
-      </View>
+      </TouchableOpacity>
     );
   }
 

--- a/apps/mobile/screens/PublicUserProfileScreen.tsx
+++ b/apps/mobile/screens/PublicUserProfileScreen.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { ChatsStackParamList } from '../navigation/ChatsStack';
+import type { LikesStackParamList } from '../navigation/LikesStack';
+import { supabase } from '../lib/supabase';
+import { getProfileImageUrls } from '../lib/storage';
+import { getPreferences } from '../lib/preferences';
+import { formatLocationLine, profilePhotoPathsFromRow } from '../lib/profileDisplay';
+import PublicProfileCard from '../components/PublicProfileCard';
+
+// Works for both ChatsStack and LikesStack since they share the same param shape
+type Props =
+  | NativeStackScreenProps<ChatsStackParamList, 'ProfileView'>
+  | NativeStackScreenProps<LikesStackParamList, 'ProfileView'>;
+
+export default function PublicUserProfileScreen({ route, navigation }: Props) {
+  const { userId } = route.params as { userId: string; name: string };
+
+  const [loading, setLoading] = useState(true);
+  const [imageUrls, setImageUrls] = useState<string[]>([]);
+  const [name, setName] = useState(route.params.name ?? '');
+  const [age, setAge] = useState<number | null>(null);
+  const [location, setLocation] = useState('');
+  const [bio, setBio] = useState<string | null>(null);
+  const [hobbies, setHobbies] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('name, age, bio, hobbies, profile_photo_url')
+        .eq('id', userId)
+        .single();
+
+      if (cancelled) return;
+
+      if (profile) {
+        setName(profile.name ?? name);
+        setAge(typeof profile.age === 'number' ? profile.age : null);
+        setBio(profile.bio ?? null);
+        setHobbies(Array.isArray(profile.hobbies) ? profile.hobbies : []);
+
+        const paths = profilePhotoPathsFromRow(profile.profile_photo_url);
+        if (paths.length > 0) {
+          const urls = await getProfileImageUrls(profile.profile_photo_url);
+          if (!cancelled) setImageUrls(urls ?? []);
+        }
+      }
+
+      const prefs = await getPreferences(userId);
+      if (!cancelled) setLocation(formatLocationLine(prefs));
+
+      setLoading(false);
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [userId]);
+
+  return (
+    <SafeAreaView style={styles.root} edges={['bottom']}>
+      <View style={styles.navBar}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.navTitle} numberOfLines={1}>{name}</Text>
+        <View style={styles.backBtn} />
+      </View>
+
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color="#0C5389" size="large" />
+        </View>
+      ) : (
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          <PublicProfileCard
+            imageUrls={imageUrls}
+            name={name}
+            age={age}
+            location={location}
+            bio={bio}
+            hobbies={hobbies}
+          />
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#F4F7F9',
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E8EEF2',
+    backgroundColor: '#FDFDFD',
+  },
+  backBtn: {
+    width: 60,
+  },
+  backText: {
+    fontSize: 17,
+    color: '#0C5389',
+    fontWeight: '600',
+  },
+  navTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 17,
+    fontWeight: '700',
+    color: '#0C5389',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  scroll: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+});


### PR DESCRIPTION
- Create PublicUserProfileScreen — fetches and displays another user's photos, bio, hobbies, and location using PublicProfileCard
- Create LikesStack so LikesScreen can push ProfileView as a screen
- Add ProfileView route to ChatsStack
- Likes: tapping a revealed card navigates to that user's profile
- Chats Matched: tapping the photo opens their profile; tapping the info row below still opens the chat
- Chats Messages: tapping the avatar opens their profile; tapping the row still opens the chat