### PR TITLE
Redesign SwipeCard: scrollable info, categorized interests, vertical …

### DIFF
--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   Image,
   FlatList,
+  ScrollView,
   StyleSheet,
   TouchableOpacity,
   Dimensions,
@@ -12,7 +13,7 @@ import {
   type ListRenderItemInfo,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { MapPin } from 'phosphor-react-native';
+import { MapPin, ArrowCounterClockwise, X, Star, Heart } from 'phosphor-react-native';
 import type { DiscoverProfile } from '../lib/discover';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -20,16 +21,25 @@ const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CARD_WIDTH = SCREEN_WIDTH - 32;
 export const CARD_HEIGHT = SCREEN_HEIGHT * 0.70;
 const TAB_HEIGHT = 48;
-const PHOTO_HEIGHT = Math.round(CARD_HEIGHT * 0.57);
+const PHOTO_HEIGHT = Math.round(CARD_HEIGHT * 0.55);
 
 type PhotoTab = 'profile' | 'place';
 
 interface Props {
   profile: DiscoverProfile;
-  onPress: () => void;
+  onPass?: () => void;
+  onLike?: () => void;
+  onTopPick?: () => void;
+  onUndo?: () => void;
+  canUndo?: boolean;
+  actionDisabled?: boolean;
 }
 
-export default function SwipeCard({ profile, onPress }: Props) {
+export default function SwipeCard({
+  profile,
+  onPass, onLike, onTopPick, onUndo,
+  canUndo = false, actionDisabled = false,
+}: Props) {
   const [photoTab, setPhotoTab] = useState<PhotoTab>('profile');
   const [photoIndex, setPhotoIndex] = useState(0);
   const listRef = useRef<FlatList<string>>(null);
@@ -66,12 +76,11 @@ export default function SwipeCard({ profile, onPress }: Props) {
   const firstName = profile.name.split(' ')[0];
 
   return (
-    <TouchableOpacity activeOpacity={0.97} onPress={onPress} style={styles.card}>
+    <View style={styles.card}>
 
       {/* ── Photo section ── */}
       <View style={[styles.photoSection, { height: PHOTO_HEIGHT }]}>
         {photoTab === 'place' && !hasListingPhotos ? (
-          /* No listing placeholder */
           <View style={styles.noListingWrap}>
             <Text style={styles.noListingIcon}>🏠</Text>
             <Text style={styles.noListingTitle}>
@@ -104,7 +113,6 @@ export default function SwipeCard({ profile, onPress }: Props) {
               scrollEventThrottle={16}
             />
 
-            {/* Progress bars */}
             {activePhotos.length > 1 && (
               <View style={styles.progressBars} pointerEvents="none">
                 {activePhotos.map((_, i) => (
@@ -115,7 +123,6 @@ export default function SwipeCard({ profile, onPress }: Props) {
               </View>
             )}
 
-            {/* Gradient scrim */}
             <LinearGradient
               colors={['transparent', 'rgba(0,0,0,0.15)', 'rgba(0,0,0,0.68)']}
               locations={[0.4, 0.68, 1]}
@@ -123,7 +130,6 @@ export default function SwipeCard({ profile, onPress }: Props) {
               pointerEvents="none"
             />
 
-            {/* Overlay — name/location on profile tab only */}
             {photoTab === 'profile' && (
               <View style={styles.overlay} pointerEvents="none">
                 <View style={styles.nameRow}>
@@ -136,6 +142,19 @@ export default function SwipeCard({ profile, onPress }: Props) {
                   <View style={styles.locationRow}>
                     <MapPin size={13} color="rgba(255,255,255,0.85)" weight="fill" />
                     <Text style={styles.overlayLocation}>{profile.location}</Text>
+                  </View>
+                )}
+                {(!!profile.roomType || profile.maxBudget != null) && (
+                  <View style={styles.budgetRow}>
+                    {!!profile.roomType && (
+                      <Text style={styles.overlayBudget}>{profile.roomType}</Text>
+                    )}
+                    {!!profile.roomType && profile.maxBudget != null && (
+                      <Text style={styles.overlayBudgetDot}>·</Text>
+                    )}
+                    {profile.maxBudget != null && (
+                      <Text style={styles.overlayBudget}>Up to ${profile.maxBudget.toLocaleString()}/mo</Text>
+                    )}
                   </View>
                 )}
               </View>
@@ -171,40 +190,100 @@ export default function SwipeCard({ profile, onPress }: Props) {
         </TouchableOpacity>
       </View>
 
-      {/* ── Info section ── */}
-      <View style={styles.infoSection}>
-        {/* Prompts — shown first, most personal content */}
+      {/* ── Info section — scrollable ── */}
+      <ScrollView
+        style={styles.infoScroll}
+        contentContainerStyle={styles.infoContent}
+        showsVerticalScrollIndicator={false}
+        scrollEventThrottle={16}
+      >
         {profile.prompts.length > 0 ? (
-          <View style={styles.promptCard}>
-            <View style={styles.promptAccent} />
-            <View style={styles.promptContent}>
-              <Text style={styles.promptQuestion} numberOfLines={2}>
-                {profile.prompts[0].question}
-              </Text>
-              <Text style={styles.promptAnswer} numberOfLines={3}>
-                {profile.prompts[0].answer}
-              </Text>
-            </View>
-          </View>
+          <>
+            {profile.prompts.map((p, i) => (
+              <View key={i} style={styles.promptCard}>
+                <View style={styles.promptAccent} />
+                <View style={styles.promptContent}>
+                  <Text style={styles.promptQuestion} numberOfLines={2}>
+                    {p.question}
+                  </Text>
+                  <Text style={styles.promptAnswer} numberOfLines={3}>
+                    {p.answer}
+                  </Text>
+                </View>
+              </View>
+            ))}
+          </>
         ) : !!profile.bio ? (
-          <Text style={styles.bio} numberOfLines={3}>{profile.bio}</Text>
+          <Text style={styles.bio}>{profile.bio}</Text>
         ) : null}
 
-        {profile.hobbies && profile.hobbies.length > 0 && (
+        {Object.keys(profile.interests).length > 0 ? (
+          Object.entries(profile.interests).map(([cat, chips]) =>
+            chips.length > 0 ? (
+              <View key={cat} style={styles.categoryBlock}>
+                <Text style={styles.categoryLabel}>{cat}</Text>
+                <View style={styles.chipsRow}>
+                  {chips.map((h, i) => (
+                    <View key={i} style={styles.chip}>
+                      <Text style={styles.chipText}>{h}</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ) : null
+          )
+        ) : profile.hobbies && profile.hobbies.length > 0 ? (
           <>
             <Text style={styles.interestsLabel}>Interests</Text>
             <View style={styles.chipsRow}>
-              {profile.hobbies.slice(0, 5).map((h, i) => (
+              {profile.hobbies.map((h, i) => (
                 <View key={i} style={styles.chip}>
                   <Text style={styles.chipText}>{h}</Text>
                 </View>
               ))}
             </View>
           </>
-        )}
-      </View>
+        ) : null}
+      </ScrollView>
 
-    </TouchableOpacity>
+      {/* ── Vertical action column (bottom-right, absolutely positioned) ── */}
+      {onPass && (
+        <View style={[styles.actionColumn, actionDisabled && styles.actionBarDisabled]}>
+          <TouchableOpacity
+            style={styles.actionCircle}
+            onPress={onLike}
+            disabled={actionDisabled}
+          >
+            <Heart size={22} color="#2D6A4F" weight="fill" />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.actionCircle}
+            onPress={onTopPick}
+            disabled={actionDisabled}
+          >
+            <Star size={20} color="#FF9500" weight="fill" />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.actionCircle}
+            onPress={onPass}
+            disabled={actionDisabled}
+          >
+            <X size={20} color="#D4183D" weight="bold" />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.actionCircle, (!canUndo || actionDisabled) && styles.actionBtnDimmed]}
+            onPress={onUndo}
+            disabled={!canUndo || actionDisabled}
+          >
+            <ArrowCounterClockwise size={18} color="#A0A0B0" weight="bold" />
+          </TouchableOpacity>
+        </View>
+      )}
+
+    </View>
   );
 }
 
@@ -295,6 +374,21 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: 'rgba(255,255,255,0.85)',
   },
+  budgetRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    marginTop: 3,
+  },
+  overlayBudget: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: 'rgba(255,255,255,0.78)',
+  },
+  overlayBudgetDot: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.5)',
+  },
 
   // ── No listing placeholder ──
   noListingWrap: {
@@ -351,14 +445,15 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
   },
 
-  // ── Info ──
-  infoSection: {
+  // ── Info (scrollable) ──
+  infoScroll: {
     flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  infoContent: {
     paddingHorizontal: 18,
     paddingTop: 12,
-    paddingBottom: 12,
-    backgroundColor: '#FFFFFF',
-    justifyContent: 'center',
+    paddingBottom: 16,
   },
   bio: {
     fontSize: 14,
@@ -373,6 +468,17 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 1,
     marginBottom: 7,
+  },
+  categoryBlock: {
+    marginBottom: 10,
+  },
+  categoryLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#A0A0B0',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginBottom: 5,
   },
   chipsRow: {
     flexDirection: 'row',
@@ -426,4 +532,24 @@ const styles = StyleSheet.create({
     color: '#1A2C24',
     lineHeight: 20,
   },
+
+  // ── Action column (bottom-right, absolutely positioned) ──
+  actionColumn: {
+    position: 'absolute',
+    right: 12,
+    bottom: 16,
+    alignItems: 'center',
+    gap: 8,
+    zIndex: 10,
+  },
+  actionBarDisabled: { opacity: 0.4 },
+  actionCircle: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: 'transparent',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actionBtnDimmed: { opacity: 0.3 },
 });

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -11,11 +11,14 @@ export type DiscoverProfile = {
   age: number | null;
   bio: string | null;
   hobbies: string[] | null;
+  interests: Record<string, string[]>;  // grouped by category e.g. { fitness: ['Gym', 'Yoga'] }
   prompts: PromptEntry[];
   photoUrls: string[];         // profile photos + listing photos combined
   profilePhotoCount: number;   // split point: photoUrls[0..n-1] are profile, rest are listing
   location: string;
   hasListing: boolean;
+  roomType: string | null;
+  maxBudget: number | null;
 };
 
 export async function fetchDiscoverProfiles(
@@ -100,9 +103,9 @@ export async function fetchDiscoverProfiles(
     const state = prefs?.state?.trim() ?? '';
     const location = city && state ? `${city}, ${state}` : city || state;
 
-    // Prefer flattened preferences.interests over legacy profiles.hobbies
-    const interestChips = Object.values(prefs?.interests ?? {}).flat() as string[];
-    const hobbies = interestChips.length > 0 ? interestChips : (row.hobbies ?? null);
+    const interests: Record<string, string[]> = prefs?.interests ?? {};
+    const interestChips = Object.values(interests).flat() as string[];
+    const hobbies = interestChips.length > 0 ? null : (row.hobbies ?? null);
 
     // Fetch listing photos if this user has a place listed
     let listingPhotoUrls: string[] = [];
@@ -131,11 +134,14 @@ export async function fetchDiscoverProfiles(
       age: row.age ?? null,
       bio: row.bio ?? null,
       hobbies,
+      interests,
       prompts,
       photoUrls: [...urls, ...listingPhotoUrls],
       profilePhotoCount: urls.length,
       hasListing: row.has_listing === true,
       location,
+      roomType: prefs?.room_type ?? null,
+      maxBudget: prefs?.max_budget ?? null,
     });
   }
 

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -5,7 +5,6 @@ import {
   Image,
   Modal,
   Platform,
-  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -16,7 +15,6 @@ import { BlurView } from 'expo-blur';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import { ArrowCounterClockwise, Heart, Star, X, DotsThreeVertical } from 'phosphor-react-native';
 import { supabase } from '../lib/supabase';
 import { fetchDiscoverProfiles, recordSwipe, type DiscoverProfile } from '../lib/discover';
 import { getProfileImageUrls } from '../lib/storage';
@@ -27,7 +25,7 @@ import type { MainTabParamList } from '../navigation/MainTabNavigator';
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 const C = {
-  bg:            '#1A3329',
+  bg:            '#C8E6C9',
   text:          '#1A2C24',
   white:         '#FFFFFF',
   gray:          '#717182',
@@ -40,8 +38,8 @@ const C = {
   top:           '#FF9500',
 };
 
-const GRAD = ['#1A3329','#2D4F42','#5A806B','#9CB8A8','#D8E8DF','#F5FAF7','#FFFFFF'] as const;
-const LOCS = [0, 0.06, 0.14, 0.28, 0.48, 0.72, 1] as const;
+const GRAD = ['#C8E6C9','#DCEDC8','#E8F5E9','#F1F8F2','#F8FBF8','#FFFFFF'] as const;
+const LOCS = [0, 0.18, 0.40, 0.62, 0.82, 1] as const;
 
 // How far the buttons float up over the card's bottom edge
 const BTN_OVERLAP = 52;
@@ -86,7 +84,6 @@ export default function DiscoverScreen() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [actionDisabled, setActionDisabled] = useState(false);
   const [matchData, setMatchData] = useState<MatchData | null>(null);
-  const [expandedProfile, setExpandedProfile] = useState<DiscoverProfile | null>(null);
   const [loading, setLoading] = useState(true);
 
   const translateX = useRef(new Animated.Value(0)).current;
@@ -187,7 +184,6 @@ export default function DiscoverScreen() {
 
   const currentProfile = profiles[currentIndex];
   const nextProfile = profiles[currentIndex + 1];
-  const remaining = profiles.length - currentIndex;
 
   if (loading) {
     return (
@@ -220,25 +216,19 @@ export default function DiscoverScreen() {
         {/* ── Header ── */}
         <View style={styles.header}>
           <Text style={styles.pearLogo}>🍐</Text>
-          <View style={styles.headerRight}>
-            <Text style={styles.nearbyPill}>{remaining} nearby</Text>
-            <TouchableOpacity style={styles.headerIconBtn}>
-              <DotsThreeVertical size={20} color={C.white} weight="bold" />
-            </TouchableOpacity>
-          </View>
         </View>
 
-        {/* ── Card stack + floating buttons ── */}
+        {/* ── Card stack ── */}
         <View style={styles.cardArea}>
 
-          {/* Back card — slightly behind and rotated */}
+          {/* Back card */}
           {nextProfile && (
             <View style={styles.backCardWrap} pointerEvents="none">
-              <SwipeCard profile={nextProfile} onPress={() => {}} />
+              <SwipeCard profile={nextProfile} />
             </View>
           )}
 
-          {/* Front card */}
+          {/* Front card — actions integrated inside */}
           <Animated.View
             style={[
               styles.frontCardWrap,
@@ -247,128 +237,17 @@ export default function DiscoverScreen() {
           >
             <SwipeCard
               profile={currentProfile}
-              onPress={() => setExpandedProfile(currentProfile)}
+              onPass={() => handleAction('pass')}
+              onLike={() => handleAction('like')}
+              onTopPick={() => handleAction('top_pick')}
+              onUndo={handleUndo}
+              canUndo={currentIndex > 0}
+              actionDisabled={actionDisabled}
             />
           </Animated.View>
-
-          {/* ── Floating action buttons — sit on bottom of card ── */}
-          <View style={styles.floatingActions} pointerEvents="box-none">
-            {/* Undo — small, top-left of group */}
-            <TouchableOpacity
-              style={[styles.btn, styles.btnUndo, (actionDisabled || currentIndex === 0) && styles.btnDisabled]}
-              onPress={handleUndo}
-              disabled={actionDisabled || currentIndex === 0}
-            >
-              <ArrowCounterClockwise size={20} color={C.grayDim} weight="bold" />
-            </TouchableOpacity>
-
-            {/* Pass */}
-            <TouchableOpacity
-              style={[styles.btn, styles.btnPass, actionDisabled && styles.btnDisabled]}
-              onPress={() => handleAction('pass')}
-              disabled={actionDisabled}
-            >
-              <X size={28} color={C.pass} weight="bold" />
-            </TouchableOpacity>
-
-            {/* Top pick */}
-            <TouchableOpacity
-              style={[styles.btn, styles.btnTop, actionDisabled && styles.btnDisabled]}
-              onPress={() => handleAction('top_pick')}
-              disabled={actionDisabled}
-            >
-              <Star size={26} color={C.top} weight="fill" />
-            </TouchableOpacity>
-
-            {/* Like */}
-            <TouchableOpacity
-              style={[styles.btn, styles.btnLike, actionDisabled && styles.btnDisabled]}
-              onPress={() => handleAction('like')}
-              disabled={actionDisabled}
-            >
-              <Heart size={30} color={C.like} weight="fill" />
-            </TouchableOpacity>
-          </View>
         </View>
 
       </SafeAreaView>
-
-      {/* ── Full profile modal ── */}
-      <Modal visible={!!expandedProfile} animationType="slide" statusBarTranslucent>
-        {expandedProfile && (
-          <View style={styles.profileModal}>
-            <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
-              <ScrollView
-                horizontal pagingEnabled showsHorizontalScrollIndicator={false}
-                style={{ height: SCREEN_HEIGHT * 0.55 }}
-              >
-                {expandedProfile.photoUrls.map((url, i) => (
-                  <Image key={i} source={{ uri: url }}
-                    style={{ width: SCREEN_WIDTH, height: SCREEN_HEIGHT * 0.55 }}
-                    resizeMode="cover"
-                  />
-                ))}
-              </ScrollView>
-              <View style={styles.profileInfo}>
-                <Text style={styles.profileName}>
-                  {expandedProfile.name}{expandedProfile.age ? `, ${expandedProfile.age}` : ''}
-                </Text>
-                {expandedProfile.location ? (
-                  <Text style={styles.profileLocation}>📍 {expandedProfile.location}</Text>
-                ) : null}
-                {expandedProfile.bio ? (
-                  <Text style={styles.profileBio}>{expandedProfile.bio}</Text>
-                ) : null}
-
-                {expandedProfile.prompts && expandedProfile.prompts.length > 0 && (
-                  <>
-                    <Text style={styles.profileSectionLabel}>Prompts</Text>
-                    {expandedProfile.prompts.map((p, i) => (
-                      <View key={i} style={styles.promptCard}>
-                        <View style={styles.promptAccent} />
-                        <View style={styles.promptContent}>
-                          <Text style={styles.promptQuestion}>{p.question}</Text>
-                          <Text style={styles.promptAnswer}>{p.answer}</Text>
-                        </View>
-                      </View>
-                    ))}
-                  </>
-                )}
-
-                {expandedProfile.hobbies && expandedProfile.hobbies.length > 0 && (
-                  <>
-                    <Text style={styles.profileSectionLabel}>Interests</Text>
-                    <View style={styles.profileChips}>
-                      {expandedProfile.hobbies.map((h, i) => (
-                        <View key={i} style={styles.profileChip}>
-                          <Text style={styles.profileChipText}>{h}</Text>
-                        </View>
-                      ))}
-                    </View>
-                  </>
-                )}
-              </View>
-            </ScrollView>
-            <View style={styles.modalActions}>
-              <TouchableOpacity style={[styles.btn, styles.btnPass]}
-                onPress={() => { setExpandedProfile(null); handleAction('pass'); }}>
-                <X size={28} color={C.pass} weight="bold" />
-              </TouchableOpacity>
-              <TouchableOpacity style={[styles.btn, styles.btnTop]}
-                onPress={() => { setExpandedProfile(null); handleAction('top_pick'); }}>
-                <Star size={26} color={C.top} weight="fill" />
-              </TouchableOpacity>
-              <TouchableOpacity style={[styles.btn, styles.btnLike]}
-                onPress={() => { setExpandedProfile(null); handleAction('like'); }}>
-                <Heart size={30} color={C.like} weight="fill" />
-              </TouchableOpacity>
-            </View>
-            <TouchableOpacity style={styles.closeBtn} onPress={() => setExpandedProfile(null)}>
-              <X size={16} color={C.white} weight="bold" />
-            </TouchableOpacity>
-          </View>
-        )}
-      </Modal>
 
       {/* ── Match modal ── */}
       <Modal visible={!!matchData} transparent animationType="fade">
@@ -441,30 +320,11 @@ const styles = StyleSheet.create({
 
   // ── Header ──
   header: {
-    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingTop: 6,
-    paddingBottom: 10,
+    paddingTop: 4,
+    paddingBottom: 4,
   },
-  pearLogo: { fontSize: 32 },
-  headerRight: { flexDirection: 'row', alignItems: 'center', gap: 10 },
-  nearbyPill: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: 'rgba(255,255,255,0.7)',
-    backgroundColor: 'rgba(255,255,255,0.15)',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 20,
-    overflow: 'hidden',
-  },
-  headerIconBtn: {
-    width: 36, height: 36, borderRadius: 18,
-    backgroundColor: 'rgba(255,255,255,0.15)',
-    alignItems: 'center', justifyContent: 'center',
-  },
+  pearLogo: { fontSize: 28 },
 
   // ── Card area ──
   cardArea: {
@@ -472,7 +332,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 16,
-    paddingBottom: 16,
+    paddingBottom: 8,
   },
   backCardWrap: {
     position: 'absolute',
@@ -517,13 +377,26 @@ const styles = StyleSheet.create({
 
   // ── Full profile modal ──
   profileModal: { flex: 1, backgroundColor: '#FFFFFF' },
+  heroWrap: { width: SCREEN_WIDTH, height: SCREEN_HEIGHT * 0.62, position: 'relative' },
+  heroImage: { width: '100%', height: '100%' },
+  heroOverlay: {
+    position: 'absolute', left: 20, right: 20, bottom: 24,
+  },
+  heroName: {
+    fontSize: 32, fontWeight: '800', color: '#FFFFFF', letterSpacing: -0.5,
+    textShadowColor: 'rgba(0,0,0,0.4)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 6,
+  },
+  heroLocation: { fontSize: 15, color: 'rgba(255,255,255,0.88)', fontWeight: '500', marginTop: 4 },
+  heroBudget: { fontSize: 13, color: 'rgba(255,255,255,0.72)', fontWeight: '500', marginTop: 3 },
+  profileInfoBlock: { paddingHorizontal: 20, paddingVertical: 16 },
+  stackedPhoto: { width: SCREEN_WIDTH, height: SCREEN_HEIGHT * 0.55 },
   profileInfo: { padding: 24, paddingBottom: 16 },
   profileName: { fontSize: 28, fontWeight: '800', color: C.text },
   profileLocation: { fontSize: 15, color: C.gray, fontWeight: '500', marginTop: 4 },
-  profileBio: { fontSize: 15, color: C.gray, lineHeight: 22, marginTop: 16 },
+  profileBio: { fontSize: 15, color: C.gray, lineHeight: 22 },
   profileSectionLabel: {
     fontSize: 11, fontWeight: '700', color: C.grayDim,
-    marginTop: 20, marginBottom: 8, textTransform: 'uppercase', letterSpacing: 1,
+    marginBottom: 12, textTransform: 'uppercase', letterSpacing: 1,
   },
   profileChips: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
   profileChip: {
@@ -531,6 +404,28 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14, paddingVertical: 7, borderRadius: 50,
   },
   profileChipText: { fontSize: 13, fontWeight: '600', color: '#2D6A4F' },
+  interestCategory: { marginBottom: 10 },
+  placePhotoLabel: {
+    position: 'absolute',
+    top: 18,
+    left: 20,
+  },
+  placePhotoLabelText: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    textShadowColor: 'rgba(0,0,0,0.4)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 4,
+  },
+  interestCategoryLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#A0A0B0',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginBottom: 6,
+  },
   promptCard: {
     flexDirection: 'row',
     backgroundColor: 'rgba(45,106,79,0.05)',


### PR DESCRIPTION
…actions, and simplified Discover header

- SwipeCard: info section is now a ScrollView so all prompts/interests are accessible
- Show all prompts stacked (not just first)
- Interests rendered by category with headers instead of a flat chip pile
- Action buttons moved to vertical column (bottom-right, transparent)
- Photo section is a plain View so FlatList swiping is unobstructed
- Add roomType and maxBudget to DiscoverProfile, shown in photo overlay
- Remove full-profile tap-to-expand modal (card is self-contained)
- Discover header simplified to pear emoji only, removed misleading nearby pill
- Pastel green gradient background