### PR TITLE
Add block and report with blocked users management

### DIFF
--- a/apps/mobile/components/BlockReportModal.tsx
+++ b/apps/mobile/components/BlockReportModal.tsx
@@ -1,0 +1,276 @@
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useState } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { blockUser, reportUser } from '../lib/blockReport';
+
+const REASONS = [
+  'Fake profile',
+  'Inappropriate photos',
+  'Harassment',
+  'Spam or scam',
+  'Underage user',
+  'Other',
+];
+
+type Props = {
+  visible: boolean;
+  reporterId: string;
+  reportedId: string;
+  reportedName: string;
+  onClose: () => void;
+  onBlocked: () => void;
+};
+
+export default function BlockReportModal({
+  visible,
+  reporterId,
+  reportedId,
+  reportedName,
+  onClose,
+  onBlocked,
+}: Props) {
+  const insets = useSafeAreaInsets();
+  const [selectedReason, setSelectedReason] = useState<string | null>(null);
+  const [details, setDetails] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  function reset() {
+    setSelectedReason(null);
+    setDetails('');
+    setBusy(false);
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  async function handleReport() {
+    if (!selectedReason) return;
+    setBusy(true);
+    const { success, error } = await reportUser(reporterId, reportedId, selectedReason, details);
+    setBusy(false);
+    if (!success) {
+      Alert.alert('Error', error ?? 'Could not submit report. Try again.');
+      return;
+    }
+    reset();
+    onClose();
+    Alert.alert('Report submitted', 'Thanks for keeping RoomPear safe. We\'ll review this shortly.');
+  }
+
+  async function handleBlock() {
+    Alert.alert(
+      `Block ${reportedName}?`,
+      "They won't appear in your discover and you won't appear in theirs.",
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Block',
+          style: 'destructive',
+          onPress: async () => {
+            setBusy(true);
+            await blockUser(reporterId, reportedId);
+            setBusy(false);
+            reset();
+            onClose();
+            onBlocked();
+          },
+        },
+      ]
+    );
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={handleClose}
+    >
+      <View style={[styles.root, { paddingBottom: insets.bottom + 16 }]}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={handleClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+            <Text style={styles.cancel}>Cancel</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>Report {reportedName}</Text>
+          <View style={{ width: 56 }} />
+        </View>
+
+        <ScrollView contentContainerStyle={styles.body} showsVerticalScrollIndicator={false}>
+          <Text style={styles.sectionLabel}>Why are you reporting this profile?</Text>
+          <View style={styles.reasonsGroup}>
+            {REASONS.map((reason, i) => (
+              <TouchableOpacity
+                key={reason}
+                style={[
+                  styles.reasonRow,
+                  i < REASONS.length - 1 && styles.reasonDivider,
+                  selectedReason === reason && styles.reasonRowSelected,
+                ]}
+                onPress={() => setSelectedReason(reason)}
+              >
+                <Text style={[styles.reasonText, selectedReason === reason && styles.reasonTextSelected]}>
+                  {reason}
+                </Text>
+                <View style={[styles.radio, selectedReason === reason && styles.radioSelected]}>
+                  {selectedReason === reason && <View style={styles.radioDot} />}
+                </View>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <Text style={styles.sectionLabel}>Additional details (optional)</Text>
+          <TextInput
+            style={styles.detailsInput}
+            placeholder="Describe what happened…"
+            placeholderTextColor="#A0A8A4"
+            multiline
+            numberOfLines={4}
+            value={details}
+            onChangeText={setDetails}
+            maxLength={500}
+          />
+
+          <TouchableOpacity
+            style={[styles.submitBtn, !selectedReason && styles.submitBtnDisabled]}
+            onPress={handleReport}
+            disabled={!selectedReason || busy}
+          >
+            {busy ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.submitBtnText}>Submit report</Text>
+            )}
+          </TouchableOpacity>
+
+          <View style={styles.dividerRow}>
+            <View style={styles.dividerLine} />
+            <Text style={styles.dividerLabel}>or</Text>
+            <View style={styles.dividerLine} />
+          </View>
+
+          <TouchableOpacity style={styles.blockBtn} onPress={handleBlock} disabled={busy}>
+            <Text style={styles.blockBtnText}>Block {reportedName}</Text>
+          </TouchableOpacity>
+          <Text style={styles.blockHelp}>
+            Blocking removes them from your discover deck and hides you from theirs.
+          </Text>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0,0,0,0.1)',
+  },
+  cancel: { fontSize: 16, color: '#2D6A4F', fontWeight: '500' },
+  title: { fontSize: 17, fontWeight: '700', color: '#1A2C24' },
+  body: { padding: 16, gap: 12 },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#717182',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 8,
+  },
+  reasonsGroup: {
+    backgroundColor: '#F3F3F5',
+    borderRadius: 12,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(0,0,0,0.08)',
+  },
+  reasonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    backgroundColor: '#F3F3F5',
+  },
+  reasonRowSelected: { backgroundColor: '#EBF5EF' },
+  reasonDivider: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0,0,0,0.08)',
+  },
+  reasonText: { fontSize: 15, color: '#252525', flex: 1 },
+  reasonTextSelected: { color: '#2D6A4F', fontWeight: '600' },
+  radio: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: '#C0C0CC',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radioSelected: { borderColor: '#2D6A4F' },
+  radioDot: { width: 10, height: 10, borderRadius: 5, backgroundColor: '#2D6A4F' },
+  detailsInput: {
+    backgroundColor: '#F3F3F5',
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(0,0,0,0.08)',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '#252525',
+    minHeight: 100,
+    textAlignVertical: 'top',
+  },
+  submitBtn: {
+    backgroundColor: '#1A2C24',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  submitBtnDisabled: { opacity: 0.4 },
+  submitBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginVertical: 4,
+  },
+  dividerLine: { flex: 1, height: StyleSheet.hairlineWidth, backgroundColor: 'rgba(0,0,0,0.1)' },
+  dividerLabel: { fontSize: 13, color: '#717182' },
+  blockBtn: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: '#D4183D',
+  },
+  blockBtnText: { color: '#D4183D', fontSize: 16, fontWeight: '700' },
+  blockHelp: {
+    fontSize: 12,
+    color: '#A0A8A4',
+    textAlign: 'center',
+    marginTop: 4,
+  },
+});

