### PR TITLE
Add pause profile feature

### DIFF
--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -126,6 +126,7 @@ export async function fetchDiscoverProfiles(
     )
     .neq('id', userId)
     .not('profile_photo_url', 'is', null)
+    .neq('is_paused', true)
     .limit(50);
 
   if (swipedIds.length > 0) {

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -93,6 +93,7 @@ export default function DiscoverScreen() {
   const [matchData, setMatchData] = useState<MatchData | null>(null);
   const [loading, setLoading] = useState(true);
   const [dailyUsage, setDailyUsage] = useState({ swipes: 0, topPicks: 0 });
+  const [isPaused, setIsPaused] = useState(false);
 
   const translateX = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(0)).current;
@@ -111,9 +112,10 @@ export default function DiscoverScreen() {
         loadProfiles(uid);
         const { data: me } = await supabase
           .from('profiles')
-          .select('profile_photo_url, hobbies')
+          .select('profile_photo_url, hobbies, is_paused')
           .eq('id', uid)
           .single();
+        setIsPaused(me?.is_paused === true);
         if (me?.profile_photo_url) {
           const paths = profilePhotoPathsFromRow(me.profile_photo_url);
           if (paths[0]) {
@@ -144,7 +146,14 @@ export default function DiscoverScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      if (userId) refreshDailyUsage(userId);
+      if (!userId) return;
+      refreshDailyUsage(userId);
+      supabase
+        .from('profiles')
+        .select('is_paused')
+        .eq('id', userId)
+        .single()
+        .then(({ data }) => setIsPaused(data?.is_paused === true));
     }, [userId, refreshDailyUsage])
   );
 
@@ -242,6 +251,32 @@ export default function DiscoverScreen() {
       <Background>
         <View style={styles.centered}>
           <Text style={styles.emptyText}>Finding roommates…</Text>
+        </View>
+      </Background>
+    );
+  }
+
+  if (isPaused) {
+    return (
+      <Background>
+        <View style={styles.centered}>
+          <Text style={styles.emptyTitle}>Your profile is paused</Text>
+          <Text style={styles.emptyText}>
+            {"You're hidden from discover.\nUnpause to start swiping again."}
+          </Text>
+          <TouchableOpacity
+            style={styles.refreshBtn}
+            onPress={async () => {
+              if (!userId) return;
+              const { error } = await supabase
+                .from('profiles')
+                .update({ is_paused: false })
+                .eq('id', userId);
+              if (!error) setIsPaused(false);
+            }}
+          >
+            <Text style={styles.refreshBtnText}>Unpause my profile</Text>
+          </TouchableOpacity>
         </View>
       </Background>
     );

--- a/apps/mobile/screens/UserProfileScreen.tsx
+++ b/apps/mobile/screens/UserProfileScreen.tsx
@@ -123,6 +123,7 @@ export default function UserProfileScreen({ route }: Props) {
     'photos' | 'interests' | 'dealbreakers' | 'prompts' | null
   >(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const [savingProfile, setSavingProfile] = useState(false);
   const [savingPhotos, setSavingPhotos] = useState(false);
   const [savingPrefs, setSavingPrefs] = useState(false);
@@ -381,6 +382,7 @@ export default function UserProfileScreen({ route }: Props) {
     }
 
     setProfile(data);
+    setIsPaused(data?.is_paused === true);
 
     const paths = profilePhotoPathsFromRow(data?.profile_photo_url);
     setPhotoPaths(paths);
@@ -549,6 +551,19 @@ export default function UserProfileScreen({ route }: Props) {
     await logoutPurchases();
     const { error } = await supabase.auth.signOut();
     if (error) Alert.alert('Error', error.message);
+  };
+
+  const handleTogglePause = async (value: boolean) => {
+    if (!user) return;
+    setIsPaused(value);
+    const { error } = await supabase
+      .from('profiles')
+      .update({ is_paused: value })
+      .eq('id', user.id);
+    if (error) {
+      setIsPaused(!value);
+      Alert.alert('Error', 'Could not update visibility. Try again.');
+    }
   };
 
   const handleCopyReferralCode = async (code: string) => {
@@ -722,6 +737,15 @@ export default function UserProfileScreen({ route }: Props) {
                     />
                   </View>
                 </View>
+
+                {isPaused && (
+                  <View style={styles.pausedBanner}>
+                    <Ionicons name="pause-circle-outline" size={16} color="#7A5C00" />
+                    <Text style={styles.pausedBannerText}>
+                      Your profile is paused — you won't appear in discover
+                    </Text>
+                  </View>
+                )}
 
                 <ProfileOverviewSection
                   displayName={displayName}
@@ -1178,6 +1202,8 @@ export default function UserProfileScreen({ route }: Props) {
         onOpenEditName={() => afterCloseSettings(() => openEditName())}
         onOpenListing={() => afterCloseSettings(() => openListingModal())}
         onDeleteListing={handleDeleteListing}
+        isPaused={isPaused}
+        onTogglePause={handleTogglePause}
         onCopyReferralCode={handleCopyReferralCode}
         onApplyReferralCode={handleApplyReferralCode}
         onSignOut={handleSignOut}
@@ -2219,5 +2245,24 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     fontSize: 15,
     color: theme.foreground,
+  },
+  pausedBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: '#FFF8E1',
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#F0C040',
+  },
+  pausedBannerText: {
+    flex: 1,
+    fontSize: 13,
+    color: '#7A5C00',
+    fontWeight: '500',
   },
 });

--- a/apps/mobile/screens/profile/SettingsModal.tsx
+++ b/apps/mobile/screens/profile/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Modal, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Modal, ScrollView, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { Listing } from '../../lib/listings';
 import { formatAvailabilityForDisplay } from './listingFormUtils';
@@ -19,6 +19,8 @@ type Props = {
   onDeleteListing: () => void;
   onCopyReferralCode: (code: string) => void;
   onApplyReferralCode: () => void;
+  isPaused: boolean;
+  onTogglePause: (value: boolean) => void;
   onSignOut: () => void;
   onDevShowOnboarding?: () => void;
   styles: Record<string, unknown>;
@@ -38,6 +40,8 @@ export default function SettingsModal({
   onOpenEditName,
   onOpenListing,
   onDeleteListing,
+  isPaused,
+  onTogglePause,
   onCopyReferralCode,
   onApplyReferralCode,
   onSignOut,
@@ -205,6 +209,27 @@ export default function SettingsModal({
               <Text style={styles.settingsInfoValue as object}>
                 {(profile?.subscription_tier as string) || 'free'}
               </Text>
+            </View>
+          </View>
+
+          <Text style={styles.settingsSectionLabel as object}>Visibility</Text>
+          <View style={styles.settingsGroup as object}>
+            <View style={styles.settingsRow as object}>
+              <View style={styles.settingsRowLeft as object}>
+                <Ionicons name="pause-circle-outline" size={20} color={theme.foreground} />
+                <View>
+                  <Text style={styles.settingsRowTitle as object}>Pause my profile</Text>
+                  <Text style={[styles.settingsInfoLabel as object, { fontSize: 12 }]}>
+                    {isPaused ? 'Hidden from discover' : 'Visible to others'}
+                  </Text>
+                </View>
+              </View>
+              <Switch
+                value={isPaused}
+                onValueChange={onTogglePause}
+                trackColor={{ false: '#D1D5DB', true: '#4A7C59' }}
+                thumbColor="#FFFFFF"
+              />
             </View>
           </View>
 


### PR DESCRIPTION
Users can pause their profile from Settings to hide themselves from discover without deleting their account. Paused users are filtered from all other users' decks, and see a blocked swipe screen with a one-tap unpause button. 

DB: adds is_paused boolean column to profiles, default is false.

- Adds `is_paused` boolean to `profiles` (default is false)
- Paused users filtered from all discover decks
- Paused users see a blocked swipe screen with a one-tap Unpause button
- Settings modal gets a Visibility section with a Switch toggle (optimistic + rollback)
- Amber banner on Profile tab confirms when hidden