### PR TITLE
Add Discover filters panel: budget, move-in, lease, room type, has li… + gender options in onboarding and preferences

### DIFF
--- a/apps/mobile/components/DiscoverFiltersModal.tsx
+++ b/apps/mobile/components/DiscoverFiltersModal.tsx
@@ -13,6 +13,12 @@ import Slider from '@react-native-community/slider';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getPreferences, savePreferences } from '../lib/preferences';
 
+const GENDER_PREF_OPTIONS = [
+  { val: 'Man',        label: 'Men' },
+  { val: 'Woman',      label: 'Women' },
+  { val: 'Non-binary', label: 'Non-binary' },
+];
+
 const ETHNICITY_OPTIONS = [
   'Asian',
   'Black / African American',
@@ -58,6 +64,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
   const [roomType, setRoomType] = useState('');
   const [moveIn, setMoveIn] = useState('');
   const [leaseDuration, setLeaseDuration] = useState<number | null>(null);
+  const [genderPref, setGenderPref] = useState('');
   const [hasListingOnly, setHasListingOnly] = useState(false);
   const [minBudget, setMinBudget] = useState(0);
   const [maxBudget, setMaxBudget] = useState(10000);
@@ -72,6 +79,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
       setRoomType(prefs?.room_type ?? '');
       setMoveIn(prefs?.move_in_date ?? '');
       setLeaseDuration(prefs?.lease_duration_months ?? null);
+      setGenderPref(prefs?.gender_preference ?? '');
       setHasListingOnly(prefs?.has_listing_only ?? false);
       setMinBudget(prefs?.min_budget ?? 0);
       setMaxBudget(prefs?.max_budget ?? 10000);
@@ -88,6 +96,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
     setSaving(true);
     try {
       await savePreferences(userId, {
+        gender_preference: genderPref || '',
         ethnicity_preference: ethnicityPref,
         room_type: (roomType as any) || undefined,
         move_in_date: moveIn || undefined,
@@ -108,6 +117,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
     setRoomType('');
     setMoveIn('');
     setLeaseDuration(null);
+    setGenderPref('');
     setHasListingOnly(false);
     setMinBudget(0);
     setMaxBudget(10000);
@@ -131,6 +141,26 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
             <ActivityIndicator style={{ marginVertical: 40 }} color="#1A3329" />
           ) : (
             <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.content}>
+
+              {/* Gender preference */}
+              <Text style={styles.sectionTitle}>I want to live with</Text>
+              <View style={[styles.chipsRow, { marginBottom: 4 }]}>
+                {GENDER_PREF_OPTIONS.map(({ val, label }) => {
+                  const on = genderPref === val;
+                  return (
+                    <TouchableOpacity
+                      key={val}
+                      style={[styles.chip, on && styles.chipOn]}
+                      onPress={() => setGenderPref(on ? '' : val)}
+                    >
+                      <Text style={[styles.chipText, on && styles.chipTextOn]}>{label}</Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+              <Text style={styles.sectionSub}>Leave blank to see everyone</Text>
+
+              <View style={styles.divider} />
 
               {/* Has listing toggle */}
               <View style={styles.toggleRow}>

--- a/apps/mobile/components/DiscoverFiltersModal.tsx
+++ b/apps/mobile/components/DiscoverFiltersModal.tsx
@@ -1,0 +1,440 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import Slider from '@react-native-community/slider';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { getPreferences, savePreferences } from '../lib/preferences';
+
+const ETHNICITY_OPTIONS = [
+  'Asian',
+  'Black / African American',
+  'Hispanic / Latino',
+  'Middle Eastern',
+  'Native American',
+  'Pacific Islander',
+  'White / Caucasian',
+  'Multiracial',
+];
+
+const ROOM_TYPE_OPTIONS = [
+  { val: 'private',  label: 'Private room' },
+  { val: 'shared',   label: 'Shared room' },
+  { val: 'entire',   label: 'Entire place' },
+  { val: 'flexible', label: 'Flexible' },
+];
+
+const MOVE_IN_OPTIONS = [
+  { val: 'ASAP',       label: 'ASAP' },
+  { val: '1-3 months', label: '1–3 months' },
+  { val: '3-6 months', label: '3–6 months' },
+  { val: 'Flexible',   label: 'Flexible' },
+];
+
+const LEASE_OPTIONS = [
+  { val: 1,  label: 'Month-to-month' },
+  { val: 6,  label: '6 months' },
+  { val: 12, label: '1 year' },
+  { val: 0,  label: 'Flexible' },
+];
+
+interface Props {
+  visible: boolean;
+  userId: string;
+  onClose: () => void;
+  onApply: () => void;
+}
+
+export default function DiscoverFiltersModal({ visible, userId, onClose, onApply }: Props) {
+  const insets = useSafeAreaInsets();
+  const [ethnicityPref, setEthnicityPref] = useState<string[]>([]);
+  const [roomType, setRoomType] = useState('');
+  const [moveIn, setMoveIn] = useState('');
+  const [leaseDuration, setLeaseDuration] = useState<number | null>(null);
+  const [hasListingOnly, setHasListingOnly] = useState(false);
+  const [minBudget, setMinBudget] = useState(0);
+  const [maxBudget, setMaxBudget] = useState(10000);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!visible) return;
+    setLoading(true);
+    getPreferences(userId).then((prefs) => {
+      setEthnicityPref(prefs?.ethnicity_preference ?? []);
+      setRoomType(prefs?.room_type ?? '');
+      setMoveIn(prefs?.move_in_date ?? '');
+      setLeaseDuration(prefs?.lease_duration_months ?? null);
+      setHasListingOnly(prefs?.has_listing_only ?? false);
+      setMinBudget(prefs?.min_budget ?? 0);
+      setMaxBudget(prefs?.max_budget ?? 10000);
+      setLoading(false);
+    });
+  }, [visible, userId]);
+
+  const toggleEthnicity = (opt: string) =>
+    setEthnicityPref((prev) =>
+      prev.includes(opt) ? prev.filter((e) => e !== opt) : [...prev, opt]
+    );
+
+  const handleApply = async () => {
+    setSaving(true);
+    try {
+      await savePreferences(userId, {
+        ethnicity_preference: ethnicityPref,
+        room_type: (roomType as any) || undefined,
+        move_in_date: moveIn || undefined,
+        lease_duration_months: leaseDuration ?? undefined,
+        has_listing_only: hasListingOnly,
+        min_budget: minBudget,
+        max_budget: maxBudget,
+      });
+      onApply();
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = () => {
+    setEthnicityPref([]);
+    setRoomType('');
+    setMoveIn('');
+    setLeaseDuration(null);
+    setHasListingOnly(false);
+    setMinBudget(0);
+    setMaxBudget(10000);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} />
+        <View style={[styles.sheet, { paddingBottom: insets.bottom + 16 }]}>
+          <View style={styles.handle} />
+
+          <View style={styles.titleRow}>
+            <Text style={styles.title}>Discover Filters</Text>
+            <TouchableOpacity onPress={handleClear}>
+              <Text style={styles.clearBtn}>Clear all</Text>
+            </TouchableOpacity>
+          </View>
+
+          {loading ? (
+            <ActivityIndicator style={{ marginVertical: 40 }} color="#1A3329" />
+          ) : (
+            <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.content}>
+
+              {/* Has listing toggle */}
+              <View style={styles.toggleRow}>
+                <View style={styles.toggleLeft}>
+                  <Text style={styles.sectionTitle}>Has a place listed</Text>
+                  <Text style={styles.sectionSub}>Only show people who already have a place to offer</Text>
+                </View>
+                <Switch
+                  value={hasListingOnly}
+                  onValueChange={setHasListingOnly}
+                  trackColor={{ false: '#D0D0D8', true: '#1A3329' }}
+                  thumbColor="#FFFFFF"
+                />
+              </View>
+
+              <View style={styles.divider} />
+
+              {/* Budget range */}
+              <Text style={styles.sectionTitle}>Monthly budget</Text>
+              <View style={styles.budgetDisplay}>
+                <View style={styles.budgetBadge}>
+                  <Text style={styles.budgetBadgeLabel}>Min</Text>
+                  <Text style={styles.budgetBadgeValue}>${minBudget.toLocaleString()}</Text>
+                </View>
+                <View style={styles.budgetDash} />
+                <View style={styles.budgetBadge}>
+                  <Text style={styles.budgetBadgeLabel}>Max</Text>
+                  <Text style={styles.budgetBadgeValue}>{maxBudget >= 10000 ? 'Unlimited' : `$${maxBudget.toLocaleString()}`}</Text>
+                </View>
+              </View>
+              <Text style={styles.sliderLabel}>Minimum</Text>
+              <Slider
+                style={styles.slider}
+                minimumValue={0}
+                maximumValue={maxBudget}
+                step={50}
+                value={minBudget}
+                onValueChange={(v) => setMinBudget(Math.min(v, maxBudget - 50))}
+                minimumTrackTintColor="#1A3329"
+                maximumTrackTintColor="#D0D8D4"
+                thumbTintColor="#1A3329"
+              />
+              <Text style={styles.sliderLabel}>Maximum</Text>
+              <Slider
+                style={styles.slider}
+                minimumValue={minBudget + 50}
+                maximumValue={10000}
+                step={50}
+                value={maxBudget}
+                onValueChange={(v) => setMaxBudget(Math.max(v, minBudget + 50))}
+                minimumTrackTintColor="#1A3329"
+                maximumTrackTintColor="#D0D8D4"
+                thumbTintColor="#1A3329"
+              />
+
+              <View style={styles.divider} />
+
+              {/* Move-in date */}
+              <Text style={styles.sectionTitle}>Move-in date</Text>
+              <View style={styles.chipsRow}>
+                {MOVE_IN_OPTIONS.map(({ val, label }) => {
+                  const on = moveIn === val;
+                  return (
+                    <TouchableOpacity
+                      key={val}
+                      style={[styles.chip, on && styles.chipOn]}
+                      onPress={() => setMoveIn(on ? '' : val)}
+                    >
+                      <Text style={[styles.chipText, on && styles.chipTextOn]}>{label}</Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+
+              <View style={styles.divider} />
+
+              {/* Lease duration */}
+              <Text style={styles.sectionTitle}>Lease duration</Text>
+              <View style={styles.chipsRow}>
+                {LEASE_OPTIONS.map(({ val, label }) => {
+                  const on = leaseDuration === val;
+                  return (
+                    <TouchableOpacity
+                      key={val}
+                      style={[styles.chip, on && styles.chipOn]}
+                      onPress={() => setLeaseDuration(on ? null : val)}
+                    >
+                      <Text style={[styles.chipText, on && styles.chipTextOn]}>{label}</Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+
+              <View style={styles.divider} />
+
+              {/* Room type */}
+              <Text style={styles.sectionTitle}>Room type</Text>
+              <View style={styles.chipsRow}>
+                {ROOM_TYPE_OPTIONS.map(({ val, label }) => {
+                  const on = roomType === val;
+                  return (
+                    <TouchableOpacity
+                      key={val}
+                      style={[styles.chip, on && styles.chipOn]}
+                      onPress={() => setRoomType(on ? '' : val)}
+                    >
+                      <Text style={[styles.chipText, on && styles.chipTextOn]}>{label}</Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+
+              <View style={styles.divider} />
+
+              {/* Ethnicity preference */}
+              <Text style={styles.sectionTitle}>Ethnicity preference</Text>
+              <Text style={styles.sectionSub}>
+                Preferred roommate ethnicity — matching profiles rank higher. Leave blank for no preference.
+              </Text>
+              <View style={styles.chipsRow}>
+                {ETHNICITY_OPTIONS.map((opt) => {
+                  const on = ethnicityPref.includes(opt);
+                  return (
+                    <TouchableOpacity
+                      key={opt}
+                      style={[styles.chip, on && styles.chipOn]}
+                      onPress={() => toggleEthnicity(opt)}
+                    >
+                      <Text style={[styles.chipText, on && styles.chipTextOn]}>{opt}</Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+
+            </ScrollView>
+          )}
+
+          <TouchableOpacity
+            style={styles.applyBtn}
+            onPress={handleApply}
+            disabled={saving}
+            activeOpacity={0.85}
+          >
+            {saving
+              ? <ActivityIndicator color="#FFFFFF" />
+              : <Text style={styles.applyBtnText}>Apply filters</Text>
+            }
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  sheet: {
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    maxHeight: '88%',
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(0,0,0,0.15)',
+    alignSelf: 'center',
+    marginBottom: 16,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#1A2C24',
+  },
+  clearBtn: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#717182',
+  },
+  content: {
+    paddingTop: 8,
+    paddingBottom: 16,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: 'rgba(0,0,0,0.08)',
+    marginVertical: 20,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  toggleLeft: {
+    flex: 1,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#1A2C24',
+    marginBottom: 6,
+  },
+  sectionSub: {
+    fontSize: 13,
+    color: '#717182',
+    lineHeight: 18,
+    marginBottom: 12,
+  },
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 50,
+    borderWidth: 1.5,
+    borderColor: '#A0B4AC',
+    backgroundColor: '#F0F5F2',
+  },
+  chipOn: {
+    backgroundColor: '#1A3329',
+    borderColor: '#1A3329',
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#1A2C24',
+  },
+  chipTextOn: {
+    color: '#FFFFFF',
+  },
+  budgetDisplay: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    marginBottom: 12,
+  },
+  budgetBadge: {
+    flex: 1,
+    backgroundColor: '#F0F5F2',
+    borderRadius: 10,
+    paddingVertical: 8,
+    alignItems: 'center',
+  },
+  budgetBadgeLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#717182',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  budgetBadgeValue: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1A2C24',
+    marginTop: 2,
+  },
+  budgetDash: {
+    width: 12,
+    height: 2,
+    borderRadius: 1,
+    backgroundColor: '#A0B4AC',
+  },
+  sliderLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#717182',
+    marginBottom: 2,
+  },
+  slider: {
+    width: '100%',
+    height: 36,
+    marginBottom: 4,
+  },
+  applyBtn: {
+    marginTop: 8,
+    backgroundColor: '#1A3329',
+    paddingVertical: 15,
+    borderRadius: 14,
+    alignItems: 'center',
+  },
+  applyBtnText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+});

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -120,13 +120,17 @@ export async function fetchDiscoverProfiles(
   let query = supabase
     .from('profiles')
     .select(
-      'id, name, age, bio, hobbies, prompts, has_listing, profile_photo_url, subscription_tier, created_at, updated_at, ' +
+      'id, name, age, bio, hobbies, prompts, has_listing, profile_photo_url, subscription_tier, ethnicity, created_at, updated_at, ' +
       'preferences(city, state, min_budget, max_budget, cleanliness_level, social_preference, ' +
-      'work_schedule, interests, dealbreakers, pets_allowed, smoking_allowed, room_type, search_lat, search_lng)'
+      'work_schedule, interests, dealbreakers, pets_allowed, smoking_allowed, room_type, move_in_date, lease_duration_months, search_lat, search_lng, ethnicity_preference)'
     )
     .neq('id', userId)
     .not('profile_photo_url', 'is', null)
     .limit(50);
+
+  if (myPrefs?.has_listing_only === true) {
+    query = query.eq('has_listing', true);
+  }
 
   if (swipedIds.length > 0) {
     query = query.not('id', 'in', `(${swipedIds.join(',')})`);
@@ -158,6 +162,7 @@ export async function fetchDiscoverProfiles(
         age: row.age,
         bio: row.bio,
         hobbies: row.hobbies,
+        ethnicity: row.ethnicity,
       });
       scored.push({ row, score });
     } else {

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -132,6 +132,10 @@ export async function fetchDiscoverProfiles(
     query = query.eq('has_listing', true);
   }
 
+  if (myPrefs?.gender_preference) {
+    query = query.eq('gender', myPrefs.gender_preference);
+  }
+
   if (swipedIds.length > 0) {
     query = query.not('id', 'in', `(${swipedIds.join(',')})`);
   }

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -49,16 +49,24 @@ export function passesHardFilters(mine: Preferences, theirs: Preferences): boole
   const myDealbreakers = mine.dealbreakers ?? {};
   for (const [key, severity] of Object.entries(myDealbreakers)) {
     if (severity !== 'hard') continue;
-    if (key === 'smoking' && theirs.smoking_allowed === true) return false;
-    if (key === 'pets'    && theirs.pets_allowed    === true) return false;
+    if (key === 'smoking'    && theirs.smoking_allowed === true) return false;
+    if (key === 'pets'       && theirs.pets_allowed    === true) return false;
+    if (key === 'parties'    && theirs.social_preference === 'social') return false;
+    if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') return false;
+    if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') return false;
+    if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) return false;
   }
 
   // Their hard dealbreakers vs my self-reported traits (avoid wasted swipes)
   const theirDealbreakers = theirs.dealbreakers ?? {};
   for (const [key, severity] of Object.entries(theirDealbreakers)) {
     if (severity !== 'hard') continue;
-    if (key === 'smoking' && mine.smoking_allowed === true) return false;
-    if (key === 'pets'    && mine.pets_allowed    === true) return false;
+    if (key === 'smoking'    && mine.smoking_allowed === true) return false;
+    if (key === 'pets'       && mine.pets_allowed    === true) return false;
+    if (key === 'parties'    && mine.social_preference === 'social') return false;
+    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') return false;
+    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') return false;
+    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) return false;
   }
 
   return true;
@@ -131,15 +139,22 @@ export function scoreCompatibility(
   const myDealbreakers = mine.dealbreakers ?? {};
   for (const [key, severity] of Object.entries(myDealbreakers)) {
     if (severity !== 'soft') continue;
-    if (key === 'smoking' && theirs.smoking_allowed === true) dealScore -= 0.05;
-    if (key === 'pets'    && theirs.pets_allowed    === true) dealScore -= 0.05;
+    if (key === 'smoking'    && theirs.smoking_allowed === true) dealScore -= 0.05;
+    if (key === 'pets'       && theirs.pets_allowed    === true) dealScore -= 0.05;
+    if (key === 'parties'    && theirs.social_preference === 'social') dealScore -= 0.05;
+    if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') dealScore -= 0.05;
+    if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') dealScore -= 0.05;
+    if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) dealScore -= 0.05;
   }
-  // Also penalise if their soft dealbreakers conflict with my traits
   const theirDealbreakers = theirs.dealbreakers ?? {};
   for (const [key, severity] of Object.entries(theirDealbreakers)) {
     if (severity !== 'soft') continue;
-    if (key === 'smoking' && mine.smoking_allowed === true) dealScore -= 0.05;
-    if (key === 'pets'    && mine.pets_allowed    === true) dealScore -= 0.05;
+    if (key === 'smoking'    && mine.smoking_allowed === true) dealScore -= 0.05;
+    if (key === 'pets'       && mine.pets_allowed    === true) dealScore -= 0.05;
+    if (key === 'parties'    && mine.social_preference === 'social') dealScore -= 0.05;
+    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') dealScore -= 0.05;
+    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') dealScore -= 0.05;
+    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) dealScore -= 0.05;
   }
   score += Math.max(0, dealScore);
 

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -15,11 +15,11 @@ export interface ProfileMeta {
   subscription_tier?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
-  // profile fields used for completeness scoring
   name?: string | null;
   age?: number | null;
   bio?: string | null;
   hobbies?: string[] | null;
+  ethnicity?: string | null;
 }
 
 // ─── Hard filters ────────────────────────────────────────────────────────────
@@ -142,6 +142,32 @@ export function scoreCompatibility(
     if (key === 'pets'    && mine.pets_allowed    === true) dealScore -= 0.05;
   }
   score += Math.max(0, dealScore);
+
+  // ── Move-in date compatibility (soft boost) ────────────────────────────────
+  if (mine.move_in_date && theirs.move_in_date) {
+    const flexVals = ['flexible', 'Flexible'];
+    const mineFlex = flexVals.includes(mine.move_in_date);
+    const theirsFlex = flexVals.includes(theirs.move_in_date);
+    if (mineFlex || theirsFlex || mine.move_in_date === theirs.move_in_date) {
+      score += 0.04;
+    }
+  }
+
+  // ── Lease duration compatibility (soft boost) ──────────────────────────────
+  if (mine.lease_duration_months != null && theirs.lease_duration_months != null) {
+    const mineFlex = mine.lease_duration_months === 0;
+    const theirsFlex = theirs.lease_duration_months === 0;
+    if (mineFlex || theirsFlex || mine.lease_duration_months === theirs.lease_duration_months) {
+      score += 0.03;
+    }
+  }
+
+  // ── Ethnicity preference (soft boost) ──────────────────────────────────────
+  // Only applied when the viewer has set a preference — never hard-filters.
+  const myEthPref = mine.ethnicity_preference ?? [];
+  if (myEthPref.length > 0 && theirMeta.ethnicity) {
+    if (myEthPref.includes(theirMeta.ethnicity)) score += 0.08;
+  }
 
   // ── City match bonus ────────────────────────────────────────────────────────
   if (

--- a/apps/mobile/lib/preferences.ts
+++ b/apps/mobile/lib/preferences.ts
@@ -72,6 +72,8 @@ export interface Preferences {
   must_haves?: string[];
   interests?: Record<string, string[]>;
   dealbreakers?: Record<string, 'hard' | 'soft' | 'none'>;
+  ethnicity_preference?: string[];
+  has_listing_only?: boolean;
   created_at?: string;
   updated_at?: string;
 }
@@ -140,25 +142,16 @@ export async function savePreferences(
     const mappedPreferences = { ...preferences };
     const roomTypeValue = mappedPreferences.room_type as string | undefined;
     
-    console.log('🔍 [savePreferences] Original room_type value:', roomTypeValue, 'Type:', typeof roomTypeValue);
-    console.log('🔍 [savePreferences] Full preferences object:', JSON.stringify(preferences, null, 2));
-    
-    // Map any variation of "either" to "flexible"
     if (roomTypeValue) {
       const normalizedValue = roomTypeValue.trim().toLowerCase();
-      if (normalizedValue.includes('either') || 
+      if (normalizedValue.includes('either') ||
           roomTypeValue === 'either Private or Shared' ||
           roomTypeValue === 'Either Private or Shared') {
-        console.log('✅ [savePreferences] Mapping room_type from "' + roomTypeValue + '" to "flexible"');
         mappedPreferences.room_type = 'flexible';
       } else if (!['private', 'shared', 'entire', 'flexible'].includes(roomTypeValue)) {
-        // If it's not a valid value, set to undefined to avoid constraint violation
-        console.warn('⚠️ [savePreferences] Invalid room_type value:', roomTypeValue, '- setting to undefined');
         mappedPreferences.room_type = undefined;
       }
     }
-    
-    console.log('💾 [savePreferences] Final room_type value being saved:', mappedPreferences.room_type);
 
     // Check if preferences exist
     const existing = await hasPreferences(userId);

--- a/apps/mobile/lib/preferences.ts
+++ b/apps/mobile/lib/preferences.ts
@@ -73,6 +73,7 @@ export interface Preferences {
   interests?: Record<string, string[]>;
   dealbreakers?: Record<string, 'hard' | 'soft' | 'none'>;
   ethnicity_preference?: string[];
+  gender_preference?: string;
   has_listing_only?: boolean;
   created_at?: string;
   updated_at?: string;

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -25,6 +25,7 @@ import { getDiscoverUsage, recordDiscoverAction } from '../lib/dailyDiscoverUsag
 import { FREE_TIER_LIMITS } from '../lib/freeTierLimits';
 import { usePurchases } from '../context/PurchasesContext';
 import SwipeCard from '../components/SwipeCard';
+import DiscoverFiltersModal from '../components/DiscoverFiltersModal';
 import type { MainTabParamList } from '../navigation/MainTabNavigator';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -93,6 +94,7 @@ export default function DiscoverScreen() {
   const [matchData, setMatchData] = useState<MatchData | null>(null);
   const [loading, setLoading] = useState(true);
   const [dailyUsage, setDailyUsage] = useState({ swipes: 0, topPicks: 0 });
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const translateX = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(0)).current;
@@ -289,8 +291,8 @@ export default function DiscoverScreen() {
           </View>
           <View style={styles.headerRight}>
             <Text style={styles.nearbyPill}>{remaining} nearby</Text>
-            <TouchableOpacity style={styles.headerIconBtn}>
-              <DotsThreeVertical size={20} color={C.white} weight="bold" />
+            <TouchableOpacity style={styles.headerIconBtn} onPress={() => setFiltersOpen(true)}>
+              <DotsThreeVertical size={20} color={C.text} weight="bold" />
             </TouchableOpacity>
           </View>
         </View>
@@ -325,6 +327,16 @@ export default function DiscoverScreen() {
         </View>
 
       </SafeAreaView>
+
+      {/* ── Filters modal ── */}
+      {userId ? (
+        <DiscoverFiltersModal
+          visible={filtersOpen}
+          userId={userId}
+          onClose={() => setFiltersOpen(false)}
+          onApply={() => userId && loadProfiles(userId)}
+        />
+      ) : null}
 
       {/* ── Match modal ── */}
       <Modal visible={!!matchData} transparent animationType="fade">
@@ -412,22 +424,22 @@ const styles = StyleSheet.create({
   headerMetrics: {
     marginTop: 4,
     fontSize: 12,
-    color: 'rgba(255,255,255,0.7)',
+    color: 'rgba(26,44,36,0.65)',
     fontWeight: '600',
     lineHeight: 16,
   },
   headerMetricsPremium: {
     marginTop: 4,
     fontSize: 12,
-    color: 'rgba(255,255,255,0.9)',
+    color: '#1A2C24',
     fontWeight: '700',
   },
   headerRight: { flexDirection: 'row', alignItems: 'center', gap: 10 },
   nearbyPill: {
     fontSize: 12,
     fontWeight: '600',
-    color: 'rgba(255,255,255,0.7)',
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    color: '#1A2C24',
+    backgroundColor: 'rgba(26,44,36,0.10)',
     paddingHorizontal: 10,
     paddingVertical: 4,
     borderRadius: 20,
@@ -435,7 +447,7 @@ const styles = StyleSheet.create({
   },
   headerIconBtn: {
     width: 36, height: 36, borderRadius: 18,
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: 'rgba(26,44,36,0.10)',
     alignItems: 'center', justifyContent: 'center',
   },
 

--- a/apps/mobile/screens/OnboardingScreen.tsx
+++ b/apps/mobile/screens/OnboardingScreen.tsx
@@ -67,7 +67,7 @@ const TOTAL_STEPS = 17;
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const PHOTO_THUMB = (SCREEN_WIDTH - 40 - 10) / 2;
 
-const GENDER_OPTIONS = ['Man', 'Woman', 'Non-binary', 'Other', 'Prefer not to say'];
+const GENDER_OPTIONS = ['Man', 'Woman', 'Non-binary', 'Trans man', 'Trans woman', 'Other', 'Prefer not to say'];
 
 const ETHNICITY_OPTIONS = [
   'Asian',
@@ -233,7 +233,7 @@ const STEPS: StepDef[] = [
   { icon: User,          question: "What's your name?",               subtitle: "This is how you'll appear to others." },
   { icon: Cake,          question: 'How old are you?',                subtitle: 'You must be 18+ to use RoomPear.' },
   { icon: Sparkle,       question: 'How do you identify?',            subtitle: 'Helps personalize your matches.' },
-  { icon: Globe,         question: "What's your ethnicity?",          subtitle: 'Optional — skip if you prefer not to say.', optional: true },
+  { icon: Globe,         question: 'A little more about you…',         subtitle: 'Both fields are optional — skip if you prefer.', optional: true },
   { icon: MapPin,        question: 'Where are you looking?',          subtitle: "We'll show you people in your area." },
   { icon: CurrencyDollar,question: "What's your monthly budget?",     subtitle: 'Your comfortable range for rent.' },
   { icon: Door,          question: 'What kind of room?',              subtitle: 'Pick what works for you.' },
@@ -331,8 +331,9 @@ export default function OnboardingScreen({ onComplete }: Props) {
   const [age, setAge] = useState('');
   // Step 2: Gender
   const [gender, setGender] = useState('');
-  // Step 3: Ethnicity
+  // Step 3: Ethnicity + gender preference
   const [ethnicity, setEthnicity] = useState('');
+  const [genderPref, setGenderPref] = useState('');
   // Step 4: Location
   const isExpoGo = Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
   const useLegacyLocationUi = !Constants.expoConfig?.extra?.mapboxAccessToken || isExpoGo;
@@ -512,6 +513,7 @@ export default function OnboardingScreen({ onComplete }: Props) {
         social_preference: socialPrefMapped as any,
         interests: Object.values(interests).some((v) => v.length > 0) ? interests : undefined,
         dealbreakers,
+        gender_preference: genderPref || '',
       });
 
       if (!result.success) { Alert.alert('Error', result.error ?? 'Could not save preferences.'); setSaving(false); return; }
@@ -729,6 +731,20 @@ export default function OnboardingScreen({ onComplete }: Props) {
                 onPress={() => { setEthnicity(ethnicity === e ? '' : e); scheduleAutoAdvance(); }}
               />
             ))}
+            <Text style={styles.sectionLabel}>Who would you like to live with?</Text>
+            {(['Man', 'Woman', 'Non-binary'] as const).map((g) => (
+              <Chip
+                key={g}
+                label={g === 'Man' ? 'Men' : g === 'Woman' ? 'Women' : 'Non-binary'}
+                selected={genderPref === g}
+                onPress={() => setGenderPref(genderPref === g ? '' : g)}
+              />
+            ))}
+            <Chip
+              label="Anyone"
+              selected={genderPref === ''}
+              onPress={() => setGenderPref('')}
+            />
           </View>
         );
 


### PR DESCRIPTION

- Adds a filters bottom sheet accessible from the ⋮ button on the Discover tab
- Filters: monthly budget (sliders, up to unlimited), move-in date, lease duration, room type, has listing toggle, and ethnicity preference
- Has listing toggle is a hard filter — only shows profiles with a place listed
- All other filters are soft — compatible profiles rank higher in the deck, no one is excluded
- Ethnicity preference gives a +0.08 score boost, move-in +0.04, lease duration +0.03
- Adds ethnicity_preference and has_listing_only columns to the preferences table
- Cleans up debug console.log statements from savePreferences