--- a/apps/mobile/components/BlockedUsersModal.tsx
+++ b/apps/mobile/components/BlockedUsersModal.tsx
@@ -1,0 +1,170 @@
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useEffect, useState } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { getBlockedProfiles, unblockUser, type BlockedProfile } from '../lib/blockReport';
+import { getProfileImageUrls } from '../lib/storage';
+
+type Props = {
+  visible: boolean;
+  userId: string;
+  onClose: () => void;
+};
+
+export default function BlockedUsersModal({ visible, userId, onClose }: Props) {
+  const insets = useSafeAreaInsets();
+  const [blocked, setBlocked] = useState<(BlockedProfile & { signedUrl: string | null })[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [unblocking, setUnblocking] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    load();
+  }, [visible]);
+
+  async function load() {
+    setLoading(true);
+    const profiles = await getBlockedProfiles(userId);
+    const withUrls = await Promise.all(
+      profiles.map(async (p) => {
+        let signedUrl: string | null = null;
+        if (p.photoUrl) {
+          const urls = await getProfileImageUrls(p.photoUrl);
+          signedUrl = urls?.[0] ?? null;
+        }
+        return { ...p, signedUrl };
+      })
+    );
+    setBlocked(withUrls);
+    setLoading(false);
+  }
+
+  async function handleUnblock(profile: BlockedProfile) {
+    Alert.alert(
+      `Unblock ${profile.name}?`,
+      'They may appear in your discover again.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Unblock',
+          onPress: async () => {
+            setUnblocking(profile.id);
+            await unblockUser(userId, profile.id);
+            setBlocked((prev) => prev.filter((p) => p.id !== profile.id));
+            setUnblocking(null);
+          },
+        },
+      ]
+    );
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={[styles.root, { paddingBottom: insets.bottom }]}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+            <Text style={styles.done}>Done</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>Blocked users</Text>
+          <View style={{ width: 48 }} />
+        </View>
+
+        {loading ? (
+          <View style={styles.centered}>
+            <ActivityIndicator color="#2D6A4F" />
+          </View>
+        ) : blocked.length === 0 ? (
+          <View style={styles.centered}>
+            <Text style={styles.emptyTitle}>No blocked users</Text>
+            <Text style={styles.emptySubtitle}>People you block will appear here.</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={blocked}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={styles.list}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+            renderItem={({ item }) => (
+              <View style={styles.row}>
+                {item.signedUrl ? (
+                  <Image source={{ uri: item.signedUrl }} style={styles.avatar} />
+                ) : (
+                  <View style={[styles.avatar, styles.avatarPlaceholder]}>
+                    <Text style={styles.avatarInitial}>{item.name[0]?.toUpperCase() ?? '?'}</Text>
+                  </View>
+                )}
+                <Text style={styles.name} numberOfLines={1}>{item.name}</Text>
+                <TouchableOpacity
+                  style={[styles.unblockBtn, unblocking === item.id && styles.unblockBtnDim]}
+                  onPress={() => handleUnblock(item)}
+                  disabled={unblocking === item.id}
+                >
+                  {unblocking === item.id ? (
+                    <ActivityIndicator color="#2D6A4F" size="small" />
+                  ) : (
+                    <Text style={styles.unblockBtnText}>Unblock</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            )}
+          />
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#FFFFFF' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0,0,0,0.1)',
+  },
+  done: { fontSize: 16, color: '#2D6A4F', fontWeight: '500' },
+  title: { fontSize: 17, fontWeight: '700', color: '#1A2C24' },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8 },
+  emptyTitle: { fontSize: 18, fontWeight: '700', color: '#1A2C24' },
+  emptySubtitle: { fontSize: 14, color: '#717182' },
+  list: { paddingHorizontal: 16, paddingTop: 8 },
+  separator: { height: StyleSheet.hairlineWidth, backgroundColor: 'rgba(0,0,0,0.08)' },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    gap: 12,
+  },
+  avatar: { width: 48, height: 48, borderRadius: 24, backgroundColor: '#ECECF0' },
+  avatarPlaceholder: { alignItems: 'center', justifyContent: 'center' },
+  avatarInitial: { fontSize: 20, fontWeight: '700', color: '#717182' },
+  name: { flex: 1, fontSize: 16, fontWeight: '600', color: '#1A2C24' },
+  unblockBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#2D6A4F',
+    minWidth: 80,
+    alignItems: 'center',
+  },
+  unblockBtnDim: { opacity: 0.5 },
+  unblockBtnText: { fontSize: 14, fontWeight: '600', color: '#2D6A4F' },
+});

