### PR TITLE
Onboarding redesign

### DIFF
--- a/apps/mobile/screens/OnboardingScreen.tsx
+++ b/apps/mobile/screens/OnboardingScreen.tsx
@@ -1,27 +1,20 @@
 /**
- * OnboardingScreen — 17-step focused onboarding flow.
- * One or two inputs per screen, Hinge-style.
+ * OnboardingScreen — unified 10-step full-screen onboarding flow.
  *
- *  0  Name
- *  1  Age
- *  2  Gender          (chips, auto-advance)
- *  3  Ethnicity       (chips, optional)
- *  4  Location        (city + state + zip)
- *  5  Budget          (min + max)
- *  6  Room type       (chips, auto-advance)
- *  7  Move-in date
- *  8  Cleanliness     (1–5 chips, auto-advance)
- *  9  Work schedule   (chips, auto-advance)
- * 10  Social vibe     (chips, auto-advance)
- * 11  Pets & Smoking  (2 yes/no rows)
- * 12  Dealbreakers
- * 13  Interests
- * 14  Prompts
- * 15  Photos
- * 16  Listing         (optional)
+ * Steps:
+ *  0  About You       (name, age, gender, ethnicity → profiles)
+ *  1  Location        (city, state, zip → preferences)
+ *  2  Budget          (min/max → preferences)
+ *  3  Room + Move-in  (room_type, move_in_date → preferences)
+ *  4  Lifestyle       (cleanliness, schedule, social, pets, smoking → preferences)
+ *  5  Dealbreakers    (hard/soft/none per item → preferences.dealbreakers)
+ *  6  Interests       (category chips → preferences.interests)
+ *  7  Prompts         (pick 2–3, answer them → profiles.prompts)
+ *  8  Photos          (upload photos → profiles.profile_photo_url)
+ *  9  Listing         (optional → listings + profiles.has_listing)
  */
 
