### PR TITLE
Roo 30 likes design

### DIFF
--- a/apps/mobile/components/PublicProfileCard.tsx
+++ b/apps/mobile/components/PublicProfileCard.tsx
@@ -173,9 +173,9 @@ export default function PublicProfileCard({
             index,
           })}
         />
-        {!profilePhotos ? (
+        {immersive ? (
           <View
-            style={[styles.bottomScrim, immersive && styles.bottomScrimImmersive]}
+            style={[styles.bottomScrim, styles.bottomScrimImmersive]}
             pointerEvents="none"
           />
         ) : null}
@@ -185,15 +185,29 @@ export default function PublicProfileCard({
             style={[styles.dots, immersive && styles.dotsImmersive]}
             pointerEvents="none"
           >
-            {imageUrls.map((_, i) => (
-              <View
-                key={i}
-                style={[
-                  styles.dot,
-                  i === activeIndex ? styles.dotActive : styles.dotInactive,
-                ]}
-              />
-            ))}
+            {immersive ? (
+              imageUrls.map((_, i) => (
+                <View
+                  key={i}
+                  style={[
+                    styles.dot,
+                    i === activeIndex ? styles.dotActive : styles.dotInactive,
+                  ]}
+                />
+              ))
+            ) : (
+              <View style={styles.dotsPill}>
+                {imageUrls.map((_, i) => (
+                  <View
+                    key={i}
+                    style={[
+                      styles.dot,
+                      i === activeIndex ? styles.dotActive : styles.dotInactive,
+                    ]}
+                  />
+                ))}
+              </View>
+            )}
           </View>
         ) : null}
       </View>
@@ -314,6 +328,15 @@ const styles = StyleSheet.create({
   dotsImmersive: {
     bottom: 108,
     zIndex: 3,
+  },
+  /** Compact backdrop for dots only (default / profilePhotos) — avoids a full-width dim bar on the photo. */
+  dotsPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.42)',
+    borderRadius: 16,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
   },
   dot: {
     marginHorizontal: 3,

--- a/apps/mobile/lib/likes.ts
+++ b/apps/mobile/lib/likes.ts
@@ -8,6 +8,8 @@ export type Liker = {
   location: string;
   photoUrls: string[];
   likedAt: string;
+  /** True when their swipe toward you was a top pick (not a standard like). */
+  usedTopPick: boolean;
 };
 
 /**
@@ -17,7 +19,7 @@ export async function fetchLikers(userId: string): Promise<Liker[]> {
   // Who liked me
   const { data: likeRows } = await supabase
     .from('swipes')
-    .select('swiper_id, created_at')
+    .select('swiper_id, created_at, direction')
     .eq('swiped_id', userId)
     .in('direction', ['like', 'top_pick']);
 
@@ -35,6 +37,17 @@ export async function fetchLikers(userId: string): Promise<Liker[]> {
   if (pending.length === 0) return [];
 
   const likerIds = pending.map((r: any) => r.swiper_id);
+
+  /** If someone has multiple swipe rows, prefer top_pick; else most recent. */
+  function swipeRowForSwiper(swiperId: string) {
+    const forUser = pending.filter((r: any) => r.swiper_id === swiperId);
+    if (forUser.length === 0) return undefined;
+    const top = forUser.find((r: any) => r.direction === 'top_pick');
+    if (top) return top;
+    return [...forUser].sort((a: any, b: any) =>
+      String(b.created_at).localeCompare(String(a.created_at))
+    )[0];
+  }
 
   const { data: profiles } = await supabase
     .from('profiles')
@@ -57,7 +70,7 @@ export async function fetchLikers(userId: string): Promise<Liker[]> {
     const state = prefs?.state?.trim() ?? '';
     const location = city && state ? `${city}, ${state}` : city || state;
 
-    const row = pending.find((r: any) => r.swiper_id === profile.id);
+    const row = swipeRowForSwiper(profile.id);
 
     result.push({
       id: profile.id,
@@ -66,6 +79,7 @@ export async function fetchLikers(userId: string): Promise<Liker[]> {
       location,
       photoUrls: urls,
       likedAt: row?.created_at ?? '',
+      usedTopPick: row?.direction === 'top_pick',
     });
   }
 

--- a/apps/mobile/lib/matches.ts
+++ b/apps/mobile/lib/matches.ts
@@ -28,7 +28,7 @@ export async function fetchMatches(userId: string): Promise<Match[]> {
     .from('swipes')
     .select('swiper_id, created_at')
     .eq('swiped_id', userId)
-    .eq('direction', 'like')
+    .in('direction', ['like', 'top_pick'])
     .in('swiper_id', matchedUserIds);
 
   // Fetch their profiles

--- a/apps/mobile/navigation/ChatsStack.tsx
+++ b/apps/mobile/navigation/ChatsStack.tsx
@@ -45,7 +45,7 @@ export default function ChatsStack() {
       <Stack.Screen
         name="ProfileView"
         component={PublicUserProfileScreen}
-        options={{ headerShown: false }}
+        options={{ headerShown: false, contentStyle: { backgroundColor: '#FFFFFF' } }}
       />
     </Stack.Navigator>
   );

--- a/apps/mobile/navigation/LikesStack.tsx
+++ b/apps/mobile/navigation/LikesStack.tsx
@@ -1,6 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LikesScreen from '../screens/LikesScreen';
 import PublicUserProfileScreen from '../screens/PublicUserProfileScreen';
+import { CHATS_SCREEN_BG } from '../theme/chatsAmbient';
 
 export type LikesStackParamList = {
   LikesHome: undefined;
@@ -19,7 +20,7 @@ export default function LikesStack() {
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: '#F4F7F9' },
+        contentStyle: { backgroundColor: CHATS_SCREEN_BG },
       }}
     >
       <Stack.Screen name="LikesHome" component={LikesScreen} />

--- a/apps/mobile/navigation/LikesStack.tsx
+++ b/apps/mobile/navigation/LikesStack.tsx
@@ -24,7 +24,11 @@ export default function LikesStack() {
       }}
     >
       <Stack.Screen name="LikesHome" component={LikesScreen} />
-      <Stack.Screen name="ProfileView" component={PublicUserProfileScreen} />
+      <Stack.Screen
+        name="ProfileView"
+        component={PublicUserProfileScreen}
+        options={{ contentStyle: { backgroundColor: '#FFFFFF' } }}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/mobile/screens/LikesScreen.tsx
+++ b/apps/mobile/screens/LikesScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { CompositeNavigationProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -48,6 +48,9 @@ type NavProp = CompositeNavigationProp<
 >;
 
 type SortBy = 'recent' | 'name';
+
+/** Skip silent refetch on tab refocus if data was loaded recently (pull-to-refresh always bypasses). */
+const FOCUS_STALE_MS = 90_000;
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const GRID_PADDING = 16;
@@ -118,17 +121,53 @@ export default function LikesScreen() {
   const [matchName, setMatchName] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortBy>('recent');
 
-  const load = useCallback(async (isRefresh = false) => {
+  /** Same pattern as Chats: no full-screen spinner on every tab focus; optional stale skip avoids redundant fetches. */
+  const initialLoadDoneRef = useRef(false);
+  const lastUserIdRef = useRef<string | null>(null);
+  const lastFetchedAtRef = useRef(0);
+
+  const load = useCallback(async (isRefresh = false, skipIfFresh = false) => {
     if (isRefresh) setRefreshing(true);
-    else setLoading(true);
 
     const { data: sessionData } = await supabase.auth.getSession();
     const uid = sessionData.session?.user.id;
     if (!uid) {
+      setUserId(null);
+      setLikers([]);
+      setRevealedIds(new Set());
+      setLikedBackIds(new Set());
       setLoading(false);
+      setRefreshing(false);
+      initialLoadDoneRef.current = false;
+      lastUserIdRef.current = null;
+      lastFetchedAtRef.current = 0;
+      return;
+    }
+
+    if (lastUserIdRef.current !== uid) {
+      if (lastUserIdRef.current !== null) {
+        setLikers([]);
+        setRevealedIds(new Set());
+        setLikedBackIds(new Set());
+      }
+      initialLoadDoneRef.current = false;
+      lastUserIdRef.current = uid;
+      lastFetchedAtRef.current = 0;
+    }
+
+    if (
+      skipIfFresh &&
+      initialLoadDoneRef.current &&
+      !isRefresh &&
+      Date.now() - lastFetchedAtRef.current < FOCUS_STALE_MS
+    ) {
       setRefreshing(false);
       return;
     }
+
+    const firstLoadForUser = !initialLoadDoneRef.current;
+    if (!isRefresh && firstLoadForUser) setLoading(true);
+
     setUserId(uid);
 
     const { data: profile } = await supabase
@@ -151,13 +190,15 @@ export default function LikesScreen() {
       [...persistedRevealed].filter((likerId) => pendingIds.has(likerId))
     );
     setRevealedIds(filteredRevealed);
+    initialLoadDoneRef.current = true;
+    lastFetchedAtRef.current = Date.now();
     setLoading(false);
     setRefreshing(false);
   }, []);
 
   useFocusEffect(
     useCallback(() => {
-      load();
+      void load(false, true);
     }, [load])
   );
 

--- a/apps/mobile/screens/LikesScreen.tsx
+++ b/apps/mobile/screens/LikesScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { CompositeNavigationProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -7,7 +7,6 @@ import {
   View,
   Text,
   FlatList,
-  Image,
   TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
@@ -16,6 +15,9 @@ import {
   Alert,
   Modal,
 } from 'react-native';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { supabase } from '../lib/supabase';
 import {
@@ -30,16 +32,77 @@ import { recordSwipe } from '../lib/discover';
 import { usePurchases } from '../context/PurchasesContext';
 import type { MainTabParamList } from '../navigation/MainTabNavigator';
 import type { LikesStackParamList } from '../navigation/LikesStack';
+import {
+  CHATS_SCREEN_BG,
+  CHATS_CARD,
+  CHATS_GREEN,
+  CHATS_GREEN_BORDER,
+  CHATS_GREEN_BORDER_STRONG,
+  CHATS_GREEN_DARK,
+  CHATS_GREEN_SOFT_BG,
+} from '../theme/chatsAmbient';
 
 type NavProp = CompositeNavigationProp<
   NativeStackNavigationProp<LikesStackParamList>,
   BottomTabNavigationProp<MainTabParamList>
 >;
 
+type SortBy = 'recent' | 'name';
+
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const GRID_PADDING = 16;
 const GRID_GAP = 12;
 const CARD_WIDTH = (SCREEN_WIDTH - GRID_PADDING * 2 - GRID_GAP) / 2;
+
+const C = {
+  text: '#1A2C24',
+  gray: '#717182',
+  grayDim: '#A0A0B0',
+  white: '#FFFFFF',
+  surface: CHATS_CARD,
+  surfaceBorder: CHATS_GREEN_BORDER,
+  accent: CHATS_GREEN,
+  accentSoft: CHATS_GREEN_SOFT_BG,
+};
+
+function Background({ children }: { children: React.ReactNode }) {
+  return <View style={{ flex: 1, backgroundColor: CHATS_SCREEN_BG }}>{children}</View>;
+}
+
+/** Likes-only ambient layers — moss tones, asymmetric glow (Chats stays flat). */
+function LikesAmbientBackdrop() {
+  return (
+    <View style={styles.ambientRoot} pointerEvents="none">
+      <View style={styles.ambientOrbTopRight} />
+      <View style={styles.ambientOrbBottomLeft} />
+      <LinearGradient
+        colors={[
+          'rgba(250, 252, 251, 0)',
+          'rgba(45, 106, 79, 0.035)',
+          'rgba(250, 252, 251, 0)',
+        ]}
+        locations={[0, 0.48, 1]}
+        start={{ x: 0.15, y: 0 }}
+        end={{ x: 0.92, y: 1 }}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <LinearGradient
+        colors={['rgba(45, 106, 79, 0.11)', 'rgba(250, 252, 251, 0)']}
+        locations={[0, 1]}
+        start={{ x: 1, y: 0 }}
+        end={{ x: 0.25, y: 0.6 }}
+        style={styles.ambientCornerGlow}
+      />
+      <View style={styles.heroGlow}>
+        <LinearGradient
+          colors={['rgba(45, 106, 79, 0.14)', 'rgba(250, 252, 251, 0)']}
+          locations={[0, 1]}
+          style={styles.heroGradientFill}
+        />
+      </View>
+    </View>
+  );
+}
 
 export default function LikesScreen() {
   const navigation = useNavigation<NavProp>();
@@ -50,10 +113,10 @@ export default function LikesScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [revealedIds, setRevealedIds] = useState<Set<string>>(new Set());
   const [likedBackIds, setLikedBackIds] = useState<Set<string>>(new Set());
-  /** True when today's free daily reveal has been consumed */
   const [dailyRevealSpentToday, setDailyRevealSpentToday] = useState(false);
   const [bonusRevealBalance, setBonusRevealBalance] = useState(0);
   const [matchName, setMatchName] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<SortBy>('recent');
 
   const load = useCallback(async (isRefresh = false) => {
     if (isRefresh) setRefreshing(true);
@@ -98,6 +161,14 @@ export default function LikesScreen() {
     }, [load])
   );
 
+  const sortedLikers = useMemo(() => {
+    const copy = [...likers];
+    if (sortBy === 'name') return copy.sort((a, b) => a.name.localeCompare(b.name));
+    return copy.sort((a, b) => b.likedAt.localeCompare(a.likedAt));
+  }, [likers, sortBy]);
+
+  const canRevealMore = !dailyRevealSpentToday || bonusRevealBalance > 0;
+
   async function handleLikeBack(liker: Liker) {
     if (!userId || likedBackIds.has(liker.id)) return;
     setLikedBackIds((prev) => new Set([...prev, liker.id]));
@@ -106,8 +177,6 @@ export default function LikesScreen() {
       setMatchName(liker.name);
     }
   }
-
-  const canRevealMore = !dailyRevealSpentToday || bonusRevealBalance > 0;
 
   async function handleReveal(liker: Liker) {
     if (revealedIds.has(liker.id)) return;
@@ -156,71 +225,120 @@ export default function LikesScreen() {
     }
   }
 
+  const revealSummary = isRoomPearPlus
+    ? {
+        icon: 'checkmark-circle' as const,
+        title: 'RoomPear+',
+        body: 'All likers are visible — unlimited reveals.',
+        tone: 'plus' as const,
+      }
+    : !dailyRevealSpentToday
+      ? {
+          icon: 'sparkles' as const,
+          title: 'Daily reveal',
+          body: 'You have 1 free reveal today. Tap a card to unlock their photo.',
+          tone: 'ready' as const,
+        }
+      : bonusRevealBalance > 0
+        ? {
+            icon: 'gift-outline' as const,
+            title: 'Bonus reveals',
+            body: `${bonusRevealBalance} referral bonus reveal${bonusRevealBalance === 1 ? '' : 's'} available.`,
+            tone: 'ready' as const,
+          }
+        : {
+            icon: 'moon' as const,
+            title: 'Come back tomorrow',
+            body: 'No reveals left today — invite friends from Profile for bonus reveals.',
+            tone: 'used' as const,
+          };
+
   function renderItem({ item }: { item: Liker }) {
     const isRevealed = revealedIds.has(item.id);
     const photoClear = isRoomPearPlus || isRevealed;
     const photo = item.photoUrls[0];
 
     return (
-      <TouchableOpacity
-        style={styles.card}
-        activeOpacity={photoClear ? 0.85 : 1}
-        onPress={() => {
-          if (photoClear) {
-            navigation.navigate('ProfileView', {
-              userId: item.id,
-              name: item.name,
-              profileSource: 'likes',
-            });
-          }
-        }}
-      >
-        {/* Photo — blurred for free users until revealed; RoomPear+ sees all */}
-        <View style={styles.photoWrap}>
-          {photo ? (
-            <Image
-              source={{ uri: photo }}
-              style={styles.photo}
-              resizeMode="cover"
-              blurRadius={photoClear ? 0 : 18}
-            />
-          ) : (
-            <View style={[styles.photo, styles.photoPlaceholder]}>
-              <Text style={styles.photoInitial}>
-                {photoClear ? item.name.slice(0, 1) : '?'}
-              </Text>
-            </View>
-          )}
+      <View style={styles.gridCard}>
+        <TouchableOpacity
+          activeOpacity={photoClear ? 0.85 : 1}
+          onPress={() => {
+            if (photoClear) {
+              navigation.navigate('ProfileView', {
+                userId: item.id,
+                name: item.name,
+                profileSource: 'likes',
+              });
+            }
+          }}
+        >
+          <View style={styles.photoWrap}>
+            {photo ? (
+              <Image
+                source={{ uri: photo, cacheKey: photo }}
+                style={styles.gridPhoto}
+                contentFit="cover"
+                cachePolicy="memory-disk"
+                recyclingKey={photo}
+                transition={0}
+                blurRadius={photoClear ? 0 : 70}
+              />
+            ) : (
+              <View style={[styles.gridPhoto, styles.gridPhotoPlaceholder]}>
+                <Text style={styles.gridPhotoInitial}>
+                  {photoClear ? item.name.slice(0, 1) : '?'}
+                </Text>
+              </View>
+            )}
 
-          {!photoClear && (
-            <View style={styles.lockOverlay} pointerEvents="none">
-              <Text style={styles.lockIcon}>🔒</Text>
-            </View>
-          )}
-        </View>
+            {!photoClear && (
+              <View style={styles.lockOverlay} pointerEvents="none">
+                <View style={styles.lockBubble}>
+                  <Ionicons name="lock-closed" size={22} color={CHATS_GREEN} />
+                </View>
+              </View>
+            )}
 
-        <View style={styles.info}>
-          <Text style={styles.name} numberOfLines={1}>
-            {item.name}{item.age ? `, ${item.age}` : ''}
+            {item.usedTopPick && (
+              <View style={styles.topPickBadge} pointerEvents="none">
+                <Ionicons name="star" size={11} color={CHATS_GREEN} />
+                <Text style={styles.topPickBadgeText}>Top pick</Text>
+              </View>
+            )}
+          </View>
+        </TouchableOpacity>
+
+        <View style={styles.gridInfo}>
+          <Text style={styles.gridName} numberOfLines={1}>
+            {item.name}
+            {item.age ? `, ${item.age}` : ''}
           </Text>
           {!!item.location && (
-            <Text style={styles.location} numberOfLines={1}>{item.location}</Text>
+            <Text style={styles.gridLocation} numberOfLines={1}>
+              {item.location}
+            </Text>
           )}
 
           {photoClear ? (
             <TouchableOpacity
-              style={[styles.revealBtn, likedBackIds.has(item.id) && styles.revealBtnDim]}
+              style={[styles.actionBtn, likedBackIds.has(item.id) && styles.actionBtnMuted]}
               onPress={() => handleLikeBack(item)}
               disabled={likedBackIds.has(item.id)}
               activeOpacity={0.8}
             >
-              <Text style={styles.revealBtnText}>
-                {likedBackIds.has(item.id) ? '✓ Liked back' : '💚 Like Back'}
+              <Ionicons
+                name={likedBackIds.has(item.id) ? 'checkmark-circle' : 'heart'}
+                size={16}
+                color={C.white}
+                style={{ marginRight: 6 }}
+              />
+              <Text style={styles.actionBtnText}>
+                {likedBackIds.has(item.id) ? 'Liked back' : 'Like back'}
               </Text>
             </TouchableOpacity>
           ) : (
             <TouchableOpacity
-              style={[styles.revealBtn, !canRevealMore && styles.revealBtnDim]}
+              style={[styles.actionBtn, !canRevealMore && styles.actionBtnMuted]}
               onPress={() => {
                 if (!canRevealMore) {
                   void presentPaywall();
@@ -230,164 +348,356 @@ export default function LikesScreen() {
               }}
               activeOpacity={0.8}
             >
-              <Text style={styles.revealBtnText}>
-                {!canRevealMore ? '🔒 RoomPear+' : '✨ Reveal'}
+              <Ionicons
+                name={!canRevealMore ? 'star' : 'sparkles'}
+                size={16}
+                color={C.white}
+                style={{ marginRight: 6 }}
+              />
+              <Text style={styles.actionBtnText}>
+                {!canRevealMore ? 'RoomPear+' : 'Reveal'}
               </Text>
             </TouchableOpacity>
           )}
         </View>
-      </TouchableOpacity>
+      </View>
     );
   }
 
   return (
-    <SafeAreaView style={styles.root} edges={['top']}>
-      {/* Header */}
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Likes</Text>
+    <Background>
+      <LikesAmbientBackdrop />
+
+      <SafeAreaView style={styles.safe} edges={['top']}>
+        <View style={styles.header}>
+          <Text style={styles.heroTitle}>Likes</Text>
+          <Text style={styles.heroTagline}>People who chose you — reveal photos on your terms</Text>
+        </View>
+
         {!loading && likers.length > 0 && (
-          <Text style={styles.headerCount}>
-            {likers.length} {likers.length === 1 ? 'person' : 'people'} liked you
-          </Text>
-        )}
-      </View>
-
-      {/* Reveal status banner */}
-      {!loading && userId && likers.length > 0 && (
-        <View
-          style={[
-            styles.banner,
-            isRoomPearPlus && styles.bannerPremium,
-            !canRevealMore && !isRoomPearPlus && styles.bannerUsed,
-          ]}
-        >
-          <Text style={[styles.bannerText, isRoomPearPlus && styles.bannerTextPremium]}>
-            {isRoomPearPlus
-              ? 'RoomPear+ · All likers visible — unlimited reveals'
-              : !dailyRevealSpentToday
-                ? '✨ 1 free daily reveal available'
-                : bonusRevealBalance > 0
-                  ? `✨ ${bonusRevealBalance} bonus reveal${bonusRevealBalance === 1 ? '' : 's'} (referrals)`
-                  : '🔒 No reveals left — come back tomorrow or invite friends (Profile)'}
-          </Text>
-        </View>
-      )}
-
-      {loading ? (
-        <View style={styles.centered}>
-          <ActivityIndicator color="#0C5389" />
-        </View>
-      ) : (
-        <FlatList
-          data={likers}
-          keyExtractor={(item) => item.id}
-          numColumns={2}
-          columnWrapperStyle={styles.gridRow}
-          contentContainerStyle={likers.length === 0 ? styles.emptyList : styles.gridContent}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => load(true)}
-              tintColor="#0C5389"
-            />
-          }
-          ListEmptyComponent={
-            <View style={styles.emptyWrap}>
-              <Text style={styles.emptyEmoji}>💛</Text>
-              <Text style={styles.emptyTitle}>No likes yet</Text>
-              <Text style={styles.emptyText}>
-                When someone likes your profile, they'll appear here.{'\n'}Keep swiping!
+          <View style={styles.statRow}>
+            <View style={styles.statPill}>
+              <Ionicons name="heart" size={16} color={CHATS_GREEN} />
+              <Text style={styles.statPillText}>
+                {likers.length} {likers.length === 1 ? 'person' : 'people'}
               </Text>
             </View>
-          }
-          renderItem={renderItem}
-        />
-      )}
-      {/* Match modal */}
-      <Modal visible={!!matchName} transparent animationType="fade">
-        <View style={styles.matchOverlay}>
-          <View style={styles.matchCard}>
-            <Text style={styles.matchEmoji}>🍐</Text>
-            <Text style={styles.matchTitle}>It's a Match!</Text>
-            <Text style={styles.matchSub}>
-              You and {matchName} both liked each other.
-            </Text>
-            <TouchableOpacity
-              style={styles.matchBtn}
-              onPress={() => {
-                setMatchName(null);
-                navigation.navigate('Chats', { screen: 'ChatsHome' });
-              }}
-            >
-              <Text style={styles.matchBtnText}>Send Message</Text>
-            </TouchableOpacity>
-            <TouchableOpacity onPress={() => setMatchName(null)}>
-              <Text style={styles.matchSkip}>Keep Browsing</Text>
-            </TouchableOpacity>
           </View>
-        </View>
-      </Modal>
-    </SafeAreaView>
+        )}
+
+        {!loading && userId && likers.length > 0 && (
+          <View
+            style={[
+              styles.revealCard,
+              revealSummary.tone === 'plus' && styles.revealCardPlus,
+              revealSummary.tone === 'used' && styles.revealCardUsed,
+            ]}
+          >
+            <View
+              style={[
+                styles.revealAccent,
+                revealSummary.tone === 'plus' && styles.revealAccentPlus,
+                revealSummary.tone === 'used' && styles.revealAccentUsed,
+              ]}
+            />
+            <View style={styles.revealCardInner}>
+              <View
+                style={[
+                  styles.revealIconWrap,
+                  revealSummary.tone === 'used' && styles.revealIconWrapMuted,
+                ]}
+              >
+                <Ionicons
+                  name={revealSummary.icon}
+                  size={22}
+                  color={
+                    revealSummary.tone === 'plus'
+                      ? CHATS_GREEN
+                      : revealSummary.tone === 'used'
+                        ? C.gray
+                        : CHATS_GREEN
+                  }
+                />
+              </View>
+              <View style={styles.revealCopy}>
+                <Text style={styles.revealTitle}>{revealSummary.title}</Text>
+                <Text style={styles.revealBody}>{revealSummary.body}</Text>
+              </View>
+            </View>
+          </View>
+        )}
+
+        {loading ? (
+          <View style={styles.centered}>
+            <ActivityIndicator color={CHATS_GREEN} />
+          </View>
+        ) : (
+          <>
+            {sortedLikers.length > 0 && (
+              <View style={styles.sortRow}>
+                <TouchableOpacity
+                  style={[styles.sortChip, sortBy === 'recent' && styles.sortChipActive]}
+                  onPress={() => setSortBy('recent')}
+                >
+                  <Text style={[styles.sortChipText, sortBy === 'recent' && styles.sortChipTextActive]}>
+                    Recent
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.sortChip, sortBy === 'name' && styles.sortChipActive]}
+                  onPress={() => setSortBy('name')}
+                >
+                  <Text style={[styles.sortChipText, sortBy === 'name' && styles.sortChipTextActive]}>
+                    Name
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            )}
+            <FlatList
+              data={sortedLikers}
+              keyExtractor={(item) => item.id}
+              numColumns={2}
+              columnWrapperStyle={styles.gridRow}
+              contentContainerStyle={sortedLikers.length === 0 ? styles.emptyList : styles.gridContent}
+              refreshControl={
+                <RefreshControl
+                  refreshing={refreshing}
+                  onRefresh={() => load(true)}
+                  tintColor={CHATS_GREEN}
+                />
+              }
+              ListEmptyComponent={
+                <View style={styles.emptyCard}>
+                  <Text style={styles.emptyEmoji}>💛</Text>
+                  <Text style={styles.emptyTitle}>No likes yet</Text>
+                  <Text style={styles.emptyText}>
+                    When someone likes your profile, they will show up here. Keep swiping in Discover.
+                  </Text>
+                </View>
+              }
+              renderItem={renderItem}
+            />
+          </>
+        )}
+
+        <Modal visible={!!matchName} transparent animationType="fade">
+          <View style={styles.matchOverlay}>
+            <View style={styles.matchCard}>
+              <Text style={styles.matchEmoji}>🍐</Text>
+              <Text style={styles.matchTitle}>{"It's a Match!"}</Text>
+              <Text style={styles.matchSub}>
+                You and {matchName} both liked each other.
+              </Text>
+              <TouchableOpacity
+                style={styles.matchBtn}
+                onPress={() => {
+                  setMatchName(null);
+                  navigation.navigate('Chats', { screen: 'ChatsHome' });
+                }}
+              >
+                <Text style={styles.matchBtnText}>Send Message</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => setMatchName(null)}>
+                <Text style={styles.matchSkip}>Keep Browsing</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Modal>
+      </SafeAreaView>
+    </Background>
   );
 }
 
 const styles = StyleSheet.create({
-  root: {
+  safe: {
     flex: 1,
-    backgroundColor: '#F4F7F9',
+    backgroundColor: 'transparent',
+    zIndex: 1,
+  },
+  ambientRoot: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 0,
+    overflow: 'hidden',
+  },
+  ambientOrbTopRight: {
+    position: 'absolute',
+    width: SCREEN_WIDTH * 0.92,
+    height: SCREEN_WIDTH * 0.92,
+    borderRadius: SCREEN_WIDTH * 0.46,
+    top: -SCREEN_WIDTH * 0.38,
+    right: -SCREEN_WIDTH * 0.28,
+    backgroundColor: 'rgba(45, 106, 79, 0.06)',
+  },
+  ambientOrbBottomLeft: {
+    position: 'absolute',
+    width: SCREEN_WIDTH * 0.75,
+    height: SCREEN_WIDTH * 0.75,
+    borderRadius: SCREEN_WIDTH * 0.375,
+    bottom: -SCREEN_WIDTH * 0.22,
+    left: -SCREEN_WIDTH * 0.32,
+    backgroundColor: 'rgba(26, 51, 41, 0.045)',
+  },
+  ambientCornerGlow: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    width: SCREEN_WIDTH * 0.72,
+    height: SCREEN_WIDTH * 0.58,
+  },
+  heroGlow: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 168,
+  },
+  heroGradientFill: {
+    flex: 1,
+    width: '100%',
+    minHeight: 168,
   },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-
-  // Header
   header: {
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    justifyContent: 'space-between',
     paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 12,
+    paddingTop: 6,
+    paddingBottom: 10,
   },
-  headerTitle: {
+  heroTitle: {
     fontSize: 28,
-    fontWeight: '800',
-    color: '#0C5389',
-  },
-  headerCount: {
-    fontSize: 13,
-    color: '#189AA2',
     fontWeight: '600',
+    color: C.text,
+    letterSpacing: -0.5,
   },
-
-  // Banner
-  banner: {
-    marginHorizontal: 16,
-    marginBottom: 12,
+  heroTagline: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: C.gray,
+    marginTop: 4,
+    lineHeight: 18,
+  },
+  statRow: {
+    flexDirection: 'row',
     paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 12,
-    backgroundColor: 'rgba(24,154,162,0.12)',
+    marginBottom: 12,
+    gap: 8,
   },
-  bannerUsed: {
-    backgroundColor: 'rgba(74,96,112,0.10)',
+  statPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: C.white,
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER,
   },
-  bannerPremium: {
-    backgroundColor: 'rgba(70,189,127,0.15)',
+  statPillText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: CHATS_GREEN_DARK,
   },
-  bannerText: {
+  revealCard: {
+    marginHorizontal: 16,
+    marginBottom: 14,
+    borderRadius: 18,
+    backgroundColor: C.surface,
+    borderWidth: 1,
+    borderColor: C.surfaceBorder,
+    overflow: 'hidden',
+    flexDirection: 'row',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.06,
+    shadowRadius: 12,
+    elevation: 3,
+  },
+  revealCardPlus: {
+    borderColor: CHATS_GREEN,
+    backgroundColor: CHATS_GREEN_SOFT_BG,
+  },
+  revealCardUsed: {
+    backgroundColor: 'rgba(113, 113, 130, 0.06)',
+    borderColor: CHATS_GREEN_BORDER,
+  },
+  revealAccent: {
+    width: 5,
+    backgroundColor: CHATS_GREEN,
+  },
+  revealAccentPlus: {
+    backgroundColor: CHATS_GREEN,
+  },
+  revealAccentUsed: {
+    backgroundColor: C.grayDim,
+  },
+  revealCardInner: {
+    flex: 1,
+    flexDirection: 'row',
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    gap: 12,
+    alignItems: 'center',
+  },
+  revealIconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: CHATS_GREEN_SOFT_BG,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER,
+  },
+  revealIconWrapMuted: {
+    backgroundColor: 'rgba(113, 113, 130, 0.10)',
+    borderColor: 'rgba(113, 113, 130, 0.22)',
+  },
+  revealCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  revealTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: CHATS_GREEN_DARK,
+    marginBottom: 2,
+  },
+  revealBody: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: C.gray,
+    lineHeight: 18,
+  },
+  sortRow: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    marginBottom: 12,
+    gap: 8,
+  },
+  sortChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 20,
+    backgroundColor: C.white,
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER,
+  },
+  sortChipActive: {
+    backgroundColor: CHATS_GREEN_SOFT_BG,
+    borderColor: CHATS_GREEN,
+  },
+  sortChipText: {
     fontSize: 13,
     fontWeight: '600',
-    color: '#189AA2',
-    textAlign: 'center',
+    color: C.gray,
   },
-  bannerTextPremium: {
-    color: '#0C5389',
+  sortChipTextActive: {
+    color: CHATS_GREEN,
   },
-
-  // Grid
   gridContent: {
     paddingHorizontal: GRID_PADDING,
     paddingBottom: 32,
@@ -396,107 +706,155 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginBottom: GRID_GAP,
   },
-
-  // Card
-  card: {
+  gridCard: {
     width: CARD_WIDTH,
-    borderRadius: 16,
-    backgroundColor: '#FDFDFD',
+    borderRadius: 18,
+    backgroundColor: C.surface,
+    borderWidth: 1,
+    borderColor: C.surfaceBorder,
     overflow: 'hidden',
-    shadowColor: '#0C5389',
-    shadowOffset: { width: 0, height: 2 },
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 3,
+    shadowRadius: 12,
+    elevation: 4,
   },
   photoWrap: {
     position: 'relative',
   },
-  photo: {
+  gridPhoto: {
     width: CARD_WIDTH,
     height: CARD_WIDTH,
-    backgroundColor: '#D9E1E6',
+    backgroundColor: CHATS_GREEN_SOFT_BG,
   },
-  photoPlaceholder: {
+  gridPhotoPlaceholder: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#C0CDD6',
+    backgroundColor: CHATS_GREEN,
   },
-  photoInitial: {
-    fontSize: 40,
+  gridPhotoInitial: {
+    fontSize: 36,
     fontWeight: '700',
-    color: '#FDFDFD',
+    color: C.white,
   },
   lockOverlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
+    ...StyleSheet.absoluteFillObject,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: 'rgba(250, 252, 251, 0.45)',
   },
-  lockIcon: {
-    fontSize: 28,
+  lockBubble: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: CHATS_CARD,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER_STRONG,
+    shadowColor: '#1A3329',
+    shadowOpacity: 0.12,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 8,
+    elevation: 3,
   },
-  info: {
+  topPickBadge: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 12,
+    backgroundColor: CHATS_CARD,
+    borderWidth: 1.5,
+    borderColor: CHATS_GREEN,
+    zIndex: 2,
+    shadowColor: '#1A3329',
+    shadowOpacity: 0.14,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 4,
+  },
+  topPickBadgeText: {
+    fontSize: 10,
+    fontWeight: '800',
+    color: CHATS_GREEN_DARK,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+  },
+  gridInfo: {
     padding: 10,
   },
-  name: {
+  gridName: {
     fontSize: 15,
     fontWeight: '700',
-    color: '#0C5389',
+    color: C.text,
     marginBottom: 2,
   },
-  location: {
+  gridLocation: {
     fontSize: 12,
-    color: '#189AA2',
+    fontWeight: '500',
+    color: C.accent,
     marginBottom: 8,
   },
-  revealBtn: {
-    backgroundColor: '#0C5389',
-    borderRadius: 10,
-    paddingVertical: 7,
+  actionBtn: {
+    flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: CHATS_GREEN,
+    borderRadius: 12,
+    paddingVertical: 8,
   },
-  revealBtnDim: {
-    backgroundColor: '#C0CDD6',
+  actionBtnMuted: {
+    backgroundColor: C.grayDim,
   },
-  revealBtnText: {
-    color: '#FDFDFD',
+  actionBtnText: {
+    color: C.white,
     fontSize: 13,
     fontWeight: '700',
   },
-
-  // Empty
   emptyList: {
     flexGrow: 1,
   },
-  emptyWrap: {
-    flex: 1,
-    justifyContent: 'center',
+  emptyCard: {
+    alignSelf: 'center',
+    maxWidth: 340,
+    marginTop: 48,
+    marginHorizontal: 20,
+    paddingHorizontal: 24,
+    paddingVertical: 28,
+    borderRadius: 22,
+    backgroundColor: C.surface,
+    borderWidth: 1,
+    borderColor: C.surfaceBorder,
     alignItems: 'center',
-    paddingHorizontal: 32,
-    paddingTop: 60,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+    elevation: 5,
   },
   emptyEmoji: {
-    fontSize: 48,
-    marginBottom: 12,
+    fontSize: 44,
+    marginBottom: 10,
   },
   emptyTitle: {
     fontSize: 20,
-    fontWeight: '800',
-    color: '#0C5389',
+    fontWeight: '700',
+    color: C.text,
     marginBottom: 8,
+    letterSpacing: -0.3,
   },
   emptyText: {
     fontSize: 15,
-    color: '#4A6070',
+    fontWeight: '500',
+    color: C.gray,
     textAlign: 'center',
     lineHeight: 22,
   },
-
-  // Match modal
   matchOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0,0,0,0.55)',
@@ -504,11 +862,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   matchCard: {
-    backgroundColor: '#FDFDFD',
+    backgroundColor: CHATS_CARD,
     borderRadius: 24,
     padding: 32,
     alignItems: 'center',
     width: '80%',
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER,
     shadowColor: '#000',
     shadowOpacity: 0.15,
     shadowRadius: 20,
@@ -517,19 +877,20 @@ const styles = StyleSheet.create({
   matchEmoji: { fontSize: 48, marginBottom: 12 },
   matchTitle: {
     fontSize: 26,
-    fontWeight: '900',
-    color: '#0C5389',
+    fontWeight: '800',
+    color: CHATS_GREEN_DARK,
     marginBottom: 8,
   },
   matchSub: {
     fontSize: 15,
-    color: '#4A6070',
+    fontWeight: '500',
+    color: C.gray,
     textAlign: 'center',
     lineHeight: 22,
     marginBottom: 24,
   },
   matchBtn: {
-    backgroundColor: '#0C5389',
+    backgroundColor: CHATS_GREEN,
     paddingHorizontal: 28,
     paddingVertical: 12,
     borderRadius: 14,
@@ -538,13 +899,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   matchBtnText: {
-    color: '#FDFDFD',
+    color: C.white,
     fontWeight: '700',
     fontSize: 15,
   },
   matchSkip: {
     fontSize: 14,
-    color: '#4A6070',
-    opacity: 0.7,
+    fontWeight: '500',
+    color: C.gray,
+    opacity: 0.85,
   },
 });

--- a/apps/mobile/screens/PublicUserProfileScreen.tsx
+++ b/apps/mobile/screens/PublicUserProfileScreen.tsx
@@ -20,7 +20,7 @@ import { getPreferences, type Preferences } from '../lib/preferences';
 import { formatLocationLine, profilePhotoPathsFromRow } from '../lib/profileDisplay';
 import PublicProfileCard from '../components/PublicProfileCard';
 import { ChatStyleTopBar } from '../components/ChatStyleTopBar';
-import { CHATS_SCREEN_BG, CHATS_CARD, CHATS_GREEN, CHATS_GREEN_BORDER } from '../theme/chatsAmbient';
+import { CHATS_CARD, CHATS_GREEN, CHATS_GREEN_BORDER } from '../theme/chatsAmbient';
 
 type PromptEntry = { question: string; answer: string };
 
@@ -237,7 +237,8 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: CHATS_SCREEN_BG,
+    /** Match card surface so safe-area padding above the card is not a visible “gray bar”. */
+    backgroundColor: '#FFFFFF',
   },
   scrollContent: {
     flexGrow: 1,


### PR DESCRIPTION
## Summary
This PR improves the Likes tab loading behavior (aligned with Chats), cleans up the public profile screen when opened from Chats/Likes, and fixes mutual matches not appearing in Matched when one side used a top pick instead of a plain like.

## Changes
### Likes tab — caching and fewer redundant loads

- Mirrors the Chats pattern: full-screen loading only on the first load for the signed-in user, not on every tab focus.
- Tracks initialLoadDoneRef and lastUserIdRef so account switches reset state and reload correctly; logout clears likers and related local state.
- On tab focus, skips refetch if data was loaded within the last 90 seconds (pull-to-refresh still always refetches).
- useFocusEffect calls load(false, true) so the stale window applies only to passive focus, not manual refresh.
### Public profile (Chats / Likes) — “gray bar”
- PublicProfileCard: Removes the full-width bottom scrim on the default (and profile-photos) variants; keeps the tall scrim only for immersive (text on image). Pagination dots use a small pill background instead of a full-width dim strip.
- PublicUserProfileScreen: Root background set to white so the safe-area band above the card doesn’t read as a separate strip.
- ChatsStack / LikesStack: ProfileView uses contentStyle: { backgroundColor: '#FFFFFF' } for consistent transitions.

### Matches — top_pick parity with app logic

- Bug: recordSwipe and fetchLikers treat top_pick like a like, but match_peers_without_messages() and get_or_create_match_conversation() only checked direction = 'like', so users could get a match modal and disappear from Likes without showing under Matched.
- New migration `20260422130000_match_mutual_includes_top_pick.sql`: both RPCs now use direction IN ('like', 'top_pick') where mutual intent is defined.
- `apps/mobile/lib/matches.ts`: matchedAt helper query uses .in('direction', ['like', 'top_pick']) for incoming swipes from matched peers.