--- a/apps/mobile/components/ChatStyleTopBar.tsx
+++ b/apps/mobile/components/ChatStyleTopBar.tsx
@@ -1,5 +1,6 @@
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { Flag } from 'phosphor-react-native';
 import {
   CHATS_CARD,
   CHATS_GREEN,
@@ -15,6 +16,7 @@ type Props = {
   onBack: () => void;
   topInset: number;
   backAccessibilityLabel?: string;
+  onReport?: () => void;
 };
 
 /** Floating back + title pills (matches Chat screen) — overlay on scroll content. */
@@ -23,6 +25,7 @@ export function ChatStyleTopBar({
   onBack,
   topInset,
   backAccessibilityLabel = 'Go back',
+  onReport,
 }: Props) {
   return (
     <View style={[styles.wrap, { paddingTop: topInset }]} pointerEvents="box-none">
@@ -45,7 +48,17 @@ export function ChatStyleTopBar({
           </View>
         </View>
 
-        <View style={styles.balance} />
+        {onReport ? (
+          <TouchableOpacity
+            onPress={onReport}
+            style={styles.roundBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+          >
+            <Flag size={20} color={CHATS_GREEN} />
+          </TouchableOpacity>
+        ) : (
+          <View style={styles.balance} />
+        )}
       </View>
     </View>
   );

--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -13,7 +13,7 @@ import {
   type ListRenderItemInfo,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { MapPin, ArrowCounterClockwise, X, Star, Heart } from 'phosphor-react-native';
+import { MapPin, ArrowCounterClockwise, X, Star, Heart, Flag } from 'phosphor-react-native';
 import type { DiscoverProfile } from '../lib/discover';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -31,13 +31,14 @@ interface Props {
   onLike?: () => void;
   onTopPick?: () => void;
   onUndo?: () => void;
+  onReport?: () => void;
   canUndo?: boolean;
   actionDisabled?: boolean;
 }
 
 export default function SwipeCard({
   profile,
-  onPass, onLike, onTopPick, onUndo,
+  onPass, onLike, onTopPick, onUndo, onReport,
   canUndo = false, actionDisabled = false,
 }: Props) {
   const [photoTab, setPhotoTab] = useState<PhotoTab>('profile');
@@ -129,6 +130,12 @@ export default function SwipeCard({
               style={styles.scrim}
               pointerEvents="none"
             />
+
+            {onReport && (
+              <TouchableOpacity style={styles.flagBtn} onPress={onReport} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+                <Flag size={18} color="rgba(255,255,255,0.85)" weight="fill" />
+              </TouchableOpacity>
+            )}
 
             {photoTab === 'profile' && (
               <View style={styles.overlay} pointerEvents="none">
@@ -552,4 +559,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   actionBtnDimmed: { opacity: 0.3 },
+  flagBtn: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });

--- a/apps/mobile/lib/blockReport.ts
+++ b/apps/mobile/lib/blockReport.ts
@@ -1,0 +1,85 @@
+import { supabase } from './supabase';
+
+export async function blockUser(
+  blockerId: string,
+  blockedId: string
+): Promise<{ success: boolean; error?: string }> {
+  const { error } = await supabase
+    .from('blocks')
+    .insert({ blocker_id: blockerId, blocked_id: blockedId });
+
+  if (error && error.code !== '23505') {
+    return { success: false, error: error.message };
+  }
+  return { success: true };
+}
+
+export async function reportUser(
+  reporterId: string,
+  reportedId: string,
+  reason: string,
+  details?: string
+): Promise<{ success: boolean; error?: string }> {
+  const { error } = await supabase.from('reports').insert({
+    reporter_id: reporterId,
+    reported_id: reportedId,
+    reason,
+    details: details?.trim() || null,
+  });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}
+
+export async function unblockUser(
+  blockerId: string,
+  blockedId: string
+): Promise<{ success: boolean; error?: string }> {
+  const { error } = await supabase
+    .from('blocks')
+    .delete()
+    .eq('blocker_id', blockerId)
+    .eq('blocked_id', blockedId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}
+
+export type BlockedProfile = {
+  id: string;
+  name: string;
+  photoUrl: string | null;
+};
+
+export async function getBlockedProfiles(userId: string): Promise<BlockedProfile[]> {
+  const { data, error } = await supabase
+    .from('blocks')
+    .select('blocked_id, profiles!blocks_blocked_id_fkey(id, name, profile_photo_url)')
+    .eq('blocker_id', userId);
+
+  if (error || !data) return [];
+
+  return (data as any[]).map((row) => {
+    const p = Array.isArray(row.profiles) ? row.profiles[0] : row.profiles;
+    return {
+      id: p?.id ?? row.blocked_id,
+      name: p?.name ?? 'Unknown',
+      photoUrl: Array.isArray(p?.profile_photo_url)
+        ? p.profile_photo_url[0] ?? null
+        : p?.profile_photo_url ?? null,
+    };
+  });
+}
+
+/** Returns all user IDs that the viewer has blocked OR that have blocked the viewer. */
+export async function getBlockedIds(userId: string): Promise<string[]> {
+  const [{ data: iBlocked }, { data: theyBlocked }] = await Promise.all([
+    supabase.from('blocks').select('blocked_id').eq('blocker_id', userId),
+    supabase.from('blocks').select('blocker_id').eq('blocked_id', userId),
+  ]);
+
+  const ids = new Set<string>();
+  iBlocked?.forEach((r: any) => ids.add(r.blocked_id));
+  theyBlocked?.forEach((r: any) => ids.add(r.blocker_id));
+  return Array.from(ids);
+}

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -4,6 +4,7 @@ import { getPreferences, type Preferences } from './preferences';
 import { passesHardFilters, scoreCompatibility, applyWildcardMix } from './matching';
 import { sendPushNotification } from './pushNotifications';
 import { isWithinRadiusMiles } from './distance';
+import { getBlockedIds } from './blockReport';
 
 export type PromptEntry = { question: string; answer: string };
 
@@ -109,13 +110,14 @@ export async function fetchDiscoverProfiles(
     return [];
   }
 
-  // Get IDs the user has already swiped on
-  const { data: swipedRows } = await supabase
-    .from('swipes')
-    .select('swiped_id')
-    .eq('swiper_id', userId);
+  // Get IDs the user has already swiped on + blocked (either direction)
+  const [{ data: swipedRows }, blockedIds] = await Promise.all([
+    supabase.from('swipes').select('swiped_id').eq('swiper_id', userId),
+    getBlockedIds(userId),
+  ]);
 
   const swipedIds = swipedRows?.map((r: any) => r.swiped_id) ?? [];
+  const excludedIds = Array.from(new Set([...swipedIds, ...blockedIds]));
 
   // Fetch a larger candidate pool so filtering still leaves enough results
   let query = supabase
@@ -138,8 +140,8 @@ export async function fetchDiscoverProfiles(
     query = query.eq('gender', myPrefs.gender_preference);
   }
 
-  if (swipedIds.length > 0) {
-    query = query.not('id', 'in', `(${swipedIds.join(',')})`);
+  if (excludedIds.length > 0) {
+    query = query.not('id', 'in', `(${excludedIds.join(',')})`);
   }
 
   if (Array.isArray(nearbyIds)) {

--- a/apps/mobile/screens/ChatScreen.tsx
+++ b/apps/mobile/screens/ChatScreen.tsx
@@ -30,6 +30,7 @@ import {
   CHATS_GREEN_BORDER,
 } from '../theme/chatsAmbient';
 import { ChatStyleTopBar } from '../components/ChatStyleTopBar';
+import BlockReportModal from '../components/BlockReportModal';
 
 type Props = NativeStackScreenProps<ChatsStackParamList, 'Chat'>;
 
@@ -114,6 +115,7 @@ export default function ChatScreen({ navigation, route }: Props) {
   const [loading, setLoading] = useState(!!initialConversationId);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   /** Bottom inset for keyboard — avoids KeyboardAvoidingView fighting FlatList (jitter). */
   const [keyboardBottom, setKeyboardBottom] = useState(0);
   const listRef = useRef<FlatList<ChatListItem>>(null);
@@ -262,6 +264,7 @@ export default function ChatScreen({ navigation, route }: Props) {
             onBack={() => navigation.goBack()}
             topInset={insets.top}
             backAccessibilityLabel="Back to chats"
+            onReport={otherUserId ? () => setReportOpen(true) : undefined}
           />
         </View>
         <View style={[styles.centered, { paddingTop: insets.top + 56 }]}>
@@ -354,6 +357,19 @@ export default function ChatScreen({ navigation, route }: Props) {
           </TouchableOpacity>
         </View>
       </View>
+      {myUserId && otherUserId && (
+        <BlockReportModal
+          visible={reportOpen}
+          reporterId={myUserId}
+          reportedId={otherUserId}
+          reportedName={title}
+          onClose={() => setReportOpen(false)}
+          onBlocked={() => {
+            setReportOpen(false);
+            navigation.goBack();
+          }}
+        />
+      )}
     </Background>
   );
 }

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -27,6 +27,7 @@ import { usePurchases } from '../context/PurchasesContext';
 import { hasRoomPearPlusEntitlement, isPremiumProfileTier } from '../lib/purchasesConfig';
 import SwipeCard from '../components/SwipeCard';
 import DiscoverFiltersModal from '../components/DiscoverFiltersModal';
+import BlockReportModal from '../components/BlockReportModal';
 import type { MainTabParamList } from '../navigation/MainTabNavigator';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -98,6 +99,7 @@ export default function DiscoverScreen() {
   const [dailyUsage, setDailyUsage] = useState({ swipes: 0, topPicks: 0 });
   const [isPaused, setIsPaused] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [reportTarget, setReportTarget] = useState<{ id: string; name: string } | null>(null);
 
   const translateX = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(0)).current;
@@ -379,6 +381,7 @@ export default function DiscoverScreen() {
               onUndo={handleUndo}
               canUndo={currentIndex > 0}
               actionDisabled={actionDisabled}
+              onReport={() => setReportTarget({ id: currentProfile.id, name: currentProfile.name })}
             />
           </Animated.View>
         </View>
@@ -446,6 +449,20 @@ export default function DiscoverScreen() {
           </View>
         </View>
       </Modal>
+
+      {reportTarget && userId && (
+        <BlockReportModal
+          visible={!!reportTarget}
+          reporterId={userId}
+          reportedId={reportTarget.id}
+          reportedName={reportTarget.name}
+          onClose={() => setReportTarget(null)}
+          onBlocked={() => {
+            setReportTarget(null);
+            setCurrentIndex(i => i + 1);
+          }}
+        />
+      )}
     </Background>
   );
 }

--- a/apps/mobile/screens/UserProfileScreen.tsx
+++ b/apps/mobile/screens/UserProfileScreen.tsx
@@ -37,6 +37,7 @@ import { getListing, saveListing, deleteListing, type Listing } from '../lib/lis
 import ProfileOverviewSection from './profile/ProfileOverviewSection';
 import ListingModal from './profile/ListingModal';
 import SettingsModal from './profile/SettingsModal';
+import BlockedUsersModal from '../components/BlockedUsersModal';
 import EditNameModal from './profile/EditNameModal';
 import {
   DEALBREAKER_ITEMS,
@@ -124,6 +125,7 @@ export default function UserProfileScreen({ route }: Props) {
   >(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+  const [blockedUsersOpen, setBlockedUsersOpen] = useState(false);
   const [savingProfile, setSavingProfile] = useState(false);
   const [savingPhotos, setSavingPhotos] = useState(false);
   const [savingPrefs, setSavingPrefs] = useState(false);
@@ -1398,6 +1400,7 @@ export default function UserProfileScreen({ route }: Props) {
         onDeleteListing={handleDeleteListing}
         isPaused={isPaused}
         onTogglePause={handleTogglePause}
+        onOpenBlockedUsers={() => afterCloseSettings(() => setBlockedUsersOpen(true))}
         onCopyReferralCode={handleCopyReferralCode}
         onApplyReferralCode={handleApplyReferralCode}
         isPremium={showRoomPearPlus}
@@ -1412,6 +1415,14 @@ export default function UserProfileScreen({ route }: Props) {
         styles={styles}
         theme={theme}
       />
+
+      {user && (
+        <BlockedUsersModal
+          visible={blockedUsersOpen}
+          userId={user.id}
+          onClose={() => setBlockedUsersOpen(false)}
+        />
+      )}
 
       <EditNameModal
         visible={editNameOpen}

--- a/apps/mobile/screens/profile/SettingsModal.tsx
+++ b/apps/mobile/screens/profile/SettingsModal.tsx
@@ -24,6 +24,7 @@ type Props = {
   isPremium: boolean;
   onUpgradeToPlus: () => void;
   onManageSubscription: () => void;
+  onOpenBlockedUsers: () => void;
   onSignOut: () => void;
   onDevShowOnboarding?: () => void;
   styles: Record<string, unknown>;
@@ -45,6 +46,7 @@ export default function SettingsModal({
   onDeleteListing,
   isPaused,
   onTogglePause,
+  onOpenBlockedUsers,
   onCopyReferralCode,
   onApplyReferralCode,
   isPremium,
@@ -254,6 +256,17 @@ export default function SettingsModal({
                 thumbColor="#FFFFFF"
               />
             </View>
+          </View>
+
+          <Text style={styles.settingsSectionLabel as object}>Privacy & safety</Text>
+          <View style={styles.settingsGroup as object}>
+            <TouchableOpacity style={styles.settingsRow as object} onPress={onOpenBlockedUsers}>
+              <View style={styles.settingsRowLeft as object}>
+                <Ionicons name="ban-outline" size={20} color={theme.foreground} />
+                <Text style={styles.settingsRowTitle as object}>Blocked users</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={18} color={theme.mutedForeground} />
+            </TouchableOpacity>
           </View>
 
           <Text style={styles.settingsSectionLabel as object}>More</Text>


### PR DESCRIPTION
Users can block or report from the swipe deck (flag icon on card) or from an active chat (flag icon in header). Blocking is bidirectional — blocked users are filtered from both users' discover decks. Settings gets a Privacy & safety section with a Blocked Users list where users can unblock anyone they've previously blocked.

DB: adds blocks table (unique pair, RLS) and reports table (RLS).