-import { useState, useEffect, useRef, useCallback, lazy, Suspense, type ComponentType } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -34,38 +27,22 @@ import {
   Alert,
   ActivityIndicator,
   Image,
-  Modal,
-  FlatList,
   Dimensions,
-  Animated,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import {
-  User, Cake, Sparkle, Globe, MapPin, CurrencyDollar,
-  Door, CalendarBlank, Broom, Clock, UsersThree, PawPrint,
-  ShieldWarning, Star, ChatCircleDots, Camera, House,
-  Prohibit, MusicNote, Sun, Moon, Bed,
-  XCircle, MinusCircle, CheckCircle,
-} from 'phosphor-react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { BlurView } from 'expo-blur';
-import Constants, { ExecutionEnvironment } from 'expo-constants';
 import * as ImagePicker from 'expo-image-picker';
 import { supabase } from '../lib/supabase';
 import { savePreferences } from '../lib/preferences';
 import { uploadStagedPhotosAndMerge } from '../lib/profilePhotos';
 import { uploadProfileImage } from '../lib/storage';
 import PublicProfileCard from '../components/PublicProfileCard';
-import type { SearchAreaValue } from '../lib/searchAreaTypes';
-
-const SearchAreaMapPicker = lazy(() => import('../components/SearchAreaMapPicker'));
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const TOTAL_STEPS = 17;
+const TOTAL_STEPS = 10;
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const PHOTO_THUMB = (SCREEN_WIDTH - 40 - 10) / 2;
+const PHOTO_THUMB = (SCREEN_WIDTH - 40 - 10) / 2; // 2-col grid, 20px padding each side, 10px gap
 
 const GENDER_OPTIONS = ['Man', 'Woman', 'Non-binary', 'Other', 'Prefer not to say'];
 
@@ -82,202 +59,94 @@ const ETHNICITY_OPTIONS = [
 ];
 
 const DEALBREAKER_ITEMS = [
-  { key: 'smoking',    question: 'Smoking indoors in the unit?' },
-  { key: 'pets',       question: 'Pets living in the unit?' },
-  { key: 'parties',    question: 'Frequent house parties?' },
-  { key: 'early_bird', question: 'Noise before 8 am?' },
-  { key: 'night_owl',  question: 'Noise after 11 pm?' },
-  { key: 'guests',     question: 'Overnight guests regularly?' },
-];
-
-const DB_OPTIONS: { level: DealbreakerLevel; label: string; sublabel: string }[] = [
-  { level: 'hard', label: 'Never',        sublabel: "It's a dealbreaker for me" },
-  { level: 'soft', label: 'Prefer not',   sublabel: "I'd rather avoid it" },
-  { level: 'none', label: 'Fine with it', sublabel: "Doesn't bother me" },
+  { key: 'smoking',    label: 'Smoking indoors' },
+  { key: 'pets',       label: 'Pets in the unit' },
+  { key: 'parties',    label: 'Frequent parties' },
+  { key: 'early_bird', label: 'Noise before 8 am' },
+  { key: 'night_owl',  label: 'Noise after 11 pm' },
+  { key: 'guests',     label: 'Overnight guests' },
+  { key: 'messy',      label: 'Messy common areas' },
 ];
 
 const INTEREST_CATEGORIES = [
   {
     key: 'fitness',
-    label: 'Fitness',
+    label: '🏃 Fitness',
     options: ['Running', 'Yoga', 'Gym', 'Hiking', 'Swimming', 'Cycling', 'Rock Climbing'],
   },
   {
     key: 'food',
-    label: 'Food & Drink',
+    label: '🍕 Food & Drink',
     options: ['Cooking', 'Baking', 'Coffee', 'Wine & Cocktails', 'Foodie Adventures', 'Meal Prep'],
   },
   {
     key: 'arts',
-    label: 'Arts & Culture',
+    label: '🎨 Arts & Culture',
     options: ['Movies', 'Music', 'Reading', 'Photography', 'Art Galleries', 'Theater'],
   },
   {
     key: 'outdoors',
-    label: 'Outdoors',
+    label: '🌿 Outdoors',
     options: ['Camping', 'Travel', 'Beach', 'Gardening', 'Road Trips', 'Surfing'],
   },
   {
     key: 'tech',
-    label: 'Tech & Gaming',
+    label: '🎮 Tech & Gaming',
     options: ['Gaming', 'Coding', 'Podcasts', 'Anime', 'Board Games', 'VR / AR'],
   },
 ];
 
-type PromptDef = { question: string; suggestions: string[] };
-
-const PROMPTS: PromptDef[] = [
-  {
-    question: 'My ideal Saturday morning looks like…',
-    suggestions: ['Coffee and a good book', 'Long run, then brunch', 'Farmers market & cooking', 'Sleeping in, zero plans'],
-  },
-  {
-    question: "I'm looking for a roommate who…",
-    suggestions: ['Respects quiet hours', 'Is tidy but chill', 'Actually uses the kitchen', 'Keeps to themselves'],
-  },
-  {
-    question: "Don't room with me if you hate…",
-    suggestions: ['Occasional music', 'My cooking smells', 'Short notice guests', 'Early mornings'],
-  },
-  {
-    question: 'My morning routine is…',
-    suggestions: ['Quick shower and go', 'Slow coffee and news', 'Gym before anything', 'Total chaos, honestly'],
-  },
-  {
-    question: "On weeknights you'll find me…",
-    suggestions: ['Cooking & winding down', 'Working late', 'Out with friends sometimes', 'Glued to my couch'],
-  },
-  {
-    question: 'Weekends are for…',
-    suggestions: ['Exploring the city', 'Recovering from the week', 'Hiking or outdoors', 'Brunching & errands'],
-  },
-  {
-    question: 'I clean the apartment…',
-    suggestions: ['Every Sunday without fail', 'When it starts to bother me', 'A little every day', 'Whenever I can'],
-  },
-  {
-    question: 'My noise level is…',
-    suggestions: ['Library quiet', 'Music on, low volume', 'TV always on in the background', 'Varies a lot'],
-  },
-  {
-    question: 'Overnight guests are…',
-    suggestions: ['Rare and I give notice', 'Pretty common, sorry', 'Never really', 'Occasional & respectful'],
-  },
-  {
-    question: 'My kitchen rule is…',
-    suggestions: ['Clean as you go', 'Dishes done before bed', 'Shared is cared', 'My stuff = my shelf'],
-  },
-  {
-    question: 'My sleep schedule is…',
-    suggestions: ['Lights out by 10pm', 'Night owl til 2am+', 'All over the place', 'Up at 6, bed by midnight'],
-  },
-  {
-    question: "I've lived with roommates before and learned…",
-    suggestions: ['Communication is everything', 'Label your food', 'Set expectations early', 'Alone time is sacred'],
-  },
-  {
-    question: 'A quirk about living with me…',
-    suggestions: ["I organize when I'm stressed", 'I hum while cooking', 'I keep the thermostat cold', 'I rearrange furniture a lot'],
-  },
-  {
-    question: 'My ideal apartment vibe…',
-    suggestions: ['Clean, minimal, calm', 'Cozy and lived-in', 'Like a coffee shop', 'Wherever my stuff is'],
-  },
-  {
-    question: 'After work I usually…',
-    suggestions: ['Decompress alone first', 'Hit the gym', 'Cook something', 'Jump on calls with friends'],
-  },
-  {
-    question: 'The best thing about me as a roommate…',
-    suggestions: ["I'm low drama", "I'm always down to help", 'I mind my own business', "I'll actually clean"],
-  },
-  {
-    question: 'My work-from-home setup is…',
-    suggestions: ['Headphones in, do not disturb', 'Calls all day, heads up', 'I go into the office', 'Mix of both'],
-  },
-  {
-    question: 'Two truths and a lie about my living habits…',
-    suggestions: ['Write your own answer…'],
-  },
-  {
-    question: 'I stay up until…',
-    suggestions: ['10–11pm usually', 'Midnight most nights', '2am is normal for me', 'Whenever I pass out'],
-  },
-  {
-    question: 'I wake up at…',
-    suggestions: ['6am, I am that person', '7–8am if I have to', '9am on a good day', 'Whenever my body decides'],
-  },
-  {
-    question: 'My relationship with mess is…',
-    suggestions: ['It stresses me out', 'Clutter = creativity', 'Clean surfaces, chaotic drawers', 'Depends on the week'],
-  },
-  {
-    question: 'The soundtrack of my home is…',
-    suggestions: ['Complete silence', 'Lo-fi or chill beats', 'Whatever podcast is on', 'TV as background noise'],
-  },
-  {
-    question: 'My go-to snack situation…',
-    suggestions: ['Snack drawer fully stocked', 'I meal prep everything', 'Whatever is around', 'I barely eat at home'],
-  },
-  {
-    question: 'I unwind by…',
-    suggestions: ['Reading or journaling', 'Working out', 'Watching something', 'Just lying down honestly'],
-  },
+const PROMPTS = [
+  'My ideal Saturday morning looks like…',
+  "I'm looking for a roommate who…",
+  "Don't room with me if you hate…",
+  'My morning routine is…',
+  "On weeknights you'll find me…",
+  'Weekends are for…',
+  'I clean the apartment…',
+  'My noise level is…',
+  'Overnight guests are…',
+  'My kitchen rule is…',
+  'My sleep schedule is…',
+  "I've lived with roommates before and learned…",
+  'A quirk about living with me…',
+  'My ideal apartment vibe…',
+  'After work I usually…',
+  'The best thing about me as a roommate…',
+  'My work-from-home setup is…',
+  'Two truths and a lie about my living habits…',
+  'I stay up until…',
+  'I wake up at…',
+  'My relationship with mess is…',
+  'The soundtrack of my home is…',
+  'My go-to snack situation…',
+  'I unwind by…',
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type StepDef = { icon: ComponentType<any>; question: string; subtitle: string; optional?: boolean };
-
-// Per-step display content
-const STEPS: StepDef[] = [
-  { icon: User,          question: "What's your name?",               subtitle: "This is how you'll appear to others." },
-  { icon: Cake,          question: 'How old are you?',                subtitle: 'You must be 18+ to use RoomPear.' },
-  { icon: Sparkle,       question: 'How do you identify?',            subtitle: 'Helps personalize your matches.' },
-  { icon: Globe,         question: "What's your ethnicity?",          subtitle: 'Optional — skip if you prefer not to say.', optional: true },
-  { icon: MapPin,        question: 'Where are you looking?',          subtitle: "We'll show you people in your area." },
-  { icon: CurrencyDollar,question: "What's your monthly budget?",     subtitle: 'Your comfortable range for rent.' },
-  { icon: Door,          question: 'What kind of room?',              subtitle: 'Pick what works for you.' },
-  { icon: CalendarBlank, question: 'When do you want to move in?',    subtitle: 'Approximate is fine — you can update later.', optional: true },
-  { icon: Broom,         question: 'How clean do you keep your space?',subtitle: '1 = relaxed about mess  ·  5 = spotless' },
-  { icon: Clock,         question: "What's your work schedule?",      subtitle: 'Helps us find someone on your rhythm.' },
-  { icon: UsersThree,    question: "What's your social vibe?",        subtitle: 'How often do you have people over?' },
-  { icon: PawPrint,      question: 'A quick yes or no…',              subtitle: 'These filter out incompatible matches.' },
-  { icon: ShieldWarning, question: 'Any dealbreakers?',               subtitle: 'Hard = never  ·  Soft = prefer not  ·  None = fine', optional: true },
-  { icon: Star,          question: 'What are you into?',              subtitle: 'Select up to 5 per category.', optional: true },
-  { icon: ChatCircleDots,question: 'In your own words…',              subtitle: 'Pick 2–3 prompts to answer.', optional: true },
-  { icon: Camera,        question: 'Show yourself off',               subtitle: 'Your first photo is your first impression.' },
-  { icon: House,         question: 'Got a place to offer?',           subtitle: 'Optional — skip if you are only looking.', optional: true },
+const STEP_TITLES = [
+  'Tell us about you',
+  'Where are you looking?',
+  "What's your budget?",
+  'What kind of room?',
+  'Your lifestyle',
+  'Any dealbreakers?',
+  'Your interests',
+  'In your own words',
+  'Add your photos',
+  'Do you have a place?',
 ];
 
-// Steps that auto-advance when a chip is selected
-const AUTO_ADVANCE_STEPS = new Set([2, 3, 6, 8, 9, 10, 12]);
-
-const US_STATES = [
-  { label: 'Alabama', abbr: 'AL' }, { label: 'Alaska', abbr: 'AK' },
-  { label: 'Arizona', abbr: 'AZ' }, { label: 'Arkansas', abbr: 'AR' },
-  { label: 'California', abbr: 'CA' }, { label: 'Colorado', abbr: 'CO' },
-  { label: 'Connecticut', abbr: 'CT' }, { label: 'Delaware', abbr: 'DE' },
-  { label: 'Florida', abbr: 'FL' }, { label: 'Georgia', abbr: 'GA' },
-  { label: 'Hawaii', abbr: 'HI' }, { label: 'Idaho', abbr: 'ID' },
-  { label: 'Illinois', abbr: 'IL' }, { label: 'Indiana', abbr: 'IN' },
-  { label: 'Iowa', abbr: 'IA' }, { label: 'Kansas', abbr: 'KS' },
-  { label: 'Kentucky', abbr: 'KY' }, { label: 'Louisiana', abbr: 'LA' },
-  { label: 'Maine', abbr: 'ME' }, { label: 'Maryland', abbr: 'MD' },
-  { label: 'Massachusetts', abbr: 'MA' }, { label: 'Michigan', abbr: 'MI' },
-  { label: 'Minnesota', abbr: 'MN' }, { label: 'Mississippi', abbr: 'MS' },
-  { label: 'Missouri', abbr: 'MO' }, { label: 'Montana', abbr: 'MT' },
-  { label: 'Nebraska', abbr: 'NE' }, { label: 'Nevada', abbr: 'NV' },
-  { label: 'New Hampshire', abbr: 'NH' }, { label: 'New Jersey', abbr: 'NJ' },
-  { label: 'New Mexico', abbr: 'NM' }, { label: 'New York', abbr: 'NY' },
-  { label: 'North Carolina', abbr: 'NC' }, { label: 'North Dakota', abbr: 'ND' },
-  { label: 'Ohio', abbr: 'OH' }, { label: 'Oklahoma', abbr: 'OK' },
-  { label: 'Oregon', abbr: 'OR' }, { label: 'Pennsylvania', abbr: 'PA' },
-  { label: 'Rhode Island', abbr: 'RI' }, { label: 'South Carolina', abbr: 'SC' },
-  { label: 'South Dakota', abbr: 'SD' }, { label: 'Tennessee', abbr: 'TN' },
-  { label: 'Texas', abbr: 'TX' }, { label: 'Utah', abbr: 'UT' },
-  { label: 'Vermont', abbr: 'VT' }, { label: 'Virginia', abbr: 'VA' },
-  { label: 'Washington', abbr: 'WA' }, { label: 'West Virginia', abbr: 'WV' },
-  { label: 'Wisconsin', abbr: 'WI' }, { label: 'Wyoming', abbr: 'WY' },
+const STEP_SUBTITLES = [
+  'This helps us find compatible roommates.',
+  "We'll show you people in your area.",
+  "We'll match you within your range.",
+  'Pick what works for you.',
+  'Helps us find someone compatible.',
+  'Hard = never · Soft = prefer not · None = fine.',
+  'Select up to 5 per category.',
+  'Answer at least 2 prompts (up to 3).',
+  'Your first impression — make it count.',
+  'Optional — skip if you are not listing a place.',
 ];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -289,15 +158,28 @@ function formatDateYMD(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
+/** Human-readable label after picking a date (API still uses YMD). */
 function formatDateDisplay(date: Date): string {
-  return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
-// ─── Chip ─────────────────────────────────────────────────────────────────────
+// ─── Chip component ───────────────────────────────────────────────────────────
 
 function Chip({
-  label, selected, onPress, disabled,
-}: { label: string; selected: boolean; onPress: () => void; disabled?: boolean }) {
+  label,
+  selected,
+  onPress,
+  disabled,
+}: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
   return (
     <TouchableOpacity
       style={[styles.chip, selected && styles.chipSelected, disabled && styles.chipDisabled]}
@@ -317,57 +199,50 @@ type DealbreakerLevel = 'hard' | 'soft' | 'none';
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-interface Props { onComplete: () => void }
+interface Props {
+  onComplete: () => void;
+}
 
 export default function OnboardingScreen({ onComplete }: Props) {
+  // Core
   const [step, setStep] = useState(0);
   const [userId, setUserId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const autoAdvanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Step 0: Name
+  // Step 0: About You
   const [name, setName] = useState('');
-  // Step 1: Age
   const [age, setAge] = useState('');
-  // Step 2: Gender
   const [gender, setGender] = useState('');
-  // Step 3: Ethnicity
   const [ethnicity, setEthnicity] = useState('');
-  // Step 4: Location
-  const isExpoGo = Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
-  const useLegacyLocationUi = !Constants.expoConfig?.extra?.mapboxAccessToken || isExpoGo;
+
+  // Step 1: Location
   const [city, setCity] = useState('');
   const [locationState, setLocationState] = useState('');
   const [zipCode, setZipCode] = useState('');
-  const [showStatePicker, setShowStatePicker] = useState(false);
-  const [stateSearch, setStateSearch] = useState('');
-  const [searchArea, setSearchArea] = useState<SearchAreaValue | null>(null);
-  // Step 5: Budget
+
+  // Step 2: Budget
   const [minBudget, setMinBudget] = useState('');
   const [maxBudget, setMaxBudget] = useState('');
-  const maxBudgetRef = useRef<TextInput>(null);
-  // Step 6: Room type
+  const maxBudgetInputRef = useRef<TextInput>(null);
+
+  // Step 3: Room + Move-in
   const [roomType, setRoomType] = useState('');
-  // Step 7: Move-in date
   const [moveInDate, setMoveInDate] = useState<Date | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);
-  // Step 8: Cleanliness
+
+  // Step 4: Lifestyle
   const [cleanliness, setCleanliness] = useState<number | null>(null);
-  // Step 9: Work schedule
   const [workSchedule, setWorkSchedule] = useState('');
-  // Step 10: Social vibe
   const [socialPref, setSocialPref] = useState('');
-  // Step 11: Pets & Smoking
   const [petsAllowed, setPetsAllowed] = useState<boolean | null>(null);
   const [smokingAllowed, setSmokingAllowed] = useState<boolean | null>(null);
-  // Step 12: Dealbreakers (sub-flow)
+
+  // Step 5: Dealbreakers
   const [dealbreakers, setDealbreakers] = useState<Record<string, DealbreakerLevel>>(
     Object.fromEntries(DEALBREAKER_ITEMS.map((d) => [d.key, 'none' as DealbreakerLevel]))
   );
-  const [dbStep, setDbStep] = useState(0);
-  const [dbSelected, setDbSelected] = useState<DealbreakerLevel | null>(null);
-  const dbCardAnim = useRef(new Animated.Value(1)).current;
-  // Step 13: Interests
+
+  // Step 6: Interests
   const [interests, setInterests] = useState<Record<string, string[]>>(
     Object.fromEntries(INTEREST_CATEGORIES.map((c) => [c.key, [] as string[]]))
   );
@@ -375,17 +250,14 @@ export default function OnboardingScreen({ onComplete }: Props) {
   const [customInputs, setCustomInputs] = useState<Record<string, string>>(
     Object.fromEntries(INTEREST_CATEGORIES.map((c) => [c.key, '']))
   );
-  // Step 14: Prompts (card sub-flow)
+
+  // Step 7: Prompts
   const [promptAnswers, setPromptAnswers] = useState<PromptEntry[]>([]);
-  const [promptCardIdx, setPromptCardIdx] = useState(0);
-  const [promptMode, setPromptMode] = useState<'browse' | 'answer'>('browse');
-  const [promptDraft, setPromptDraft] = useState('');
-  const [promptBrowseAll, setPromptBrowseAll] = useState(false);
-  const promptSlide = useRef(new Animated.Value(0)).current;
-  const promptFade  = useRef(new Animated.Value(1)).current;
-  // Step 15: Photos
+
+  // Step 8: Photos
   const [stagingUris, setStagingUris] = useState<string[]>([]);
-  // Step 16: Listing
+
+  // Step 9: Listing
   const [hasListing, setHasListing] = useState(false);
   const [listingRent, setListingRent] = useState('');
   const [listingRoomType, setListingRoomType] = useState('');
@@ -399,21 +271,9 @@ export default function OnboardingScreen({ onComplete }: Props) {
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (user) setUserId(user.id);
     });
-    return () => {
-      if (autoAdvanceTimer.current) clearTimeout(autoAdvanceTimer.current);
-    };
   }, []);
 
-  // ── Auto-advance ────────────────────────────────────────────────────────────
-
-  const scheduleAutoAdvance = useCallback(() => {
-    if (autoAdvanceTimer.current) clearTimeout(autoAdvanceTimer.current);
-    autoAdvanceTimer.current = setTimeout(() => {
-      setStep((s) => Math.min(s + 1, TOTAL_STEPS - 1));
-    }, 380);
-  }, []);
-
-  // ── Save helpers ────────────────────────────────────────────────────────────
+  // ── Save helpers ───────────────────────────────────────────────────────────
 
   const ensureProfile = async (uid: string): Promise<boolean> => {
     const { data } = await supabase.from('profiles').select('id').eq('id', uid).single();
@@ -448,7 +308,10 @@ export default function OnboardingScreen({ onComplete }: Props) {
     if (!userId) return;
     const filtered = promptAnswers.filter((p) => p.answer.trim());
     if (filtered.length === 0) return;
-    const { error } = await supabase.from('profiles').update({ prompts: filtered }).eq('id', userId);
+    const { error } = await supabase
+      .from('profiles')
+      .update({ prompts: filtered })
+      .eq('id', userId);
     if (error) console.warn('savePrompts', error.message);
   };
 
@@ -463,16 +326,25 @@ export default function OnboardingScreen({ onComplete }: Props) {
   };
 
   const handleComplete = async () => {
-    if (!userId) { Alert.alert('Error', 'Not signed in. Please restart the app.'); setSaving(false); return; }
+    if (!userId) {
+      Alert.alert('Error', 'Not signed in. Please restart the app.');
+      setSaving(false);
+      return;
+    }
     try {
+      // Save listing if opted in
       if (hasListing) {
         const photoPaths: string[] = [];
         for (const uri of listingPhotos) {
           const { path, error } = await uploadProfileImage(userId, uri);
-          if (error || !path) { Alert.alert('Upload failed', 'Could not upload a listing photo.'); setSaving(false); return; }
+          if (error || !path) {
+            Alert.alert('Upload failed', 'Could not upload a listing photo. Please try again.');
+            setSaving(false);
+            return;
+          }
           photoPaths.push(path);
         }
-        await supabase.from('listings').insert({
+        const { error: listErr } = await supabase.from('listings').insert({
           user_id: userId,
           rent: listingRent ? parseFloat(listingRent) : null,
           room_type: listingRoomType || null,
@@ -482,9 +354,11 @@ export default function OnboardingScreen({ onComplete }: Props) {
           zip_code: listingZip || null,
           listing_photos: photoPaths,
         });
+        if (listErr) console.warn('saveListing', listErr.message);
         await supabase.from('profiles').update({ has_listing: true }).eq('id', userId);
       }
 
+      // Map social preference label to DB value
       const socialPrefMapped =
         socialPref === 'Social Butterfly' ? 'social'
         : socialPref === 'Homebody' ? 'quiet'
@@ -492,18 +366,14 @@ export default function OnboardingScreen({ onComplete }: Props) {
         : undefined;
 
       const result = await savePreferences(userId, {
-        city: (searchArea?.city || city.trim()) || undefined,
-        state: (searchArea?.state || locationState.trim()) || undefined,
-        zip_code: (searchArea?.zipCode || zipCode.trim()) || undefined,
-        location: searchArea?.searchLabel || undefined,
-        search_lat: searchArea?.latitude,
-        search_lng: searchArea?.longitude,
-        search_radius_miles: searchArea?.radiusMiles,
-        search_label: searchArea?.searchLabel,
+        city: city.trim() || undefined,
+        state: locationState.trim() || undefined,
+        zip_code: zipCode.trim() || undefined,
         min_budget: minBudget ? parseFloat(minBudget) : undefined,
         max_budget: maxBudget ? parseFloat(maxBudget) : undefined,
         room_type: (['private', 'shared', 'flexible', 'entire'] as const).includes(roomType as any)
-          ? (roomType as 'private' | 'shared' | 'flexible' | 'entire') : undefined,
+          ? (roomType as 'private' | 'shared' | 'flexible' | 'entire')
+          : undefined,
         move_in_date: moveInDate ? formatDateYMD(moveInDate) : undefined,
         pets_allowed: petsAllowed ?? undefined,
         smoking_allowed: smokingAllowed ?? undefined,
@@ -514,556 +384,407 @@ export default function OnboardingScreen({ onComplete }: Props) {
         dealbreakers,
       });
 
-      if (!result.success) { Alert.alert('Error', result.error ?? 'Could not save preferences.'); setSaving(false); return; }
+      if (!result.success) {
+        Alert.alert('Error', result.error ?? 'Could not save preferences.');
+        setSaving(false);
+        return;
+      }
+
       onComplete();
     } catch (err: unknown) {
-      Alert.alert('Error', err instanceof Error ? err.message : 'Something went wrong');
+      const msg = err instanceof Error ? err.message : 'Something went wrong';
+      Alert.alert('Error', msg);
       setSaving(false);
     }
   };
 
-  // ── Navigation ──────────────────────────────────────────────────────────────
+  // ── Navigation ─────────────────────────────────────────────────────────────
+
+  const advance = () => setStep((s) => Math.min(s + 1, TOTAL_STEPS - 1));
 
   const handleBack = () => {
     if (saving) return;
-    if (step === 12 && dbStep > 0) { setDbStep((s) => s - 1); setDbSelected(null); }
-    else if (step === 14 && promptMode === 'answer') { setPromptMode('browse'); setPromptDraft(''); }
-    else setStep((s) => Math.max(s - 1, 0));
+    setStep((s) => Math.max(s - 1, 0));
   };
 
-  const selectDealbreaker = (level: DealbreakerLevel) => {
-    const key = DEALBREAKER_ITEMS[dbStep].key;
-    setDbSelected(level);
-    setDealbreakers((p) => ({ ...p, [key]: level }));
-    Animated.sequence([
-      Animated.timing(dbCardAnim, { toValue: 0.97, duration: 80, useNativeDriver: true }),
-      Animated.timing(dbCardAnim, { toValue: 1, duration: 100, useNativeDriver: true }),
-    ]).start();
-    setTimeout(() => {
-      setDbSelected(null);
-      if (dbStep < DEALBREAKER_ITEMS.length - 1) {
-        setDbStep((s) => s + 1);
-      } else {
-        setDbStep(0);
-        setStep((s) => s + 1);
-      }
-    }, 400);
+  const handleSkip = () => {
+    if (saving) return;
+    if (step === TOTAL_STEPS - 1) {
+      setSaving(true);
+      handleComplete();
+    } else {
+      advance();
+    }
   };
 
   const handleNext = async () => {
     if (saving) return;
-    if (step === TOTAL_STEPS - 1) { setSaving(true); await handleComplete(); return; }
+
+    if (step === TOTAL_STEPS - 1) {
+      setSaving(true);
+      await handleComplete();
+      return;
+    }
 
     setSaving(true);
     try {
-      if (step === 3) {
-        // End of about-you steps — save profile
+      if (step === 0) {
         const ok = await saveAboutYou();
-        if (!ok) { Alert.alert('Error', 'Could not save your info. Please try again.'); return; }
-      } else if (step === 14) {
+        if (!ok) {
+          Alert.alert('Error', 'Could not save your info. Please try again.');
+          return;
+        }
+      } else if (step === 7) {
         await savePrompts();
-      } else if (step === 15) {
+      } else if (step === 8) {
         const ok = await uploadPhotos();
         if (!ok) return;
       }
-      setStep((s) => Math.min(s + 1, TOTAL_STEPS - 1));
+      advance();
     } finally {
       setSaving(false);
     }
   };
 
-  // ── Validation ──────────────────────────────────────────────────────────────
+  // ── Validation ─────────────────────────────────────────────────────────────
 
   const canAdvance = (): boolean => {
     if (step === 0) return name.trim().length > 0;
-    if (step === 1) return age === '' || parseInt(age, 10) >= 18;
-    if (step === 5) {
-      if (!minBudget.trim() || !maxBudget.trim()) return false;
+    if (step === 2 && minBudget && maxBudget) {
       return parseFloat(minBudget) <= parseFloat(maxBudget);
     }
-    if (step === 15) return stagingUris.length >= 1;
+    if (step === 7) return promptAnswers.filter((p) => p.answer.trim()).length >= 2;
     return true;
   };
 
-  // ── Photo pickers ────────────────────────────────────────────────────────────
+  // ── Photo pickers ──────────────────────────────────────────────────────────
 
   const pickProfilePhoto = async () => {
     if (stagingUris.length >= 4) return;
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (status !== 'granted') { Alert.alert('Permission needed', 'Please allow photo library access.'); return; }
-    const result = await ImagePicker.launchImageLibraryAsync({ mediaTypes: 'images', quality: 0.85, allowsEditing: true, aspect: [4, 5] });
-    if (!result.canceled && result.assets[0]) setStagingUris((p) => [...p, result.assets[0].uri].slice(0, 4));
+    if (status !== 'granted') {
+      Alert.alert('Permission needed', 'Please allow photo library access.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      quality: 0.85,
+      allowsEditing: true,
+      aspect: [4, 5],
+    });
+    if (!result.canceled && result.assets[0]) {
+      setStagingUris((prev) => [...prev, result.assets[0].uri].slice(0, 4));
+    }
   };
 
   const pickListingPhoto = async () => {
     if (listingPhotos.length >= 6) return;
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (status !== 'granted') { Alert.alert('Permission needed', 'Please allow photo library access.'); return; }
-    const result = await ImagePicker.launchImageLibraryAsync({ mediaTypes: 'images', quality: 0.85 });
-    if (!result.canceled && result.assets[0]) setListingPhotos((p) => [...p, result.assets[0].uri].slice(0, 6));
+    if (status !== 'granted') {
+      Alert.alert('Permission needed', 'Please allow photo library access.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      quality: 0.85,
+    });
+    if (!result.canceled && result.assets[0]) {
+      setListingPhotos((prev) => [...prev, result.assets[0].uri].slice(0, 6));
+    }
   };
 
-  // ── Prompt helpers ────────────────────────────────────────────────────────────
+  // ── Prompt helpers ─────────────────────────────────────────────────────────
 
   const isPromptSelected = (q: string) => promptAnswers.some((p) => p.question === q);
 
-  const advancePromptCard = (direction: 'skip' | 'use') => {
-    if (direction === 'use') {
-      setPromptDraft('');
-      setPromptMode('answer');
-      return;
+  const togglePrompt = (q: string) => {
+    if (isPromptSelected(q)) {
+      setPromptAnswers((prev) => prev.filter((p) => p.question !== q));
+    } else if (promptAnswers.length < 3) {
+      setPromptAnswers((prev) => [...prev, { question: q, answer: '' }]);
     }
-    // Slide current card out left, bring next in from right
-    Animated.parallel([
-      Animated.timing(promptSlide, { toValue: -SCREEN_WIDTH, duration: 240, useNativeDriver: true }),
-      Animated.timing(promptFade,  { toValue: 0,             duration: 180, useNativeDriver: true }),
-    ]).start(() => {
-      setPromptCardIdx((i) => {
-        // Skip already-answered prompts
-        let next = (i + 1) % PROMPTS.length;
-        let tries = 0;
-        while (isPromptSelected(PROMPTS[next].question) && tries < PROMPTS.length) {
-          next = (next + 1) % PROMPTS.length;
-          tries++;
-        }
-        return next;
-      });
-      promptSlide.setValue(SCREEN_WIDTH * 0.4);
-      promptFade.setValue(0);
-      Animated.parallel([
-        Animated.timing(promptSlide, { toValue: 0, duration: 240, useNativeDriver: true }),
-        Animated.timing(promptFade,  { toValue: 1, duration: 200, useNativeDriver: true }),
-      ]).start();
-    });
   };
 
-  const savePromptAnswer = () => {
-    const answer = promptDraft.trim();
-    if (!answer) return;
-    const question = PROMPTS[promptCardIdx].question;
-    setPromptAnswers((p) => {
-      const exists = p.find((x) => x.question === question);
-      if (exists) return p.map((x) => x.question === question ? { ...x, answer } : x);
-      if (p.length >= 3) return p;
-      return [...p, { question, answer }];
-    });
-    setPromptMode('browse');
-    setPromptDraft('');
-    // Advance to next unanswered prompt
-    advancePromptCard('skip');
+  const setPromptAnswer = (q: string, answer: string) => {
+    setPromptAnswers((prev) =>
+      prev.map((p) => (p.question === q ? { ...p, answer } : p))
+    );
   };
 
-  // ── Step renders ─────────────────────────────────────────────────────────────
+  // ── Step renders ───────────────────────────────────────────────────────────
 
-  const renderStepContent = () => {
+  const renderStep = () => {
     switch (step) {
-
-      // 0: Name
       case 0:
         return (
-          <View style={styles.focusInput}>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
             <TextInput
-              style={styles.heroInput}
+              style={styles.input}
               placeholder="Your name"
-              placeholderTextColor={D.grayDim}
+              placeholderTextColor="#9AA"
               value={name}
               onChangeText={setName}
               autoCapitalize="words"
-              autoFocus
-              returnKeyType="done"
-              onSubmitEditing={() => canAdvance() && handleNext()}
-            />
-          </View>
-        );
-
-      // 1: Age
-      case 1: {
-        const ageNum = parseInt(age, 10);
-        const ageTooYoung = age.length > 0 && !isNaN(ageNum) && ageNum < 18;
-        return (
-          <View style={styles.focusInput}>
-            {ageTooYoung && (
-              <Text style={[styles.errorText, { marginBottom: 8 }]}>You must be 18 or older to use RoomPear.</Text>
-            )}
-            <TextInput
-              style={styles.heroInput}
-              placeholder="Your age"
-              placeholderTextColor={D.grayDim}
-              value={age}
-              onChangeText={(t) => {
-                const digits = t.replace(/\D/g, '');
-                if (digits === '' || parseInt(digits, 10) <= 130) setAge(digits);
-              }}
-              keyboardType="number-pad"
-              maxLength={3}
-              autoFocus
-            />
-          </View>
-        );
-      }
-
-      // 2: Gender (auto-advance)
-      case 2:
-        return (
-          <View style={styles.chipArea}>
-            {GENDER_OPTIONS.map((g) => (
-              <Chip
-                key={g}
-                label={g}
-                selected={gender === g}
-                onPress={() => { setGender(g); scheduleAutoAdvance(); }}
-              />
-            ))}
-          </View>
-        );
-
-      // 3: Ethnicity (optional)
-      case 3:
-        return (
-          <View style={styles.chipArea}>
-            {ETHNICITY_OPTIONS.map((e) => (
-              <Chip
-                key={e}
-                label={e}
-                selected={ethnicity === e}
-                onPress={() => { setEthnicity(ethnicity === e ? '' : e); scheduleAutoAdvance(); }}
-              />
-            ))}
-          </View>
-        );
-
-      // 4: Location
-      case 4: {
-        const filteredStates = US_STATES.filter(
-          (s) =>
-            s.label.toLowerCase().includes(stateSearch.toLowerCase()) ||
-            s.abbr.toLowerCase().includes(stateSearch.toLowerCase())
-        );
-        const selectedStateLabel = US_STATES.find((s) => s.abbr === locationState)?.label ?? '';
-
-        return useLegacyLocationUi ? (
-          <View style={styles.inputStack}>
-            {/* State picker trigger */}
-            <TouchableOpacity
-              style={styles.pickerBtn}
-              onPress={() => { setStateSearch(''); setShowStatePicker(true); }}
-            >
-              <Text style={locationState ? styles.pickerBtnText : styles.pickerBtnPlaceholder}>
-                {selectedStateLabel || 'Select a state'}
-              </Text>
-              <Text style={styles.pickerChevron}>▼</Text>
-            </TouchableOpacity>
-
-            {/* City — only enabled after state chosen */}
-            <TextInput
-              style={[styles.input, !locationState && styles.inputDisabled]}
-              placeholder={locationState ? `City in ${selectedStateLabel}` : 'City (choose state first)'}
-              placeholderTextColor={D.grayDim}
-              value={city}
-              onChangeText={setCity}
-              editable={!!locationState}
               returnKeyType="next"
             />
-
-            {/* ZIP — optional */}
             <TextInput
-              style={[styles.input, !locationState && styles.inputDisabled]}
-              placeholder="ZIP code (optional)"
-              placeholderTextColor={D.grayDim}
-              value={zipCode}
-              onChangeText={(t) => setZipCode(t.replace(/\D/g, '').slice(0, 5))}
-              keyboardType="number-pad"
-              editable={!!locationState}
+              style={styles.input}
+              placeholder="Age (optional)"
+              placeholderTextColor="#9AA"
+              value={age}
+              onChangeText={setAge}
+              keyboardType="numeric"
+              maxLength={3}
             />
-
-            {/* State picker modal */}
-            <Modal
-              visible={showStatePicker}
-              animationType="slide"
-              transparent
-              onRequestClose={() => setShowStatePicker(false)}
-            >
-              <View style={styles.modalOverlay}>
-                <View style={styles.modalSheet}>
-                  <View style={styles.modalHeader}>
-                    <Text style={styles.modalTitle}>Select a state</Text>
-                    <TouchableOpacity onPress={() => setShowStatePicker(false)}>
-                      <Text style={styles.modalClose}>✕</Text>
-                    </TouchableOpacity>
-                  </View>
-                  <TextInput
-                    style={styles.modalSearch}
-                    placeholder="Search states…"
-                    placeholderTextColor={D.grayDim}
-                    value={stateSearch}
-                    onChangeText={setStateSearch}
-                    autoFocus
-                  />
-                  <FlatList
-                    data={filteredStates}
-                    keyExtractor={(s) => s.abbr}
-                    keyboardShouldPersistTaps="handled"
-                    renderItem={({ item }) => (
-                      <TouchableOpacity
-                        style={[styles.stateRow, locationState === item.abbr && styles.stateRowSelected]}
-                        onPress={() => {
-                          setLocationState(item.abbr);
-                          setCity('');
-                          setShowStatePicker(false);
-                        }}
-                      >
-                        <Text style={[styles.stateRowText, locationState === item.abbr && styles.stateRowTextSelected]}>
-                          {item.label}
-                        </Text>
-                        <Text style={styles.stateRowAbbr}>{item.abbr}</Text>
-                      </TouchableOpacity>
-                    )}
-                  />
-                </View>
-              </View>
-            </Modal>
-          </View>
-        ) : (
-          <Suspense fallback={<ActivityIndicator color={D.lime} style={{ marginVertical: 24 }} />}>
-            <SearchAreaMapPicker onChange={setSearchArea} />
-          </Suspense>
+            <Text style={styles.sectionLabel}>Gender</Text>
+            <View style={styles.chipRow}>
+              {GENDER_OPTIONS.map((g) => (
+                <Chip
+                  key={g}
+                  label={g}
+                  selected={gender === g}
+                  onPress={() => setGender(gender === g ? '' : g)}
+                />
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Ethnicity (optional)</Text>
+            <View style={styles.chipRow}>
+              {ETHNICITY_OPTIONS.map((e) => (
+                <Chip
+                  key={e}
+                  label={e}
+                  selected={ethnicity === e}
+                  onPress={() => setEthnicity(ethnicity === e ? '' : e)}
+                />
+              ))}
+            </View>
+          </ScrollView>
         );
-      }
 
-      // 5: Budget
-      case 5: {
+      case 1:
+        return (
+          <View style={styles.stepBody}>
+            <TextInput
+              style={styles.input}
+              placeholder="City"
+              placeholderTextColor="#9AA"
+              value={city}
+              onChangeText={setCity}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="State (e.g. CA)"
+              placeholderTextColor="#9AA"
+              value={locationState}
+              onChangeText={setLocationState}
+              autoCapitalize="characters"
+              maxLength={2}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="ZIP code (optional)"
+              placeholderTextColor="#9AA"
+              value={zipCode}
+              onChangeText={setZipCode}
+              keyboardType="numeric"
+              maxLength={5}
+            />
+          </View>
+        );
+
+      case 2: {
         const budgetError =
           minBudget && maxBudget && parseFloat(minBudget) > parseFloat(maxBudget)
-            ? 'Max budget must be greater than or equal to min'
+            ? 'Min budget cannot exceed max budget'
             : '';
-        const kbType = Platform.OS === 'ios' ? 'number-pad' : 'numeric';
+        const budgetKeyboardType = Platform.OS === 'ios' ? 'number-pad' : 'numeric';
         return (
-          <View style={styles.inputStack}>
+          <ScrollView
+            style={styles.stepBody}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            keyboardDismissMode="on-drag"
+          >
             <TextInput
               style={styles.input}
               placeholder="Min / month ($)"
-              placeholderTextColor={D.grayDim}
+              placeholderTextColor="#9AA"
               value={minBudget}
               onChangeText={setMinBudget}
-              keyboardType={kbType}
-              autoFocus
+              keyboardType={budgetKeyboardType}
+              returnKeyType="next"
+              blurOnSubmit={false}
+              onSubmitEditing={() => maxBudgetInputRef.current?.focus()}
             />
             <TextInput
-              ref={maxBudgetRef}
+              ref={maxBudgetInputRef}
               style={styles.input}
               placeholder="Max / month ($)"
-              placeholderTextColor={D.grayDim}
+              placeholderTextColor="#9AA"
               value={maxBudget}
               onChangeText={setMaxBudget}
-              keyboardType={kbType}
+              keyboardType={budgetKeyboardType}
+              returnKeyType="done"
             />
             {!!budgetError && <Text style={styles.errorText}>{budgetError}</Text>}
-          </View>
+          </ScrollView>
         );
       }
 
-      // 6: Room type (auto-advance)
-      case 6:
-        return (
-          <View style={styles.chipArea}>
-            {[
-              { val: 'private',  label: 'Private Room' },
-              { val: 'shared',   label: 'Shared Room' },
-              { val: 'flexible', label: 'Either works' },
-              { val: 'entire',   label: 'Entire Place' },
-            ].map(({ val, label }) => (
-              <Chip
-                key={val}
-                label={label}
-                selected={roomType === val}
-                onPress={() => { setRoomType(val); scheduleAutoAdvance(); }}
-              />
-            ))}
-          </View>
-        );
-
-      // 7: Move-in date
-      case 7: {
+      case 3: {
         const tomorrow = new Date();
         tomorrow.setDate(tomorrow.getDate() + 1);
         tomorrow.setHours(0, 0, 0, 0);
         return (
-          <View style={styles.inputStack}>
-            {Platform.OS === 'ios' ? (
-              <View style={styles.datePickerWrap}>
-                <DateTimePicker
-                  value={moveInDate ?? tomorrow}
-                  mode="date"
-                  display="spinner"
-                  minimumDate={tomorrow}
-                  themeVariant="light"
-                  style={{ width: '100%' }}
-                  onChange={(_, date) => { if (date) setMoveInDate(date); }}
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false}>
+            <Text style={styles.sectionLabel}>Room type</Text>
+            <View style={styles.chipRow}>
+              {[
+                { val: 'private',  label: 'Private Room' },
+                { val: 'shared',   label: 'Shared Room' },
+                { val: 'flexible', label: 'Either' },
+                { val: 'entire',   label: 'Entire Place' },
+              ].map(({ val, label }) => (
+                <Chip
+                  key={val}
+                  label={label}
+                  selected={roomType === val}
+                  onPress={() => setRoomType(roomType === val ? '' : val)}
                 />
-              </View>
-            ) : (
-              <>
-                <TouchableOpacity style={styles.dateBtn} onPress={() => setShowDatePicker(true)}>
-                  <Text style={[styles.dateBtnText, !moveInDate && styles.dateBtnPlaceholder]}>
-                    {moveInDate ? formatDateDisplay(moveInDate) : 'Select a date'}
-                  </Text>
-                </TouchableOpacity>
-                {showDatePicker && (
-                  <DateTimePicker
-                    value={moveInDate ?? tomorrow}
-                    mode="date"
-                    display="default"
-                    minimumDate={tomorrow}
-                    onChange={(event, date) => {
-                      setShowDatePicker(false);
-                      if (event.type === 'set' && date) { const d = new Date(date); d.setHours(0,0,0,0); if (d > new Date()) setMoveInDate(date); }
-                    }}
-                  />
-                )}
-              </>
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Move-in date (optional)</Text>
+            <TouchableOpacity style={styles.dateBtn} onPress={() => setShowDatePicker(true)}>
+              <Text style={[styles.dateBtnText, !moveInDate && styles.dateBtnPlaceholder]}>
+                {moveInDate ? formatDateDisplay(moveInDate) : 'Select a date'}
+              </Text>
+            </TouchableOpacity>
+            {showDatePicker && (
+              <DateTimePicker
+                value={moveInDate ?? tomorrow}
+                mode="date"
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                minimumDate={tomorrow}
+                onChange={(event, date) => {
+                  if (Platform.OS === 'android') {
+                    setShowDatePicker(false);
+                    if (event.type === 'set' && date) {
+                      const d = new Date(date);
+                      d.setHours(0, 0, 0, 0);
+                      if (d > new Date()) setMoveInDate(date);
+                    }
+                  } else if (date) {
+                    setMoveInDate(date);
+                  }
+                }}
+              />
             )}
-          </View>
+            {Platform.OS === 'ios' && showDatePicker && (
+              <TouchableOpacity style={styles.dateDoneBtn} onPress={() => setShowDatePicker(false)}>
+                <Text style={styles.dateDoneBtnText}>Done</Text>
+              </TouchableOpacity>
+            )}
+          </ScrollView>
         );
       }
 
-      // 8: Cleanliness (auto-advance)
-      case 8:
+      case 4:
         return (
-          <View style={styles.scaleArea}>
-            <View style={styles.scaleLabels}>
-              <Text style={styles.scaleLabel}>Relaxed</Text>
-              <Text style={styles.scaleLabel}>Spotless</Text>
-            </View>
-            <View style={styles.scaleChips}>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.sectionLabel}>Cleanliness (1 = relaxed · 5 = spotless)</Text>
+            <View style={styles.chipRow}>
               {[1, 2, 3, 4, 5].map((n) => (
-                <TouchableOpacity
+                <Chip
                   key={n}
-                  style={[styles.scaleChip, cleanliness === n && styles.scaleChipSelected]}
-                  onPress={() => {
-                    setCleanliness(n);
-                    scheduleAutoAdvance();
-                  }}
-                >
-                  <Text style={[styles.scaleChipText, cleanliness === n && styles.scaleChipTextSelected]}>{n}</Text>
-                </TouchableOpacity>
+                  label={String(n)}
+                  selected={cleanliness === n}
+                  onPress={() => setCleanliness(cleanliness === n ? null : n)}
+                />
               ))}
             </View>
-          </View>
-        );
-
-      // 9: Work schedule (auto-advance)
-      case 9:
-        return (
-          <View style={styles.chipArea}>
-            {[
-              { val: '9-to-5',    label: '9 to 5' },
-              { val: 'Remote',    label: 'Remote / WFH' },
-              { val: 'Night Shift', label: 'Night Shift' },
-              { val: 'Flexible',  label: 'Flexible' },
-            ].map(({ val, label }) => (
-              <Chip
-                key={val}
-                label={label}
-                selected={workSchedule === val}
-                onPress={() => {
-                  setWorkSchedule(val);
-                  scheduleAutoAdvance();
-                }}
-              />
-            ))}
-          </View>
-        );
-
-      // 10: Social vibe (auto-advance)
-      case 10:
-        return (
-          <View style={styles.chipArea}>
-            {[
-              { val: 'Social Butterfly', label: 'Social Butterfly' },
-              { val: 'Balanced',         label: 'Balanced' },
-              { val: 'Homebody',         label: 'Homebody' },
-            ].map(({ val, label }) => (
-              <Chip
-                key={val}
-                label={label}
-                selected={socialPref === val}
-                onPress={() => {
-                  setSocialPref(val);
-                  scheduleAutoAdvance();
-                }}
-              />
-            ))}
-          </View>
-        );
-
-      // 11: Pets & Smoking
-      case 11:
-        return (
-          <View style={styles.yesNoArea}>
-            <View style={styles.yesNoRow}>
-              <Text style={styles.yesNoLabel}>Pets okay?</Text>
-              <View style={styles.yesNoChips}>
-                <Chip label="Yes" selected={petsAllowed === true}  onPress={() => setPetsAllowed(petsAllowed === true ? null : true)} />
-                <Chip label="No"  selected={petsAllowed === false} onPress={() => setPetsAllowed(petsAllowed === false ? null : false)} />
-              </View>
-            </View>
-            <View style={styles.yesNoRow}>
-              <Text style={styles.yesNoLabel}>Smoking okay?</Text>
-              <View style={styles.yesNoChips}>
-                <Chip label="Yes" selected={smokingAllowed === true}  onPress={() => setSmokingAllowed(smokingAllowed === true ? null : true)} />
-                <Chip label="No"  selected={smokingAllowed === false} onPress={() => setSmokingAllowed(smokingAllowed === false ? null : false)} />
-              </View>
-            </View>
-          </View>
-        );
-
-      // 12: Dealbreakers (card sub-flow — one question at a time)
-      case 12:
-        return (
-          <Animated.View style={[styles.dbCardArea, { transform: [{ scale: dbCardAnim }] }]}>
-            {/* Sub-progress dots */}
-            <View style={styles.dbDots}>
-              {DEALBREAKER_ITEMS.map((_, i) => (
-                <View key={i} style={[styles.dbDot, i === dbStep && styles.dbDotActive, i < dbStep && styles.dbDotDone]} />
+            <Text style={styles.sectionLabel}>Work schedule</Text>
+            <View style={styles.chipRow}>
+              {['9-to-5', 'Remote', 'Night Shift', 'Flexible'].map((s) => (
+                <Chip
+                  key={s}
+                  label={s}
+                  selected={workSchedule === s}
+                  onPress={() => setWorkSchedule(workSchedule === s ? '' : s)}
+                />
               ))}
             </View>
-
-            {/* Option cards */}
-            {DB_OPTIONS.map(({ level, label, sublabel }) => {
-              const isSelected = dbSelected === level;
-              return (
-                <TouchableOpacity
-                  key={level}
-                  style={[
-                    styles.dbCard,
-                    isSelected && level === 'hard' && styles.dbCardHard,
-                    isSelected && level === 'soft' && styles.dbCardSoft,
-                    isSelected && level === 'none' && styles.dbCardNone,
-                  ]}
-                  onPress={() => selectDealbreaker(level)}
-                  activeOpacity={0.8}
-                >
-                  <View style={styles.dbCardText}>
-                    <Text style={[styles.dbCardLabel, isSelected && styles.dbCardLabelSelected]}>{label}</Text>
-                    <Text style={styles.dbCardSub}>{sublabel}</Text>
-                  </View>
-                </TouchableOpacity>
-              );
-            })}
-          </Animated.View>
+            <Text style={styles.sectionLabel}>Social vibe</Text>
+            <View style={styles.chipRow}>
+              {['Social Butterfly', 'Balanced', 'Homebody'].map((s) => (
+                <Chip
+                  key={s}
+                  label={s}
+                  selected={socialPref === s}
+                  onPress={() => setSocialPref(socialPref === s ? '' : s)}
+                />
+              ))}
+            </View>
+            <Text style={styles.sectionLabel}>Pets</Text>
+            <View style={styles.chipRow}>
+              <Chip label="Yes" selected={petsAllowed === true} onPress={() => setPetsAllowed(petsAllowed === true ? null : true)} />
+              <Chip label="No"  selected={petsAllowed === false} onPress={() => setPetsAllowed(petsAllowed === false ? null : false)} />
+            </View>
+            <Text style={styles.sectionLabel}>Smoking</Text>
+            <View style={styles.chipRow}>
+              <Chip label="Yes" selected={smokingAllowed === true} onPress={() => setSmokingAllowed(smokingAllowed === true ? null : true)} />
+              <Chip label="No"  selected={smokingAllowed === false} onPress={() => setSmokingAllowed(smokingAllowed === false ? null : false)} />
+            </View>
+          </ScrollView>
         );
 
-      // 13: Interests
-      case 13:
+      case 5:
         return (
-          <ScrollView style={styles.scrollArea} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false}>
+            <Text style={styles.hint}>Tap each row to set your preference.</Text>
+            {DEALBREAKER_ITEMS.map(({ key, label }) => (
+              <View key={key} style={styles.dbRow}>
+                <Text style={styles.dbLabel}>{label}</Text>
+                <View style={styles.dbChips}>
+                  {(['hard', 'soft', 'none'] as DealbreakerLevel[]).map((level) => {
+                    const selected = dealbreakers[key] === level;
+                    return (
+                      <TouchableOpacity
+                        key={level}
+                        style={[
+                          styles.dbChip,
+                          selected && level === 'hard' && styles.dbChipHard,
+                          selected && level === 'soft' && styles.dbChipSoft,
+                          selected && level === 'none' && styles.dbChipNone,
+                        ]}
+                        onPress={() => setDealbreakers((prev) => ({ ...prev, [key]: level }))}
+                      >
+                        <Text style={[styles.dbChipText, selected && styles.dbChipTextSelected]}>
+                          {level.charAt(0).toUpperCase() + level.slice(1)}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+        );
+
+      case 6:
+        return (
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
             {INTEREST_CATEGORIES.map(({ key, label, options }) => {
               const isOpen = expandedCategory === key;
               const selected = interests[key] ?? [];
               return (
                 <View key={key} style={styles.catBlock}>
-                  <TouchableOpacity style={styles.catHeader} onPress={() => setExpandedCategory(isOpen ? null : key)}>
-                    <Text style={styles.catLabel}>{label}{selected.length > 0 ? `  (${selected.length})` : ''}</Text>
+                  <TouchableOpacity
+                    style={styles.catHeader}
+                    onPress={() => setExpandedCategory(isOpen ? null : key)}
+                  >
+                    <Text style={styles.catLabel}>
+                      {label}{selected.length > 0 ? `  (${selected.length})` : ''}
+                    </Text>
                     <Text style={styles.catChevron}>{isOpen ? '▲' : '▼'}</Text>
                   </TouchableOpacity>
                   {isOpen && (
@@ -1075,32 +796,34 @@ export default function OnboardingScreen({ onComplete }: Props) {
                             label={opt}
                             selected={selected.includes(opt)}
                             disabled={!selected.includes(opt) && selected.length >= 5}
-                            onPress={() => setInterests((p) => {
-                              const cur = p[key] ?? [];
-                              if (cur.includes(opt)) return { ...p, [key]: cur.filter((i) => i !== opt) };
-                              if (cur.length >= 5) return p;
-                              return { ...p, [key]: [...cur, opt] };
-                            })}
+                            onPress={() => {
+                              setInterests((prev) => {
+                                const cur = prev[key] ?? [];
+                                if (cur.includes(opt)) return { ...prev, [key]: cur.filter((i) => i !== opt) };
+                                if (cur.length >= 5) return prev;
+                                return { ...prev, [key]: [...cur, opt] };
+                              });
+                            }}
                           />
                         ))}
                       </View>
                       <View style={styles.customInputRow}>
                         <TextInput
                           style={styles.customInput}
-                          placeholder="+ Add your own"
-                          placeholderTextColor={D.grayDim}
+                          placeholder="+ Add custom"
+                          placeholderTextColor="#9AA"
                           value={customInputs[key]}
-                          onChangeText={(t) => setCustomInputs((p) => ({ ...p, [key]: t }))}
+                          onChangeText={(t) => setCustomInputs((prev) => ({ ...prev, [key]: t }))}
                           returnKeyType="done"
                           onSubmitEditing={() => {
                             const val = customInputs[key].trim();
                             if (!val) return;
-                            setInterests((p) => {
-                              const cur = p[key] ?? [];
-                              if (cur.includes(val) || cur.length >= 5) return p;
-                              return { ...p, [key]: [...cur, val] };
+                            setInterests((prev) => {
+                              const cur = prev[key] ?? [];
+                              if (cur.includes(val) || cur.length >= 5) return prev;
+                              return { ...prev, [key]: [...cur, val] };
                             });
-                            setCustomInputs((p) => ({ ...p, [key]: '' }));
+                            setCustomInputs((prev) => ({ ...prev, [key]: '' }));
                           }}
                         />
                       </View>
@@ -1112,156 +835,60 @@ export default function OnboardingScreen({ onComplete }: Props) {
           </ScrollView>
         );
 
-      // 14: Prompts (card sub-flow)
-      case 14: {
-        const currentPrompt = PROMPTS[promptCardIdx];
-        const done = promptAnswers.length;
-        const maxDone = done >= 3;
-
-        if (promptMode === 'answer') {
-          return (
-            <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-              <ScrollView style={styles.scrollArea} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
-                <Text style={styles.pAnswerQuestion}>{currentPrompt.question}</Text>
-
-                {/* Suggestions */}
-                <Text style={styles.pSuggestLabel}>Tap a suggestion or write your own</Text>
-                <View style={styles.pSuggestList}>
-                  {currentPrompt.suggestions.map((s) => (
-                    <TouchableOpacity
-                      key={s}
-                      style={[styles.pSuggestChip, promptDraft === s && styles.pSuggestChipActive]}
-                      onPress={() => setPromptDraft(s)}
-                      activeOpacity={0.75}
-                    >
-                      <Text style={[styles.pSuggestText, promptDraft === s && styles.pSuggestTextActive]}>{s}</Text>
-                    </TouchableOpacity>
-                  ))}
-                </View>
-
-                {/* Custom input */}
-                <TextInput
-                  style={styles.pDraftInput}
-                  placeholder="Write your own answer…"
-                  placeholderTextColor={D.grayDim}
-                  value={promptDraft}
-                  onChangeText={setPromptDraft}
-                  multiline
-                  maxLength={300}
-                  autoFocus={currentPrompt.suggestions.length === 1}
-                />
-                <Text style={styles.pCharCount}>{promptDraft.length} / 300</Text>
-
-                {/* Save button */}
-                <TouchableOpacity
-                  style={[styles.pSaveBtn, !promptDraft.trim() && styles.pSaveBtnDisabled]}
-                  onPress={savePromptAnswer}
-                  disabled={!promptDraft.trim()}
-                  activeOpacity={0.8}
-                >
-                  <Text style={styles.pSaveBtnText}>Save answer</Text>
-                </TouchableOpacity>
-              </ScrollView>
-            </KeyboardAvoidingView>
-          );
-        }
-
-        // Browse mode
+      case 7:
         return (
-          <View style={{ flex: 1 }}>
-            {/* Progress */}
-            <View style={styles.pProgressRow}>
-              {[0, 1, 2].map((i) => (
-                <View key={i} style={[styles.pProgressDot, i < done && styles.pProgressDotDone]} />
-              ))}
-              <Text style={styles.pProgressText}>
-                {done === 0 ? 'Pick up to 3 prompts' : done === 3 ? '3 / 3 — you\'re done!' : `${done} / 3 completed`}
-              </Text>
-            </View>
-
-            {/* Card */}
-            <Animated.View
-              style={[styles.pCard, { opacity: promptFade, transform: [{ translateX: promptSlide }] }]}
-            >
-              <Text style={styles.pCardQuestion}>{currentPrompt.question}</Text>
-              {isPromptSelected(currentPrompt.question) && (
-                <View style={styles.pCardDoneBadge}>
-                  <Text style={styles.pCardDoneBadgeText}>Answered</Text>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.hint}>Tap a prompt to select it, then write your answer.</Text>
+            <Text style={styles.promptCount}>
+              {(() => {
+                const answered = promptAnswers.filter((p) => p.answer.trim()).length;
+                if (answered === 0) return 'Answer at least 2 (max 3)';
+                if (answered < 2) return `${answered} / 2 — need 1 more`;
+                if (answered === 3) return 'All done!';
+                return `${answered} / 3 — you can add one more`;
+              })()}
+            </Text>
+            {PROMPTS.map((q) => {
+              const selected = isPromptSelected(q);
+              const entry = promptAnswers.find((p) => p.question === q);
+              const maxReached = !selected && promptAnswers.length >= 3;
+              return (
+                <View key={q} style={styles.promptBlock}>
+                  <TouchableOpacity
+                    style={[styles.promptRow, selected && styles.promptRowSelected, maxReached && styles.promptRowDimmed]}
+                    onPress={() => !maxReached && togglePrompt(q)}
+                    activeOpacity={maxReached ? 1 : 0.7}
+                  >
+                    <Text style={[styles.promptText, selected && styles.promptTextSelected]}>{q}</Text>
+                    {selected && <Text style={styles.promptCheck}>✓</Text>}
+                  </TouchableOpacity>
+                  {selected && (
+                    <TextInput
+                      style={styles.promptInput}
+                      placeholder="Your answer…"
+                      placeholderTextColor="#9AA"
+                      value={entry?.answer ?? ''}
+                      onChangeText={(t) => setPromptAnswer(q, t)}
+                      multiline
+                      maxLength={300}
+                    />
+                  )}
                 </View>
-              )}
-            </Animated.View>
-
-            {/* Actions */}
-            <View style={styles.pActions}>
-              <TouchableOpacity style={styles.pSkipBtn} onPress={() => advancePromptCard('skip')} activeOpacity={0.7}>
-                <Text style={styles.pSkipBtnText}>Skip</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.pUseBtn, maxDone && styles.pUseBtnDisabled]}
-                onPress={() => !maxDone && advancePromptCard('use')}
-                disabled={maxDone}
-                activeOpacity={0.8}
-              >
-                <Text style={styles.pUseBtnText}>{maxDone ? 'All done!' : 'Use this prompt'}</Text>
-              </TouchableOpacity>
-            </View>
-
-            {/* Browse all link */}
-            <TouchableOpacity style={styles.pBrowseAllBtn} onPress={() => setPromptBrowseAll(true)}>
-              <Text style={styles.pBrowseAllText}>Browse all prompts</Text>
-            </TouchableOpacity>
-
-            {/* Browse all modal */}
-            <Modal visible={promptBrowseAll} animationType="slide" transparent onRequestClose={() => setPromptBrowseAll(false)}>
-              <View style={styles.pAllModalRoot}>
-                <View style={styles.pAllModalSheet}>
-                  <View style={styles.pAllModalHeader}>
-                    <Text style={styles.pAllModalTitle}>All prompts</Text>
-                    <TouchableOpacity onPress={() => setPromptBrowseAll(false)}>
-                      <Text style={styles.pAllModalClose}>Done</Text>
-                    </TouchableOpacity>
-                  </View>
-                  <ScrollView style={styles.pAllModalScroll} showsVerticalScrollIndicator={false}>
-                    {PROMPTS.map((p, i) => {
-                      const selected = isPromptSelected(p.question);
-                      const disabled = !selected && maxDone;
-                      return (
-                        <TouchableOpacity
-                          key={i}
-                          style={[styles.pAllRow, selected && styles.pAllRowSelected, disabled && styles.pAllRowDisabled]}
-                          onPress={() => {
-                            if (disabled) return;
-                            setPromptCardIdx(i);
-                            setPromptBrowseAll(false);
-                            setPromptDraft('');
-                            setPromptMode('answer');
-                          }}
-                          activeOpacity={0.7}
-                        >
-                          <Text style={[styles.pAllRowText, selected && styles.pAllRowTextSelected]}>{p.question}</Text>
-                          {selected && <Text style={styles.pAllRowCheck}>✓</Text>}
-                        </TouchableOpacity>
-                      );
-                    })}
-                  </ScrollView>
-                </View>
-              </View>
-            </Modal>
-          </View>
+              );
+            })}
+          </ScrollView>
         );
-      }
 
-      // 15: Photos
-      case 15:
+      case 8:
         return (
-          <ScrollView style={styles.scrollArea} showsVerticalScrollIndicator={false}>
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false}>
             <PublicProfileCard
               imageUrls={stagingUris}
               name={name.trim() || 'Your name'}
               age={age ? parseInt(age, 10) : null}
               location={[city.trim(), locationState.trim()].filter(Boolean).join(', ')}
             />
-            <Text style={[styles.hint, { marginTop: 14 }]}>Add up to 4 photos. Tap + to add.</Text>
+            <Text style={[styles.hint, { marginTop: 16 }]}>Add up to 4 photos. Tap + to add more.</Text>
             <View style={styles.photoGrid}>
               {stagingUris.map((uri, i) => (
                 <View key={i} style={[styles.photoThumb, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}>
@@ -1272,7 +899,10 @@ export default function OnboardingScreen({ onComplete }: Props) {
                 </View>
               ))}
               {stagingUris.length < 4 && (
-                <TouchableOpacity style={[styles.photoAdd, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]} onPress={pickProfilePhoto}>
+                <TouchableOpacity
+                  style={[styles.photoAdd, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}
+                  onPress={pickProfilePhoto}
+                >
                   <Text style={styles.photoAddIcon}>+</Text>
                   <Text style={styles.photoAddLabel}>Add photo</Text>
                 </TouchableOpacity>
@@ -1282,26 +912,46 @@ export default function OnboardingScreen({ onComplete }: Props) {
           </ScrollView>
         );
 
-      // 16: Listing (optional)
-      case 16:
+      case 9:
         return (
-          <ScrollView style={styles.scrollArea} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+          <ScrollView style={styles.stepBody} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.hint}>Only fill this in if you have a room or place to offer.</Text>
             <View style={styles.chipRow}>
-              <Chip label="Yes, I have a place to list" selected={hasListing} onPress={() => setHasListing(!hasListing)} />
+              <Chip
+                label="I have a place to list"
+                selected={hasListing}
+                onPress={() => setHasListing(!hasListing)}
+              />
             </View>
             {hasListing && (
               <View>
-                <TextInput style={styles.input} placeholder="Monthly rent ($)" placeholderTextColor={D.grayDim} value={listingRent} onChangeText={setListingRent} keyboardType="numeric" />
+                <TextInput
+                  style={styles.input}
+                  placeholder="Monthly rent ($)"
+                  placeholderTextColor="#9AA"
+                  value={listingRent}
+                  onChangeText={setListingRent}
+                  keyboardType="numeric"
+                />
                 <Text style={styles.sectionLabel}>Room type</Text>
                 <View style={styles.chipRow}>
-                  {[{ val: 'private', label: 'Private Room' }, { val: 'shared', label: 'Shared Room' }, { val: 'entire', label: 'Entire Place' }].map(({ val, label }) => (
-                    <Chip key={val} label={label} selected={listingRoomType === val} onPress={() => setListingRoomType(listingRoomType === val ? '' : val)} />
+                  {[
+                    { val: 'private', label: 'Private Room' },
+                    { val: 'shared',  label: 'Shared Room' },
+                    { val: 'entire',  label: 'Entire Place' },
+                  ].map(({ val, label }) => (
+                    <Chip
+                      key={val}
+                      label={label}
+                      selected={listingRoomType === val}
+                      onPress={() => setListingRoomType(listingRoomType === val ? '' : val)}
+                    />
                   ))}
                 </View>
-                <TextInput style={styles.input} placeholder="Address" placeholderTextColor={D.grayDim} value={listingAddress} onChangeText={setListingAddress} />
-                <TextInput style={styles.input} placeholder="City" placeholderTextColor={D.grayDim} value={listingCity} onChangeText={setListingCity} />
-                <TextInput style={styles.input} placeholder="State (e.g. CA)" placeholderTextColor={D.grayDim} value={listingStateVal} onChangeText={setListingStateVal} autoCapitalize="characters" maxLength={2} />
-                <TextInput style={styles.input} placeholder="ZIP code" placeholderTextColor={D.grayDim} value={listingZip} onChangeText={setListingZip} keyboardType="numeric" maxLength={5} />
+                <TextInput style={styles.input} placeholder="Address" placeholderTextColor="#9AA" value={listingAddress} onChangeText={setListingAddress} />
+                <TextInput style={styles.input} placeholder="City" placeholderTextColor="#9AA" value={listingCity} onChangeText={setListingCity} />
+                <TextInput style={styles.input} placeholder="State (e.g. CA)" placeholderTextColor="#9AA" value={listingStateVal} onChangeText={setListingStateVal} autoCapitalize="characters" maxLength={2} />
+                <TextInput style={styles.input} placeholder="ZIP code" placeholderTextColor="#9AA" value={listingZip} onChangeText={setListingZip} keyboardType="numeric" maxLength={5} />
                 <Text style={styles.sectionLabel}>Photos (up to 6)</Text>
                 <View style={styles.photoGrid}>
                   {listingPhotos.map((uri, i) => (
@@ -1313,7 +963,10 @@ export default function OnboardingScreen({ onComplete }: Props) {
                     </View>
                   ))}
                   {listingPhotos.length < 6 && (
-                    <TouchableOpacity style={[styles.photoAdd, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]} onPress={pickListingPhoto}>
+                    <TouchableOpacity
+                      style={[styles.photoAdd, { width: PHOTO_THUMB, height: PHOTO_THUMB * 1.25 }]}
+                      onPress={pickListingPhoto}
+                    >
                       <Text style={styles.photoAddIcon}>+</Text>
                       <Text style={styles.photoAddLabel}>Add photo</Text>
                     </TouchableOpacity>
@@ -1329,617 +982,469 @@ export default function OnboardingScreen({ onComplete }: Props) {
     }
   };
 
-  // ── Render ────────────────────────────────────────────────────────────────────
+  // ── Render ─────────────────────────────────────────────────────────────────
 
   const isLastStep = step === TOTAL_STEPS - 1;
-  const progress = step === 12
-    ? (12 + (dbStep + 1) / DEALBREAKER_ITEMS.length) / TOTAL_STEPS
-    : (step + 1) / TOTAL_STEPS;
-  const StepIcon  = step === 12 ? null : STEPS[step].icon;
-  const question  = step === 12 ? DEALBREAKER_ITEMS[dbStep].question : STEPS[step].question;
-  const subtitle  = step === 12 ? `${dbStep + 1} of ${DEALBREAKER_ITEMS.length}` : STEPS[step].subtitle;
-  const isScrollStep = step > 12;
+  const progress = (step + 1) / TOTAL_STEPS;
 
   return (
     <SafeAreaView style={styles.root} edges={['top', 'bottom']}>
-      {/* ── Gradient + blur background (matches profile screen) ── */}
-      <LinearGradient
-        colors={['#1A3329', '#2D4F42', '#5A806B', '#9CB8A8', '#D8E8DF', '#F5FAF7', '#FFFFFF']}
-        locations={[0, 0.06, 0.14, 0.28, 0.48, 0.72, 1]}
-        start={{ x: 0.5, y: 0 }}
-        end={{ x: 0.5, y: 1 }}
-        style={StyleSheet.absoluteFill}
-      />
-      <BlurView
-        intensity={Platform.OS === 'ios' ? 52 : 34}
-        tint={Platform.OS === 'ios' ? 'systemUltraThinMaterial' : 'light'}
-        style={StyleSheet.absoluteFill}
-        pointerEvents="none"
-      />
-      <KeyboardAvoidingView style={styles.flex} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-
-        {/* ── Header ── */}
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* Header: back arrow + progress bar */}
         <View style={styles.header}>
-          <TouchableOpacity style={styles.backBtn} onPress={handleBack} disabled={step === 0 || saving}>
+          <TouchableOpacity
+            style={styles.backBtn}
+            onPress={handleBack}
+            disabled={step === 0 || saving}
+          >
             {step > 0 && <Text style={styles.backBtnText}>←</Text>}
           </TouchableOpacity>
           <View style={styles.progressWrap}>
             <View style={styles.progressTrack}>
               <View style={[styles.progressFill, { width: `${progress * 100}%` as any }]} />
             </View>
+            <Text style={styles.progressLabel}>{step + 1} of {TOTAL_STEPS}</Text>
           </View>
+          <View style={styles.backBtn} />
         </View>
 
-        {/* ── Question block — hidden in prompt answer mode ── */}
-        {!(step === 14 && promptMode === 'answer') && (
-          <View style={styles.questionBlock}>
-            {StepIcon && <StepIcon size={52} color={D.lime} weight="duotone" />}
-            <Text style={styles.stepQuestion}>{question}</Text>
-            <Text style={styles.stepSubtitle}>{subtitle}</Text>
-          </View>
-        )}
-
-        {/* ── Step content ── */}
-        <View style={isScrollStep ? styles.scrollWrapper : styles.inputWrapper}>
-          {renderStepContent()}
+        {/* Step title + subtitle */}
+        <View style={styles.titleBlock}>
+          <Text style={styles.stepTitle}>{STEP_TITLES[step]}</Text>
+          <Text style={styles.stepSubtitle}>{STEP_SUBTITLES[step]}</Text>
         </View>
 
-        {/* ── Footer — hidden in prompt answer mode ── */}
-        {!AUTO_ADVANCE_STEPS.has(step) && !(step === 14 && promptMode === 'answer') && (
-          <View style={styles.footer}>
-            <TouchableOpacity
-              style={[styles.nextBtn, (!canAdvance() || saving) && styles.nextBtnDisabled]}
-              onPress={handleNext}
-              disabled={!canAdvance() || saving}
-            >
-              {saving
-                ? <ActivityIndicator color="#0F1A00" />
-                : <Text style={styles.nextBtnText}>{isLastStep ? 'Finish' : 'Continue'}</Text>
-              }
-            </TouchableOpacity>
-          </View>
-        )}
+        {/* Step content */}
+        {renderStep()}
 
+        {/* Footer buttons */}
+        <View style={styles.footer}>
+          <TouchableOpacity style={styles.skipBtn} onPress={handleSkip} disabled={saving}>
+            <Text style={styles.skipBtnText}>{isLastStep ? 'Finish' : 'Skip'}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.nextBtn, (!canAdvance() || saving) && styles.nextBtnDisabled]}
+            onPress={handleNext}
+            disabled={!canAdvance() || saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#FDFDFD" />
+            ) : (
+              <Text style={styles.nextBtnText}>{isLastStep ? 'Done' : 'Next'}</Text>
+            )}
+          </TouchableOpacity>
+        </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
 
-// ─── Theme — matches profile-design branch ────────────────────────────────────
-
-const D = {
-  bg:            'transparent',
-  surface:       'rgba(255,255,255,0.82)',   // glass card
-  section:       'rgba(255,255,255,0.55)',
-  surfaceBorder: 'rgba(255,255,255,0.45)',
-  inputBg:       'rgba(255,255,255,0.60)',
-  inputBorder:   'rgba(0,0,0,0.06)',
-  white:         '#1A2C24',                  // dark forest text (matches profile)
-  gray:          '#717182',
-  grayDim:       '#A0A0B0',
-  lime:          '#030213',                  // near-black for buttons/accents
-  limeDark:      '#000000',
-  selectedBg:    '#030213',
-  selectedBorder:'#030213',
-  red:           '#D4183D',
-  orange:        '#FF9500',
-  trackBg:       'rgba(255,255,255,0.35)',
-};
-
 // ─── Styles ───────────────────────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
-  root:  { flex: 1, backgroundColor: '#1A3329' },
-  flex:  { flex: 1 },
+  root: {
+    flex: 1,
+    backgroundColor: '#E8EEF2',
+  },
+  flex: {
+    flex: 1,
+  },
 
   // Header
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 12,
-    gap: 12,
-  },
-  backBtn: { width: 36, height: 36, justifyContent: 'center', alignItems: 'center' },
-  backBtnText: { fontSize: 22, color: 'rgba(255,255,255,0.90)' },
-  progressWrap: { flex: 1 },
-  progressTrack: {
-    height: 5,
-    backgroundColor: D.trackBg,
-    borderRadius: 3,
-    overflow: 'hidden',
-  },
-  progressFill: { height: '100%', backgroundColor: D.lime, borderRadius: 3 },
-  stepCounter: { fontSize: 12, color: D.gray, fontWeight: '600', minWidth: 38, textAlign: 'right' },
-
-  // Question block
-  questionBlock: {
-    paddingHorizontal: 24,
-    paddingBottom: 24,
-    paddingTop: 4,
-  },
-  stepEmoji: { fontSize: 48, marginBottom: 16 },
-  stepQuestion: {
-    fontSize: 28,
-    fontWeight: '800',
-    color: '#FFFFFF',
-    lineHeight: 35,
-    marginBottom: 6,
-    marginTop: 14,
-  },
-  stepSubtitle: { fontSize: 15, color: 'rgba(255,255,255,0.72)', lineHeight: 22 },
-
-  // Content areas
-  inputWrapper: { flex: 1, paddingHorizontal: 24 },
-  scrollWrapper: { flex: 1, paddingHorizontal: 24 },
-  scrollArea: { flex: 1 },
-
-  // Single focused input (name, age)
-  focusInput: { paddingTop: 8 },
-  heroInput: {
-    fontSize: 26,
-    fontWeight: '600',
-    color: D.white,
-    borderBottomWidth: 1.5,
-    borderBottomColor: 'rgba(0,0,0,0.15)',
-    paddingVertical: 12,
-    paddingHorizontal: 0,
-    backgroundColor: 'transparent',
-  },
-
-  // Stacked inputs (location, budget)
-  inputStack: { gap: 0 },
-  input: {
-    backgroundColor: D.inputBg,
-    borderRadius: 12,
-    borderWidth: 0,
     paddingHorizontal: 16,
-    paddingVertical: 15,
-    fontSize: 16,
-    color: D.white,
-    marginBottom: 10,
+    paddingTop: 8,
+    paddingBottom: 4,
   },
-  sectionLabel: {
-    fontSize: 12,
-    fontWeight: '700',
-    color: D.grayDim,
-    marginTop: 16,
-    marginBottom: 10,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-  },
-  hint: { fontSize: 13, color: D.grayDim, lineHeight: 18, marginBottom: 12 },
-  errorText: { fontSize: 13, color: D.red, marginBottom: 8 },
-
-  // Chips
-  chipArea: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, paddingTop: 4 },
-  chipRow: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 4 },
-  chip: {
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-    borderRadius: 12,
-    borderWidth: 0,
-    backgroundColor: D.surface,
-    marginRight: 8,
-    marginBottom: 8,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 1,
-  },
-  chipSelected: { backgroundColor: D.selectedBg, shadowOpacity: 0 },
-  chipDisabled: { opacity: 0.4 },
-  chipText: { fontSize: 15, color: D.white },
-  chipTextSelected: { color: '#FFFFFF', fontWeight: '700' },
-
-  // Scale (cleanliness)
-  scaleArea: { paddingTop: 16 },
-  scaleLabels: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 16 },
-  scaleLabel: { fontSize: 13, color: D.gray },
-  scaleChips: { flexDirection: 'row', gap: 10 },
-  scaleChip: {
-    flex: 1,
-    aspectRatio: 1,
-    borderRadius: 14,
-    borderWidth: 1.5,
-    borderColor: D.surfaceBorder,
-    backgroundColor: D.surface,
-    alignItems: 'center',
+  backBtn: {
+    width: 40,
+    height: 40,
     justifyContent: 'center',
   },
-  scaleChipSelected: { backgroundColor: D.selectedBg, borderColor: D.selectedBorder },
-  scaleChipText: { fontSize: 20, fontWeight: '700', color: D.gray },
-  scaleChipTextSelected: { color: '#FFFFFF' },
+  backBtnText: {
+    fontSize: 24,
+    color: '#0C5389',
+  },
+  progressWrap: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  progressTrack: {
+    height: 4,
+    width: '100%',
+    backgroundColor: '#D9E1E6',
+    borderRadius: 2,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#189AA2',
+    borderRadius: 2,
+  },
+  progressLabel: {
+    fontSize: 11,
+    color: '#0C5389',
+    marginTop: 4,
+  },
 
-  // Yes/No rows (pets & smoking)
-  yesNoArea: { gap: 20, paddingTop: 8 },
-  yesNoRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  yesNoLabel: { fontSize: 17, color: D.white, fontWeight: '500' },
-  yesNoChips: { flexDirection: 'row', gap: 10 },
+  // Title block
+  titleBlock: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 8,
+  },
+  stepTitle: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#0C5389',
+    marginBottom: 4,
+  },
+  stepSubtitle: {
+    fontSize: 14,
+    color: '#7A8FA0',
+    lineHeight: 20,
+  },
+
+  // Step body
+  stepBody: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+
+  // Inputs
+  input: {
+    backgroundColor: '#FDFDFD',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 14,
+    paddingVertical: 13,
+    fontSize: 16,
+    color: '#0C5389',
+    marginBottom: 12,
+  },
+  sectionLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0C5389',
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  hint: {
+    fontSize: 13,
+    color: '#7A8FA0',
+    lineHeight: 18,
+    marginBottom: 12,
+    marginTop: 4,
+  },
+  errorText: {
+    fontSize: 13,
+    color: '#E53E3E',
+    marginBottom: 8,
+  },
+
+  // Chips
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 4,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  chipSelected: {
+    backgroundColor: '#189AA2',
+    borderColor: '#189AA2',
+  },
+  chipDisabled: {
+    opacity: 0.4,
+  },
+  chipText: {
+    fontSize: 14,
+    color: '#0C5389',
+  },
+  chipTextSelected: {
+    color: '#FDFDFD',
+    fontWeight: '600',
+  },
 
   // Date picker
   dateBtn: {
-    backgroundColor: D.surface,
-    borderRadius: 14,
-    borderWidth: 1.5,
-    borderColor: D.surfaceBorder,
-    padding: 18,
+    backgroundColor: '#FDFDFD',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    padding: 14,
+    marginBottom: 12,
     alignItems: 'center',
-    marginTop: 8,
   },
-  dateBtnText: { fontSize: 18, color: D.white, fontWeight: '600' },
-  dateBtnPlaceholder: { color: D.grayDim },
-  datePickerWrap: {
-    borderRadius: 16,
-    overflow: 'hidden',
-    backgroundColor: D.surface,
-    borderWidth: 1.5,
-    borderColor: D.surfaceBorder,
+  dateBtnText: {
+    fontSize: 16,
+    color: '#0C5389',
+  },
+  dateBtnPlaceholder: {
+    color: '#9AA',
   },
   dateDoneBtn: {
     alignSelf: 'flex-end',
     paddingHorizontal: 20,
     paddingVertical: 8,
-    backgroundColor: D.lime,
+    backgroundColor: '#189AA2',
     borderRadius: 8,
-    marginTop: 10,
+    marginTop: 8,
+    marginBottom: 8,
   },
-  dateDoneBtnText: { color: '#FFFFFF', fontSize: 14, fontWeight: '700' },
+  dateDoneBtnText: {
+    color: '#FDFDFD',
+    fontSize: 14,
+    fontWeight: '600',
+  },
 
-  // Dealbreakers (old chip style — unused in card flow but kept)
-  dbRow: { marginBottom: 18 },
-  dbLabel: { fontSize: 15, color: D.white, fontWeight: '500', marginBottom: 8 },
-  dbChips: { flexDirection: 'row', gap: 8 },
+  // Dealbreakers
+  dbRow: {
+    marginBottom: 14,
+  },
+  dbLabel: {
+    fontSize: 15,
+    color: '#0C5389',
+    fontWeight: '500',
+    marginBottom: 6,
+  },
+  dbChips: {
+    flexDirection: 'row',
+    gap: 8,
+  },
   dbChip: {
-    flex: 1, paddingVertical: 9, borderRadius: 10,
-    borderWidth: 1.5, borderColor: D.surfaceBorder,
-    backgroundColor: D.surface, alignItems: 'center',
+    flex: 1,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
+    alignItems: 'center',
   },
-  dbChipHard: { backgroundColor: '#FEF2F2', borderColor: D.red },
-  dbChipSoft: { backgroundColor: '#FFF7ED', borderColor: D.orange },
-  dbChipNone: { backgroundColor: D.selectedBg, borderColor: D.lime },
-  dbChipText: { fontSize: 13, color: D.gray, fontWeight: '500' },
-  dbChipTextSelected: { color: D.white, fontWeight: '700' },
+  dbChipHard: {
+    backgroundColor: '#E53E3E',
+    borderColor: '#E53E3E',
+  },
+  dbChipSoft: {
+    backgroundColor: '#F6AD55',
+    borderColor: '#F6AD55',
+  },
+  dbChipNone: {
+    backgroundColor: '#189AA2',
+    borderColor: '#189AA2',
+  },
+  dbChipText: {
+    fontSize: 13,
+    color: '#0C5389',
+    fontWeight: '500',
+  },
+  dbChipTextSelected: {
+    color: '#FDFDFD',
+    fontWeight: '600',
+  },
 
-  // Interests
-  catBlock: { borderBottomWidth: 1, borderBottomColor: D.surfaceBorder },
-  catHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 16 },
-  catLabel: { fontSize: 16, fontWeight: '600', color: D.white },
-  catChevron: { fontSize: 12, color: D.lime },
-  catContent: { paddingBottom: 10 },
-  customInputRow: { marginTop: 4, marginBottom: 8 },
+  // Interests accordion
+  catBlock: {
+    borderBottomWidth: 1,
+    borderBottomColor: '#D9E1E6',
+    marginBottom: 0,
+  },
+  catHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 14,
+  },
+  catLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#0C5389',
+  },
+  catChevron: {
+    fontSize: 12,
+    color: '#189AA2',
+  },
+  catContent: {
+    paddingBottom: 8,
+  },
+  customInputRow: {
+    marginTop: 4,
+    marginBottom: 8,
+  },
   customInput: {
-    backgroundColor: D.surface, borderRadius: 10, borderWidth: 1.5,
-    borderColor: D.surfaceBorder, paddingHorizontal: 14, paddingVertical: 10,
-    fontSize: 14, color: D.white,
+    backgroundColor: '#FDFDFD',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    color: '#0C5389',
   },
 
-  // Prompts (legacy — kept for safety)
-  promptCount: { fontSize: 13, color: D.lime, fontWeight: '600', marginBottom: 12 },
-  promptBlock: { marginBottom: 8 },
-  promptRow: {
-    padding: 14, borderRadius: 14, borderWidth: 1.5,
-    borderColor: D.surfaceBorder, backgroundColor: D.surface,
-    flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center',
+  // Prompts
+  promptCount: {
+    fontSize: 13,
+    color: '#189AA2',
+    fontWeight: '600',
+    marginBottom: 12,
   },
-  promptRowSelected: { borderColor: D.selectedBorder, backgroundColor: D.selectedBg },
-  promptRowDimmed: { opacity: 0.35 },
-  promptText: { fontSize: 14, color: D.gray, flex: 1, lineHeight: 20 },
-  promptTextSelected: { color: D.white, fontWeight: '500' },
-  promptCheck: { fontSize: 16, color: D.lime, marginLeft: 8, fontWeight: '700' },
+  promptBlock: {
+    marginBottom: 8,
+  },
+  promptRow: {
+    padding: 14,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: '#D9E1E6',
+    backgroundColor: '#FDFDFD',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  promptRowSelected: {
+    borderColor: '#189AA2',
+    backgroundColor: '#EDF8F9',
+  },
+  promptRowDimmed: {
+    opacity: 0.45,
+  },
+  promptText: {
+    fontSize: 14,
+    color: '#0C5389',
+    flex: 1,
+    lineHeight: 20,
+  },
+  promptTextSelected: {
+    fontWeight: '500',
+  },
+  promptCheck: {
+    fontSize: 16,
+    color: '#189AA2',
+    marginLeft: 8,
+    fontWeight: '700',
+  },
   promptInput: {
-    backgroundColor: D.surface, borderRadius: 12, borderWidth: 1.5,
-    borderColor: D.surfaceBorder, paddingHorizontal: 14, paddingVertical: 12,
-    fontSize: 14, color: D.white, marginTop: 6, minHeight: 80, textAlignVertical: 'top',
+    backgroundColor: '#FDFDFD',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#D9E1E6',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: '#0C5389',
+    marginTop: 4,
+    minHeight: 70,
+    textAlignVertical: 'top',
   },
 
   // Photos
-  photoGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginBottom: 8, marginTop: 8 },
-  photoThumb: { borderRadius: 14, overflow: 'hidden', position: 'relative' },
-  photoImg: { width: '100%', height: '100%', resizeMode: 'cover' },
+  photoGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  photoThumb: {
+    borderRadius: 12,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  photoImg: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
   photoRemove: {
-    position: 'absolute', top: 6, right: 6, width: 26, height: 26,
-    borderRadius: 13, backgroundColor: 'rgba(0,0,0,0.55)',
-    alignItems: 'center', justifyContent: 'center',
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  photoRemoveText: { color: '#FFFFFF', fontSize: 12, fontWeight: '700' },
+  photoRemoveText: {
+    color: '#FDFDFD',
+    fontSize: 12,
+    fontWeight: '700',
+  },
   photoAdd: {
-    borderRadius: 14, borderWidth: 2, borderColor: D.surfaceBorder,
-    borderStyle: 'dashed', alignItems: 'center', justifyContent: 'center',
-    backgroundColor: D.surface,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: '#D9E1E6',
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FDFDFD',
   },
-  photoAddIcon: { fontSize: 32, color: D.grayDim },
-  photoAddLabel: { fontSize: 12, color: D.grayDim, marginTop: 4 },
-  photoCount: { fontSize: 13, color: D.grayDim, textAlign: 'center', marginBottom: 8 },
+  photoAddIcon: {
+    fontSize: 32,
+    color: '#D9E1E6',
+  },
+  photoAddLabel: {
+    fontSize: 12,
+    color: '#7A8FA0',
+    marginTop: 4,
+  },
+  photoCount: {
+    fontSize: 13,
+    color: '#7A8FA0',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
 
   // Footer
   footer: {
     flexDirection: 'row',
-    paddingHorizontal: 24,
+    paddingHorizontal: 20,
     paddingBottom: 16,
     paddingTop: 12,
     gap: 12,
+    backgroundColor: '#E8EEF2',
   },
   skipBtn: {
     flex: 1,
-    borderRadius: 14,
-    paddingVertical: 16,
+    borderRadius: 12,
+    paddingVertical: 14,
     alignItems: 'center',
-    backgroundColor: D.inputBg,
-    borderWidth: 0,
+    backgroundColor: '#D9E1E6',
   },
-  skipBtnText: { fontSize: 16, fontWeight: '600', color: D.gray },
+  skipBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#0C5389',
+  },
   nextBtn: {
     flex: 2,
-    borderRadius: 14,
-    paddingVertical: 16,
-    alignItems: 'center',
-    backgroundColor: D.lime,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.12,
-    shadowRadius: 6,
-    elevation: 2,
-  },
-  nextBtnFlex: { flex: 1 },
-  nextBtnDisabled: { opacity: 0.35, shadowOpacity: 0 },
-  nextBtnText: { fontSize: 16, fontWeight: '700', color: '#FFFFFF' },
-
-  // State picker trigger
-  pickerBtn: {
-    backgroundColor: D.inputBg,
     borderRadius: 12,
-    borderWidth: 0,
-    paddingHorizontal: 16,
-    paddingVertical: 15,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 10,
-  },
-  pickerBtnText: { fontSize: 16, color: D.white, fontWeight: '500' },
-  pickerBtnPlaceholder: { fontSize: 16, color: D.grayDim },
-  pickerChevron: { fontSize: 11, color: D.lime },
-
-  // Disabled input
-  inputDisabled: { opacity: 0.4 },
-
-  // Modal bottom sheet
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
-  modalSheet: {
-    backgroundColor: 'rgba(242,242,247,0.97)',
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    paddingTop: 16,
-    maxHeight: '75%',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: -1 },
-    shadowOpacity: 0.06,
-    shadowRadius: 20,
-    elevation: 8,
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingBottom: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: D.surfaceBorder,
-  },
-  modalTitle: { fontSize: 17, fontWeight: '700', color: D.white },
-  modalClose: { fontSize: 18, color: D.grayDim, paddingHorizontal: 4 },
-  modalSearch: {
-    marginHorizontal: 16,
-    marginTop: 12,
-    marginBottom: 8,
-    backgroundColor: D.inputBg,
-    borderRadius: 12,
-    borderWidth: 0,
-    paddingHorizontal: 14,
-    paddingVertical: 11,
-    fontSize: 15,
-    color: D.white,
-  },
-
-  // State list rows
-  stateRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingVertical: 15,
-    borderBottomWidth: 1,
-    borderBottomColor: D.surfaceBorder,
-  },
-  stateRowSelected: { backgroundColor: D.selectedBg },
-  stateRowText: { fontSize: 16, color: D.white },
-  stateRowTextSelected: { color: '#FFFFFF', fontWeight: '700' },
-  stateRowAbbr: { fontSize: 14, color: D.grayDim, fontWeight: '600' },
-
-  // Dealbreaker card sub-flow
-  dbCardArea: { flex: 1, paddingTop: 8, gap: 12 },
-  dbDots: { flexDirection: 'row', justifyContent: 'center', gap: 6, marginBottom: 8 },
-  dbDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: D.trackBg },
-  dbDotActive: { backgroundColor: D.lime, width: 20, borderRadius: 4 },
-  dbDotDone: { backgroundColor: D.selectedBorder },
-  dbCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: D.surface,
-    borderWidth: 0.5,
-    borderColor: 'rgba(255,255,255,0.9)',
-    borderRadius: 16,
-    paddingVertical: 18,
-    paddingHorizontal: 20,
-    gap: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.06,
-    shadowRadius: 10,
-    elevation: 2,
-  },
-  dbCardHard: { backgroundColor: '#FEF2F2', borderColor: D.red },
-  dbCardSoft: { backgroundColor: '#FFF7ED', borderColor: D.orange },
-  dbCardNone: { backgroundColor: '#F9FAFB', borderColor: '#9CA3AF' },
-  dbCardEmoji: { fontSize: 32 },
-  dbCardText: { flex: 1 },
-  dbCardLabel: { fontSize: 17, fontWeight: '700', color: D.white, marginBottom: 2 },
-  dbCardLabelSelected: { color: D.white },
-  dbCardSub: { fontSize: 13, color: D.gray },
-
-  // ── Prompt card sub-flow ──────────────────────────────────────────────────────
-
-  pProgressRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 20 },
-  pProgressDot: { width: 10, height: 10, borderRadius: 5, backgroundColor: D.trackBg },
-  pProgressDotDone: { backgroundColor: D.lime },
-  pProgressText: { fontSize: 13, color: D.gray, fontWeight: '600', marginLeft: 4 },
-
-  pCard: {
-    flex: 1,
-    backgroundColor: D.surface,
-    borderRadius: 20,
-    borderWidth: 0.5,
-    borderColor: 'rgba(255,255,255,0.9)',
-    padding: 28,
-    justifyContent: 'center',
-    marginBottom: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.08,
-    shadowRadius: 20,
-    elevation: 3,
-  },
-  pCardQuestion: { fontSize: 24, fontWeight: '800', color: D.white, lineHeight: 32 },
-  pCardDoneBadge: {
-    alignSelf: 'flex-start',
-    marginTop: 16,
-    backgroundColor: D.selectedBg,
-    borderRadius: 50,
-    paddingHorizontal: 12,
-    paddingVertical: 4,
-  },
-  pCardDoneBadgeText: { fontSize: 12, fontWeight: '700', color: '#FFFFFF' },
-
-  pActions: { flexDirection: 'row', gap: 12, paddingBottom: 8 },
-  pSkipBtn: {
-    flex: 1,
-    borderRadius: 50,
-    paddingVertical: 15,
-    alignItems: 'center',
-    backgroundColor: D.surface,
-    borderWidth: 1.5,
-    borderColor: D.surfaceBorder,
-  },
-  pSkipBtnText: { fontSize: 16, fontWeight: '600', color: D.gray },
-  pUseBtn: {
-    flex: 2,
-    borderRadius: 50,
-    paddingVertical: 15,
-    alignItems: 'center',
-    backgroundColor: D.lime,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  pUseBtnDisabled: { opacity: 0.4, shadowOpacity: 0 },
-  pUseBtnText: { fontSize: 16, fontWeight: '700', color: '#FFFFFF' },
-
-  pAnswerHeader: {
-    backgroundColor: D.surface,
-    borderRadius: 16,
-    padding: 20,
-    marginBottom: 24,
-  },
-  pAnswerQuestion: { fontSize: 28, fontWeight: '700', color: '#1A2C24', lineHeight: 36, marginBottom: 20 },
-  pSuggestLabel: { fontSize: 13, color: D.gray, fontWeight: '600', marginBottom: 10 },
-  pSuggestList: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginBottom: 20 },
-  pSuggestChip: {
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 50,
-    backgroundColor: D.surface,
-    borderWidth: 1.5,
-    borderColor: D.surfaceBorder,
-  },
-  pSuggestChipActive: { borderColor: D.selectedBorder, backgroundColor: D.selectedBg },
-  pSuggestText: { fontSize: 14, color: D.gray, fontWeight: '500' },
-  pSuggestTextActive: { color: '#FFFFFF', fontWeight: '600' },
-  pDraftInput: {
-    backgroundColor: D.surface,
-    borderRadius: 14,
-    borderWidth: 1.5,
-    borderColor: D.surfaceBorder,
-    paddingHorizontal: 16,
     paddingVertical: 14,
-    fontSize: 15,
-    color: D.white,
-    minHeight: 100,
-    textAlignVertical: 'top',
-    marginBottom: 6,
-  },
-  pCharCount: { fontSize: 12, color: D.grayDim, textAlign: 'right', marginBottom: 20 },
-  pSaveBtn: {
-    borderRadius: 50,
-    paddingVertical: 16,
     alignItems: 'center',
-    backgroundColor: D.lime,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 2,
-    marginBottom: 24,
+    backgroundColor: '#0C5389',
   },
-  pSaveBtnDisabled: { opacity: 0.4, shadowOpacity: 0 },
-  pSaveBtnText: { fontSize: 16, fontWeight: '700', color: '#FFFFFF' },
-
-  // Browse-all link + modal
-  pBrowseAllBtn: { alignItems: 'center', paddingVertical: 12 },
-  pBrowseAllText: { fontSize: 14, color: D.gray, fontWeight: '500', textDecorationLine: 'underline' },
-  pAllModalRoot: { flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' },
-  pAllModalHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingTop: 20,
-    paddingBottom: 14,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: D.surfaceBorder,
+  nextBtnDisabled: {
+    opacity: 0.4,
   },
-  pAllModalTitle: { fontSize: 18, fontWeight: '700', color: D.white },
-  pAllModalClose: { fontSize: 15, color: D.gray, fontWeight: '600' },
-  pAllModalList: {
-    paddingBottom: 32,
+  nextBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FDFDFD',
   },
-  pAllModalSheet: {
-    backgroundColor: '#FFFFFF',
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    height: '80%',
-  },
-  pAllModalScroll: { flex: 1 },
-  pAllRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: 'rgba(0,0,0,0.06)',
-  },
-  pAllRowSelected: { backgroundColor: 'rgba(3,2,19,0.04)' },
-  pAllRowDisabled: { opacity: 0.35 },
-  pAllRowText: { fontSize: 15, color: D.white, flex: 1 },
-  pAllRowTextSelected: { fontWeight: '600' },
-  pAllRowCheck: { marginLeft: 12 },
 });


### PR DESCRIPTION
## Summary
- Replaces the old 3-screen onboarding split (OnboardingScreen → ProfileCompletionScreen → ProfileCardScreen) with a single unified 10-step flow — one focused question per screen with a progress bar
- Prompts step is now a plain scrollable list of all 24 prompts; tap any to expand an inline answer with suggestion chips and a text input. Requires at least 2 answers (up to 3) before continuing
- Adds full profile editing for interests, dealbreakers, and prompts directly from the Profile tab — no re-onboarding needed
- Adds in-place photo replacement so users can swap a photo without dropping below the 3-photo minimum
- DEV button on the profile screen to preview onboarding without creating a new account

## Test plan
- [ ] Complete onboarding start to finish on a fresh account — all 10 steps save correctly
- [ ] Try to continue past the prompts step with fewer than 2 answered — Continue should stay disabled
- [ ] Answer 2 prompts and confirm Continue enables; answer a 3rd and confirm the counter updates
- [ ] Edit interests, dealbreakers, and prompts from the Profile tab and verify they persist after restart
- [ ] Replace a photo in-place and confirm the count doesn't drop