### PR TITLE
Roo 8 matching compatibility logic

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -53,6 +53,9 @@ export default function App() {
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       await checkUserState(session);
+      if (session?.user?.id) {
+        supabase.from('profiles').update({ last_active_at: new Date().toISOString() }).eq('id', session.user.id);
+      }
       setLoading(false);
     });
 

--- a/apps/mobile/__tests__/lib/matching.test.ts
+++ b/apps/mobile/__tests__/lib/matching.test.ts
@@ -1,0 +1,336 @@
+// Lazy-load matching (same pattern as other tests) to let Jest env stabilise first
+let passesHardFilters: any;
+let scoreCompatibility: any;
+let applyWildcardMix: any;
+let selectTopPicks: any;
+let getMatchReasons: any;
+
+beforeAll(() => {
+  jest.resetModules();
+  const m = require('../../lib/matching');
+  passesHardFilters = m.passesHardFilters;
+  scoreCompatibility = m.scoreCompatibility;
+  applyWildcardMix   = m.applyWildcardMix;
+  selectTopPicks     = m.selectTopPicks;
+  getMatchReasons    = m.getMatchReasons;
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function prefs(overrides: Record<string, any> = {}): any {
+  return {
+    user_id: 'test',
+    state: 'CA',
+    city: 'Riverside',
+    min_budget: 800,
+    max_budget: 1500,
+    cleanliness_level: 3,
+    social_preference: 'balanced',
+    work_schedule: '9-to-5',
+    interests: { fitness: ['Gym', 'Yoga'], music: ['Guitar'] },
+    dealbreakers: {},
+    ...overrides,
+  };
+}
+
+function meta(overrides: Record<string, any> = {}): any {
+  return {
+    name: 'Alex',
+    age: 22,
+    bio: 'Looking for a roommate',
+    hobbies: ['Gym'],
+    prompts: [
+      { question: 'Q1', answer: 'A1' },
+      { question: 'Q2', answer: 'A2' },
+    ],
+    subscription_tier: 'free',
+    ...overrides,
+  };
+}
+
+// ─── passesHardFilters ────────────────────────────────────────────────────────
+
+describe('passesHardFilters', () => {
+  test('passes when all data matches', () => {
+    expect(passesHardFilters(prefs(), prefs())).toBe(true);
+  });
+
+  test('fails on state mismatch', () => {
+    expect(passesHardFilters(prefs({ state: 'CA' }), prefs({ state: 'TX' }))).toBe(false);
+  });
+
+  test('passes when one side has no state', () => {
+    expect(passesHardFilters(prefs({ state: undefined }), prefs({ state: 'TX' }))).toBe(true);
+  });
+
+  test('fails on non-overlapping budgets', () => {
+    expect(passesHardFilters(
+      prefs({ min_budget: 500, max_budget: 800 }),
+      prefs({ min_budget: 900, max_budget: 1400 }),
+    )).toBe(false);
+  });
+
+  test('passes on touching budget ranges', () => {
+    expect(passesHardFilters(
+      prefs({ min_budget: 500, max_budget: 900 }),
+      prefs({ min_budget: 900, max_budget: 1400 }),
+    )).toBe(true);
+  });
+
+  test('pets hard dealbreaker — free users still see pet owners', () => {
+    const mine = prefs({ dealbreakers: { pets: 'hard' } });
+    const theirs = prefs({ pets_allowed: true });
+    expect(passesHardFilters(mine, theirs, false)).toBe(true);
+  });
+
+  test('pets hard dealbreaker — premium users exclude pet owners', () => {
+    const mine = prefs({ dealbreakers: { pets: 'hard' } });
+    const theirs = prefs({ pets_allowed: true });
+    expect(passesHardFilters(mine, theirs, true)).toBe(false);
+  });
+
+  test('smoking hard dealbreaker — premium only', () => {
+    const mine = prefs({ dealbreakers: { smoking: 'hard' } });
+    const theirs = prefs({ smoking_allowed: true });
+    expect(passesHardFilters(mine, theirs, false)).toBe(true);
+    expect(passesHardFilters(mine, theirs, true)).toBe(false);
+  });
+
+  test('parties hard dealbreaker — applies to all users', () => {
+    const mine = prefs({ dealbreakers: { parties: 'hard' } });
+    const theirs = prefs({ social_preference: 'social' });
+    expect(passesHardFilters(mine, theirs, false)).toBe(false);
+    expect(passesHardFilters(mine, theirs, true)).toBe(false);
+  });
+
+  test('early_bird hard dealbreaker blocks night shift candidate', () => {
+    const mine = prefs({ dealbreakers: { early_bird: 'hard' } });
+    const theirs = prefs({ work_schedule: 'Night Shift' });
+    expect(passesHardFilters(mine, theirs)).toBe(false);
+  });
+
+  test('messy hard dealbreaker blocks cleanliness ≤ 2', () => {
+    const mine = prefs({ dealbreakers: { messy: 'hard' } });
+    expect(passesHardFilters(mine, prefs({ cleanliness_level: 2 }))).toBe(false);
+    expect(passesHardFilters(mine, prefs({ cleanliness_level: 3 }))).toBe(true);
+  });
+
+  test('bidirectional — their dealbreakers check mine', () => {
+    const mine = prefs({ smoking_allowed: true });
+    const theirs = prefs({ dealbreakers: { smoking: 'hard' } });
+    expect(passesHardFilters(mine, theirs, false)).toBe(false);
+  });
+});
+
+// ─── scoreCompatibility ───────────────────────────────────────────────────────
+
+describe('scoreCompatibility', () => {
+  test('identical profiles score above 0.8', () => {
+    expect(scoreCompatibility(prefs(), prefs(), meta())).toBeGreaterThan(0.8);
+  });
+
+  test('score is in a valid range', () => {
+    const score = scoreCompatibility(prefs(), prefs(), meta());
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(2); // boosts can push above 1.0
+  });
+
+  test('shared interests score higher than no shared interests', () => {
+    const mine = prefs({ interests: { fitness: ['Gym'] } });
+    const shared  = scoreCompatibility(mine, prefs({ interests: { fitness: ['Gym'] } }), meta());
+    const noShare = scoreCompatibility(mine, prefs({ interests: { music: ['Jazz'] } }), meta());
+    expect(shared).toBeGreaterThan(noShare);
+  });
+
+  test('hard dealbreaker conflict reduces score by ~0.10', () => {
+    const mine = prefs({ dealbreakers: { smoking: 'hard' } });
+    const theirs = prefs({ smoking_allowed: true });
+    const withConflict = scoreCompatibility(mine, theirs, meta());
+    const noConflict   = scoreCompatibility(prefs(), theirs, meta());
+    expect(noConflict - withConflict).toBeCloseTo(0.10, 1);
+  });
+
+  test('soft dealbreaker conflict reduces score by ~0.05', () => {
+    const mine = prefs({ dealbreakers: { smoking: 'soft' } });
+    const theirs = prefs({ smoking_allowed: true });
+    const withConflict = scoreCompatibility(mine, theirs, meta());
+    const noConflict   = scoreCompatibility(prefs(), theirs, meta());
+    expect(noConflict - withConflict).toBeCloseTo(0.05, 1);
+  });
+
+  test('new user (<48h) gets boost vs old user', () => {
+    const recentMeta = meta({ created_at: new Date(Date.now() - 10 * 3_600_000).toISOString() });
+    const oldMeta    = meta({ created_at: new Date(Date.now() - 72 * 3_600_000).toISOString() });
+    expect(scoreCompatibility(prefs(), prefs(), recentMeta)).toBeGreaterThan(
+      scoreCompatibility(prefs(), prefs(), oldMeta)
+    );
+  });
+
+  test('premium tier gets visibility boost', () => {
+    const premium = scoreCompatibility(prefs(), prefs(), meta({ subscription_tier: 'premium' }));
+    const free    = scoreCompatibility(prefs(), prefs(), meta({ subscription_tier: 'free' }));
+    expect(premium).toBeGreaterThan(free);
+  });
+
+  test('social preference gradient: same > adjacent > opposite', () => {
+    const base = prefs({ social_preference: 'quiet' });
+    const same = scoreCompatibility(base, prefs({ social_preference: 'quiet' }), meta());
+    const adj  = scoreCompatibility(base, prefs({ social_preference: 'balanced' }), meta());
+    const opp  = scoreCompatibility(base, prefs({ social_preference: 'social' }), meta());
+    expect(same).toBeGreaterThan(adj);
+    expect(adj).toBeGreaterThan(opp);
+  });
+
+  test('work schedule: same > flexible > 9-to-5 vs Night Shift', () => {
+    const base = prefs({ work_schedule: '9-to-5' });
+    const same = scoreCompatibility(base, prefs({ work_schedule: '9-to-5' }), meta());
+    const flex = scoreCompatibility(base, prefs({ work_schedule: 'Flexible' }), meta());
+    const opp  = scoreCompatibility(base, prefs({ work_schedule: 'Night Shift' }), meta());
+    expect(same).toBeGreaterThan(flex);
+    expect(flex).toBeGreaterThan(opp);
+  });
+
+  test('ethnicity match gives boost', () => {
+    const mine = prefs({ ethnicity_preference: ['Asian'] });
+    const withMatch = scoreCompatibility(mine, prefs(), meta({ ethnicity: 'Asian' }));
+    const noMatch   = scoreCompatibility(mine, prefs(), meta({ ethnicity: 'Latino' }));
+    expect(withMatch).toBeGreaterThan(noMatch);
+  });
+
+  test('ethnicity mismatch does NOT penalise', () => {
+    const mine     = prefs({ ethnicity_preference: ['Asian'] });
+    const mismatch = scoreCompatibility(mine, prefs(), meta({ ethnicity: 'Latino' }));
+    const noPref   = scoreCompatibility(prefs(), prefs(), meta({ ethnicity: 'Latino' }));
+    expect(mismatch).toBeCloseTo(noPref, 5);
+  });
+
+  test('has_listing boost when viewer prefers listings', () => {
+    const withListing = scoreCompatibility(prefs(), prefs(), meta({ has_listing: true }),  { has_listing_only: true });
+    const noListing   = scoreCompatibility(prefs(), prefs(), meta({ has_listing: false }), { has_listing_only: true });
+    expect(withListing).toBeGreaterThan(noListing);
+  });
+});
+
+// ─── applyWildcardMix ─────────────────────────────────────────────────────────
+
+describe('applyWildcardMix', () => {
+  function items(scores: number[]) {
+    return scores.map((score, i) => ({ item: `p${i}`, score }));
+  }
+
+  test('returns up to count items', () => {
+    expect(applyWildcardMix(items([0.9, 0.8, 0.7, 0.5, 0.3]), 3).length).toBeLessThanOrEqual(3);
+  });
+
+  test('returns empty array for empty input', () => {
+    expect(applyWildcardMix([], 10)).toEqual([]);
+  });
+
+  test('all items have item and score fields', () => {
+    for (const r of applyWildcardMix(items([0.9, 0.5, 0.2]), 3)) {
+      expect(r).toHaveProperty('item');
+      expect(r).toHaveProperty('score');
+    }
+  });
+
+  test('free feed: ≥70% of results are high scorers (≥0.65)', () => {
+    const result = applyWildcardMix(
+      items([0.9, 0.85, 0.8, 0.75, 0.7, 0.55, 0.5, 0.3, 0.2]),
+      9, false
+    );
+    const highCount = result.filter((x: any) => x.score >= 0.65).length;
+    expect(highCount).toBeGreaterThanOrEqual(Math.floor(result.length * 0.65));
+  });
+
+  test('premium gets at least as many high scorers as free', () => {
+    const scored = items([0.9, 0.85, 0.8, 0.75, 0.7, 0.68, 0.55, 0.5, 0.3, 0.2]);
+    const freeHigh    = applyWildcardMix(scored, 10, false).filter((x: any) => x.score >= 0.65).length;
+    const premiumHigh = applyWildcardMix(scored, 10, true).filter((x: any) => x.score >= 0.65).length;
+    expect(premiumHigh).toBeGreaterThanOrEqual(freeHigh);
+  });
+
+  test('progressive fallback: works when pool is smaller than count', () => {
+    expect(applyWildcardMix(items([0.8, 0.7]), 10).length).toBe(2);
+  });
+});
+
+// ─── selectTopPicks ───────────────────────────────────────────────────────────
+
+describe('selectTopPicks', () => {
+  function scored(scores: number[]) {
+    return scores.map((score, i) => ({ item: `p${i}`, score }));
+  }
+
+  test('only returns profiles scoring ≥ 0.70', () => {
+    const result = selectTopPicks(scored([0.9, 0.75, 0.69, 0.5]), 10);
+    expect(result.every((x: any) => x.score >= 0.70)).toBe(true);
+    expect(result.length).toBe(2);
+  });
+
+  test('capped at count', () => {
+    expect(selectTopPicks(scored([0.9, 0.85, 0.8, 0.75]), 2).length).toBe(2);
+  });
+
+  test('sorted highest first', () => {
+    const result = selectTopPicks(scored([0.75, 0.9, 0.8]), 10);
+    expect(result[0].score).toBe(0.9);
+    expect(result[1].score).toBe(0.8);
+  });
+
+  test('returns empty when nothing meets threshold', () => {
+    expect(selectTopPicks(scored([0.5, 0.3]), 10)).toEqual([]);
+  });
+});
+
+// ─── getMatchReasons ──────────────────────────────────────────────────────────
+
+describe('getMatchReasons', () => {
+  test('shared interests appear in reasons (3+ shows count)', () => {
+    const mine   = prefs({ interests: { fitness: ['Gym', 'Yoga', 'Running'] } });
+    const theirs = prefs({ interests: { fitness: ['Gym', 'Yoga', 'Running', 'Hiking'] } });
+    // 3 shared → "3 shared interests"
+    expect(getMatchReasons(mine, theirs, meta()).some((r: string) => r.includes('shared interests'))).toBe(true);
+  });
+
+  test('close cleanliness levels produce a reason', () => {
+    expect(getMatchReasons(prefs({ cleanliness_level: 4 }), prefs({ cleanliness_level: 4 }), meta())
+      .some((r: string) => r.toLowerCase().includes('clean'))).toBe(true);
+  });
+
+  test('no cleanliness reason when levels differ by more than 1', () => {
+    expect(getMatchReasons(prefs({ cleanliness_level: 5 }), prefs({ cleanliness_level: 2 }), meta())
+      .some((r: string) => r.toLowerCase().includes('clean'))).toBe(false);
+  });
+
+  test('same social preference produces a reason', () => {
+    expect(getMatchReasons(prefs({ social_preference: 'quiet' }), prefs({ social_preference: 'quiet' }), meta())
+      .some((r: string) => r.toLowerCase().includes('quiet'))).toBe(true);
+  });
+
+  test('budget overlap produces a $ reason', () => {
+    expect(getMatchReasons(
+      prefs({ min_budget: 800, max_budget: 1200 }),
+      prefs({ min_budget: 1000, max_budget: 1500 }),
+      meta(),
+    ).some((r: string) => r.includes('$'))).toBe(true);
+  });
+
+  test('same city produces a location reason', () => {
+    // Use minimal prefs so city isn't crowded out by the 5-reason cap
+    const minimal = { user_id: 'x', city: 'Riverside', dealbreakers: {}, interests: {} };
+    expect(getMatchReasons(minimal as any, minimal as any, meta())
+      .some((r: string) => r.includes('Riverside'))).toBe(true);
+  });
+
+  test('at most 5 reasons returned', () => {
+    expect(getMatchReasons(prefs(), prefs(), meta()).length).toBeLessThanOrEqual(5);
+  });
+
+  test('always returns an array', () => {
+    expect(Array.isArray(getMatchReasons(
+      prefs({ interests: {}, city: 'LA', social_preference: 'quiet', cleanliness_level: 1 }),
+      prefs({ interests: {}, city: 'SF', social_preference: 'social', cleanliness_level: 5 }),
+      meta(),
+    ))).toBe(true);
+  });
+});

--- a/apps/mobile/components/DiscoverFiltersModal.tsx
+++ b/apps/mobile/components/DiscoverFiltersModal.tsx
@@ -68,6 +68,8 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
   const [hasListingOnly, setHasListingOnly] = useState(false);
   const [minBudget, setMinBudget] = useState(0);
   const [maxBudget, setMaxBudget] = useState(10000);
+  const [minAge, setMinAge] = useState(18);
+  const [maxAge, setMaxAge] = useState(99);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -83,6 +85,8 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
       setHasListingOnly(prefs?.has_listing_only ?? false);
       setMinBudget(prefs?.min_budget ?? 0);
       setMaxBudget(prefs?.max_budget ?? 10000);
+      setMinAge(prefs?.min_age ?? 18);
+      setMaxAge(prefs?.max_age ?? 99);
       setLoading(false);
     });
   }, [visible, userId]);
@@ -104,6 +108,8 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
         has_listing_only: hasListingOnly,
         min_budget: minBudget,
         max_budget: maxBudget,
+        min_age: minAge,
+        max_age: maxAge,
       });
       onApply();
       onClose();
@@ -121,6 +127,8 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
     setHasListingOnly(false);
     setMinBudget(0);
     setMaxBudget(10000);
+    setMinAge(18);
+    setMaxAge(99);
   };
 
   return (
@@ -211,6 +219,46 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
                 step={50}
                 value={maxBudget}
                 onValueChange={(v) => setMaxBudget(Math.max(v, minBudget + 50))}
+                minimumTrackTintColor="#1A3329"
+                maximumTrackTintColor="#D0D8D4"
+                thumbTintColor="#1A3329"
+              />
+
+              <View style={styles.divider} />
+
+              {/* Age range */}
+              <Text style={styles.sectionTitle}>Age range</Text>
+              <View style={styles.budgetDisplay}>
+                <View style={styles.budgetBadge}>
+                  <Text style={styles.budgetBadgeLabel}>Min</Text>
+                  <Text style={styles.budgetBadgeValue}>{minAge}</Text>
+                </View>
+                <View style={styles.budgetDash} />
+                <View style={styles.budgetBadge}>
+                  <Text style={styles.budgetBadgeLabel}>Max</Text>
+                  <Text style={styles.budgetBadgeValue}>{maxAge >= 99 ? 'Any' : maxAge}</Text>
+                </View>
+              </View>
+              <Text style={styles.sliderLabel}>Minimum age</Text>
+              <Slider
+                style={styles.slider}
+                minimumValue={18}
+                maximumValue={maxAge - 1}
+                step={1}
+                value={minAge}
+                onValueChange={(v) => setMinAge(Math.floor(v))}
+                minimumTrackTintColor="#1A3329"
+                maximumTrackTintColor="#D0D8D4"
+                thumbTintColor="#1A3329"
+              />
+              <Text style={styles.sliderLabel}>Maximum age</Text>
+              <Slider
+                style={styles.slider}
+                minimumValue={minAge + 1}
+                maximumValue={99}
+                step={1}
+                value={maxAge}
+                onValueChange={(v) => setMaxAge(Math.floor(v))}
                 minimumTrackTintColor="#1A3329"
                 maximumTrackTintColor="#D0D8D4"
                 thumbTintColor="#1A3329"

--- a/apps/mobile/components/DiscoverFiltersModal.tsx
+++ b/apps/mobile/components/DiscoverFiltersModal.tsx
@@ -56,9 +56,11 @@ interface Props {
   userId: string;
   onClose: () => void;
   onApply: () => void;
+  isPremium?: boolean;
+  onUpgrade?: () => void;
 }
 
-export default function DiscoverFiltersModal({ visible, userId, onClose, onApply }: Props) {
+export default function DiscoverFiltersModal({ visible, userId, onClose, onApply, isPremium = false, onUpgrade }: Props) {
   const insets = useSafeAreaInsets();
   const [ethnicityPref, setEthnicityPref] = useState<string[]>([]);
   const [roomType, setRoomType] = useState('');
@@ -343,6 +345,37 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
                 })}
               </View>
 
+              <View style={styles.divider} />
+
+              {/* Advanced Filters — premium only */}
+              {isPremium ? (
+                <View style={styles.advancedActive}>
+                  <Text style={styles.advancedActiveTitle}>✓ Advanced Filters active</Text>
+                  <Text style={styles.advancedActiveSub}>
+                    Your hard dealbreakers (pets, smoking, parties, cleanliness, sleep schedule, social vibe) strictly exclude incompatible profiles. Manage dealbreakers in onboarding settings.
+                  </Text>
+                </View>
+              ) : (
+                <TouchableOpacity
+                  style={styles.advancedLocked}
+                  onPress={onUpgrade}
+                  activeOpacity={0.8}
+                >
+                  <View style={styles.advancedLockedHeader}>
+                    <Text style={styles.advancedLockedTitle}>🔒 Advanced Filters</Text>
+                    <View style={styles.plusBadge}>
+                      <Text style={styles.plusBadgeText}>RoomPear+</Text>
+                    </View>
+                  </View>
+                  <Text style={styles.advancedLockedSub}>
+                    Convert soft preferences into hard filters — strictly exclude profiles with pets, smoking, parties, or incompatible cleanliness and schedules.
+                  </Text>
+                  <View style={styles.advancedUnlockBtn}>
+                    <Text style={styles.advancedUnlockBtnText}>Unlock with RoomPear+</Text>
+                  </View>
+                </TouchableOpacity>
+              )}
+
             </ScrollView>
           )}
 
@@ -502,6 +535,69 @@ const styles = StyleSheet.create({
     width: '100%',
     height: 36,
     marginBottom: 4,
+  },
+  advancedActive: {
+    backgroundColor: '#F0F5F2',
+    borderRadius: 14,
+    padding: 16,
+  },
+  advancedActiveTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1A3329',
+    marginBottom: 6,
+  },
+  advancedActiveSub: {
+    fontSize: 13,
+    color: '#717182',
+    lineHeight: 18,
+  },
+  advancedLocked: {
+    backgroundColor: '#F8F8FC',
+    borderRadius: 14,
+    borderWidth: 1.5,
+    borderColor: 'rgba(0,0,0,0.08)',
+    padding: 16,
+  },
+  advancedLockedHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  advancedLockedTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#1A2C24',
+  },
+  plusBadge: {
+    backgroundColor: '#030213',
+    borderRadius: 6,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+  },
+  plusBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    letterSpacing: 0.3,
+  },
+  advancedLockedSub: {
+    fontSize: 13,
+    color: '#717182',
+    lineHeight: 18,
+    marginBottom: 14,
+  },
+  advancedUnlockBtn: {
+    backgroundColor: '#030213',
+    borderRadius: 10,
+    paddingVertical: 11,
+    alignItems: 'center',
+  },
+  advancedUnlockBtnText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#FFFFFF',
   },
   applyBtn: {
     marginTop: 8,

--- a/apps/mobile/components/DiscoverFiltersModal.tsx
+++ b/apps/mobile/components/DiscoverFiltersModal.tsx
@@ -72,6 +72,12 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
   const [maxBudget, setMaxBudget] = useState(10000);
   const [minAge, setMinAge] = useState(18);
   const [maxAge, setMaxAge] = useState(99);
+  const [strictPets, setStrictPets] = useState(false);
+  const [strictSmoking, setStrictSmoking] = useState(false);
+  const [strictParties, setStrictParties] = useState(false);
+  const [strictCleanliness, setStrictCleanliness] = useState(false);
+  const [strictEarlyBird, setStrictEarlyBird] = useState(false);
+  const [strictNightOwl, setStrictNightOwl] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -89,6 +95,13 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
       setMaxBudget(prefs?.max_budget ?? 10000);
       setMinAge(prefs?.min_age ?? 18);
       setMaxAge(prefs?.max_age ?? 99);
+      const db = prefs?.dealbreakers ?? {};
+      setStrictPets(db.pets === 'hard');
+      setStrictSmoking(db.smoking === 'hard');
+      setStrictParties(db.parties === 'hard');
+      setStrictCleanliness(db.messy === 'hard');
+      setStrictEarlyBird(db.early_bird === 'hard');
+      setStrictNightOwl(db.night_owl === 'hard');
       setLoading(false);
     });
   }, [visible, userId]);
@@ -101,6 +114,16 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
   const handleApply = async () => {
     setSaving(true);
     try {
+      const dealbreakers: Record<string, string> = {};
+      if (isPremium) {
+        dealbreakers.pets       = strictPets        ? 'hard' : 'none';
+        dealbreakers.smoking    = strictSmoking     ? 'hard' : 'none';
+        dealbreakers.parties    = strictParties     ? 'hard' : 'none';
+        dealbreakers.messy      = strictCleanliness ? 'hard' : 'none';
+        dealbreakers.early_bird = strictEarlyBird   ? 'hard' : 'none';
+        dealbreakers.night_owl  = strictNightOwl    ? 'hard' : 'none';
+      }
+
       await savePreferences(userId, {
         gender_preference: genderPref || '',
         ethnicity_preference: ethnicityPref,
@@ -112,6 +135,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
         max_budget: maxBudget,
         min_age: minAge,
         max_age: maxAge,
+        ...(isPremium ? { dealbreakers } : {}),
       });
       onApply();
       onClose();
@@ -131,6 +155,12 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
     setMaxBudget(10000);
     setMinAge(18);
     setMaxAge(99);
+    setStrictPets(false);
+    setStrictSmoking(false);
+    setStrictParties(false);
+    setStrictCleanliness(false);
+    setStrictEarlyBird(false);
+    setStrictNightOwl(false);
   };
 
   return (
@@ -347,34 +377,53 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
 
               <View style={styles.divider} />
 
-              {/* Advanced Filters — premium only */}
-              {isPremium ? (
-                <View style={styles.advancedActive}>
-                  <Text style={styles.advancedActiveTitle}>✓ Advanced Filters active</Text>
-                  <Text style={styles.advancedActiveSub}>
-                    Your hard dealbreakers (pets, smoking, parties, cleanliness, sleep schedule, social vibe) strictly exclude incompatible profiles. Manage dealbreakers in onboarding settings.
-                  </Text>
-                </View>
-              ) : (
-                <TouchableOpacity
-                  style={styles.advancedLocked}
-                  onPress={onUpgrade}
-                  activeOpacity={0.8}
-                >
-                  <View style={styles.advancedLockedHeader}>
-                    <Text style={styles.advancedLockedTitle}>🔒 Advanced Filters</Text>
-                    <View style={styles.plusBadge}>
-                      <Text style={styles.plusBadgeText}>RoomPear+</Text>
-                    </View>
+              {/* Advanced Filters — visible to all, interactive for premium only */}
+              <View style={styles.advancedHeader}>
+                <Text style={styles.sectionTitle}>Advanced Filters</Text>
+                {!isPremium && (
+                  <View style={styles.plusBadge}>
+                    <Text style={styles.plusBadgeText}>RoomPear+</Text>
                   </View>
-                  <Text style={styles.advancedLockedSub}>
-                    Convert soft preferences into hard filters — strictly exclude profiles with pets, smoking, parties, or incompatible cleanliness and schedules.
-                  </Text>
-                  <View style={styles.advancedUnlockBtn}>
-                    <Text style={styles.advancedUnlockBtnText}>Unlock with RoomPear+</Text>
+                )}
+              </View>
+              <Text style={styles.sectionSub}>Strictly exclude profiles that don't meet these criteria.</Text>
+
+              <View style={[styles.advancedControls, !isPremium && styles.advancedControlsLocked]}>
+                {[
+                  { label: 'No pets',            value: strictPets,        set: setStrictPets },
+                  { label: 'No smoking',          value: strictSmoking,     set: setStrictSmoking },
+                  { label: 'No parties',          value: strictParties,     set: setStrictParties },
+                  { label: 'Strict cleanliness',  value: strictCleanliness, set: setStrictCleanliness },
+                  { label: 'No night owls',       value: strictEarlyBird,   set: setStrictEarlyBird },
+                  { label: 'No early birds',      value: strictNightOwl,    set: setStrictNightOwl },
+                ].map(({ label, value, set }) => (
+                  <View key={label} style={styles.advancedRow}>
+                    <Text style={styles.advancedRowLabel}>{label}</Text>
+                    <Switch
+                      value={value}
+                      onValueChange={isPremium ? set : undefined}
+                      disabled={!isPremium}
+                      trackColor={{ false: '#D0D0D8', true: '#1A3329' }}
+                      thumbColor="#FFFFFF"
+                    />
                   </View>
-                </TouchableOpacity>
-              )}
+                ))}
+
+                {!isPremium && (
+                  <View style={styles.advancedOverlay}>
+                    <Text style={styles.advancedOverlayText}>🔒 Upgrade to RoomPear+ to use advanced filters</Text>
+                  </View>
+                )}
+
+                {/* Transparent tap-catcher sits on top for free users */}
+                {!isPremium && (
+                  <TouchableOpacity
+                    style={StyleSheet.absoluteFill}
+                    onPress={() => { onClose(); onUpgrade?.(); }}
+                    activeOpacity={0.0}
+                  />
+                )}
+              </View>
 
             </ScrollView>
           )}
@@ -536,39 +585,11 @@ const styles = StyleSheet.create({
     height: 36,
     marginBottom: 4,
   },
-  advancedActive: {
-    backgroundColor: '#F0F5F2',
-    borderRadius: 14,
-    padding: 16,
-  },
-  advancedActiveTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#1A3329',
-    marginBottom: 6,
-  },
-  advancedActiveSub: {
-    fontSize: 13,
-    color: '#717182',
-    lineHeight: 18,
-  },
-  advancedLocked: {
-    backgroundColor: '#F8F8FC',
-    borderRadius: 14,
-    borderWidth: 1.5,
-    borderColor: 'rgba(0,0,0,0.08)',
-    padding: 16,
-  },
-  advancedLockedHeader: {
+  advancedHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    marginBottom: 8,
-  },
-  advancedLockedTitle: {
-    fontSize: 15,
-    fontWeight: '700',
-    color: '#1A2C24',
+    marginBottom: 6,
   },
   plusBadge: {
     backgroundColor: '#030213',
@@ -582,22 +603,38 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     letterSpacing: 0.3,
   },
-  advancedLockedSub: {
-    fontSize: 13,
-    color: '#717182',
-    lineHeight: 18,
-    marginBottom: 14,
+  advancedControls: {
+    borderRadius: 14,
+    borderWidth: 1.5,
+    borderColor: 'rgba(0,0,0,0.08)',
+    overflow: 'hidden',
   },
-  advancedUnlockBtn: {
-    backgroundColor: '#030213',
-    borderRadius: 10,
-    paddingVertical: 11,
+  advancedControlsLocked: {
+    opacity: 0.55,
+  },
+  advancedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0,0,0,0.07)',
+  },
+  advancedRowLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1A2C24',
+  },
+  advancedOverlay: {
+    padding: 14,
     alignItems: 'center',
   },
-  advancedUnlockBtnText: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#FFFFFF',
+  advancedOverlayText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#717182',
+    textAlign: 'center',
   },
   applyBtn: {
     marginTop: 8,

--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -34,12 +34,14 @@ interface Props {
   onReport?: () => void;
   canUndo?: boolean;
   actionDisabled?: boolean;
+  showMatchReasons?: boolean;
 }
 
 export default function SwipeCard({
   profile,
   onPass, onLike, onTopPick, onUndo, onReport,
   canUndo = false, actionDisabled = false,
+  showMatchReasons = false,
 }: Props) {
   const [photoTab, setPhotoTab] = useState<PhotoTab>('profile');
   const [photoIndex, setPhotoIndex] = useState(0);
@@ -209,6 +211,16 @@ export default function SwipeCard({
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={16}
       >
+        {showMatchReasons && profile.matchReasons.length > 0 && (
+          <View style={styles.reasonsRow}>
+            {profile.matchReasons.map((r, i) => (
+              <View key={i} style={styles.reasonChip}>
+                <Text style={styles.reasonChipText}>{r}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+
         {profile.prompts.length > 0 ? (
           <>
             {profile.prompts.map((p, i) => (
@@ -586,5 +598,24 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 11,
     fontFamily: 'Nunito_700Bold',
+  },
+  reasonsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginBottom: 12,
+  },
+  reasonChip: {
+    backgroundColor: 'rgba(45,106,79,0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(45,106,79,0.25)',
+    borderRadius: 20,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  reasonChipText: {
+    fontSize: 11,
+    fontFamily: 'Nunito_600SemiBold',
+    color: '#2D6A4F',
   },
 });

--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -144,6 +144,11 @@ export default function SwipeCard({
                   {profile.age != null && (
                     <Text style={styles.overlayAge}>{profile.age}</Text>
                   )}
+                  {profile.compatibilityScore > 0 && (
+                    <View style={styles.matchBadge}>
+                      <Text style={styles.matchBadgeText}>{profile.compatibilityScore}% Match</Text>
+                    </View>
+                  )}
                 </View>
                 {!!profile.location && (
                   <View style={styles.locationRow}>
@@ -569,5 +574,17 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.35)',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  matchBadge: {
+    backgroundColor: 'rgba(12,83,137,0.82)',
+    borderRadius: 10,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    marginLeft: 6,
+  },
+  matchBadgeText: {
+    color: '#fff',
+    fontSize: 11,
+    fontFamily: 'Nunito_700Bold',
   },
 });

--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -35,13 +35,14 @@ interface Props {
   canUndo?: boolean;
   actionDisabled?: boolean;
   showMatchReasons?: boolean;
+  onUnlockReasons?: () => void;
 }
 
 export default function SwipeCard({
   profile,
   onPass, onLike, onTopPick, onUndo, onReport,
   canUndo = false, actionDisabled = false,
-  showMatchReasons = false,
+  showMatchReasons = false, onUnlockReasons,
 }: Props) {
   const [photoTab, setPhotoTab] = useState<PhotoTab>('profile');
   const [photoIndex, setPhotoIndex] = useState(0);
@@ -211,7 +212,7 @@ export default function SwipeCard({
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={16}
       >
-        {showMatchReasons && profile.matchReasons.length > 0 && (
+        {showMatchReasons && profile.matchReasons.length > 0 ? (
           <View style={styles.reasonsRow}>
             {profile.matchReasons.map((r, i) => (
               <View key={i} style={styles.reasonChip}>
@@ -219,7 +220,11 @@ export default function SwipeCard({
               </View>
             ))}
           </View>
-        )}
+        ) : !showMatchReasons && profile.matchReasons.length > 0 && onUnlockReasons ? (
+          <TouchableOpacity style={styles.reasonsLock} onPress={onUnlockReasons} activeOpacity={0.75}>
+            <Text style={styles.reasonsLockText}>🔒 See why you match</Text>
+          </TouchableOpacity>
+        ) : null}
 
         {profile.prompts.length > 0 ? (
           <>
@@ -617,5 +622,18 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontFamily: 'Nunito_600SemiBold',
     color: '#2D6A4F',
+  },
+  reasonsLock: {
+    alignSelf: 'flex-start',
+    backgroundColor: 'rgba(0,0,0,0.06)',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    marginBottom: 12,
+  },
+  reasonsLockText: {
+    fontSize: 12,
+    fontFamily: 'Nunito_600SemiBold',
+    color: '#717182',
   },
 });

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -1,7 +1,7 @@
 import { supabase } from './supabase';
 import { getProfileImageUrls, getProfileImageUrl } from './storage';
 import { getPreferences, type Preferences } from './preferences';
-import { passesHardFilters, scoreCompatibility, applyWildcardMix } from './matching';
+import { passesHardFilters, scoreCompatibility, applyWildcardMix, getMatchReasons } from './matching';
 import { sendPushNotification } from './pushNotifications';
 import { isWithinRadiusMiles } from './distance';
 import { getBlockedIds } from './blockReport';
@@ -23,6 +23,7 @@ export type DiscoverProfile = {
   roomType: string | null;
   maxBudget: number | null;
   compatibilityScore: number;  // 0–100, display as "XX% Match"
+  matchReasons: string[];      // why these profiles match (premium display)
 };
 
 type PreferenceCoordinateRow = {
@@ -153,7 +154,7 @@ export async function fetchDiscoverProfiles(
   if (error || !rows) return [];
 
   // Score each candidate, applying hard filters when we have preference data
-  type ScoredRow = { row: typeof rows[0]; score: number };
+  type ScoredRow = { row: typeof rows[0]; score: number; reasons: string[] };
   const scored: ScoredRow[] = [];
 
   for (const row of rows) {
@@ -170,7 +171,7 @@ export async function fetchDiscoverProfiles(
       if (options?.useAdvancedFilters && !passesPremiumAdvancedFilters(myPrefs, theirPrefs)) {
         continue;
       }
-      const score = scoreCompatibility(myPrefs, theirPrefs, {
+      const theirMeta = {
         subscription_tier: row.subscription_tier,
         created_at: row.created_at,
         updated_at: row.updated_at,
@@ -180,15 +181,18 @@ export async function fetchDiscoverProfiles(
         bio: row.bio,
         hobbies: row.hobbies,
         ethnicity: row.ethnicity,
-      });
-      scored.push({ row, score });
+      };
+      const score = scoreCompatibility(myPrefs, theirPrefs, theirMeta);
+      const reasons = getMatchReasons(myPrefs, theirPrefs, theirMeta);
+      scored.push({ row, score, reasons });
     } else {
       // No preferences data on one side — include with neutral score
-      scored.push({ row, score: 0.5 });
+      scored.push({ row, score: 0.5, reasons: [] });
     }
   }
 
   // Feed mixing: free 70/20/10, premium 85/10/5
+  const reasonsByRow = new Map(scored.map(s => [s.row, s.reasons]));
   const mixed = applyWildcardMix(
     scored.map(s => ({ item: s.row, score: s.score })),
     Math.min(limit, scored.length),
@@ -250,6 +254,7 @@ export async function fetchDiscoverProfiles(
       roomType: prefs?.room_type ?? null,
       maxBudget: prefs?.max_budget ?? null,
       compatibilityScore: Math.min(100, Math.round(score * 100)),
+      matchReasons: reasonsByRow.get(row) ?? [],
     });
   }
 

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -54,16 +54,13 @@ async function getNearbyCandidateIds(
 ): Promise<string[] | null> {
   const centerLat = viewerPreferences?.search_lat;
   const centerLng = viewerPreferences?.search_lng;
-  const radiusMiles = viewerPreferences?.search_radius_miles;
+  const rawRadius = viewerPreferences?.search_radius_miles;
+  const radiusMiles = (rawRadius != null && Number.isFinite(rawRadius) && rawRadius > 0)
+    ? rawRadius
+    : 25; // default 25-mile radius
 
-  // If the viewer has no location/radius configured, skip distance filtering.
-  if (
-    centerLat == null ||
-    centerLng == null ||
-    radiusMiles == null ||
-    !Number.isFinite(radiusMiles) ||
-    radiusMiles <= 0
-  ) {
+  // If no location coords, skip distance filtering entirely.
+  if (centerLat == null || centerLng == null) {
     return null;
   }
 
@@ -193,11 +190,37 @@ export async function fetchDiscoverProfiles(
 
   // Feed mixing: free 70/20/10, premium 85/10/5
   const reasonsByRow = new Map(scored.map(s => [s.row, s.reasons]));
-  const mixed = applyWildcardMix(
+  let mixed = applyWildcardMix(
     scored.map(s => ({ item: s.row, score: s.score })),
     Math.min(limit, scored.length),
     options?.isPremium ?? false,
   );
+
+  // Ethnicity cap: no more than 65% of the feed should match the viewer's ethnicity preference.
+  // This ensures diversity and prevents ethnicity from dominating the feed.
+  const ethPref = myPrefs?.ethnicity_preference ?? [];
+  if (ethPref.length > 0 && mixed.length > 0) {
+    const CAP = 0.65;
+    const maxEthMatch = Math.floor(mixed.length * CAP);
+    let ethCount = mixed.filter(x => ethPref.includes(x.item.ethnicity)).length;
+    if (ethCount > maxEthMatch) {
+      // Swap excess ethnicity-matches with non-matching rows from scored pool
+      const nonEthRows = scored
+        .filter(s => !ethPref.includes(s.row.ethnicity) && !mixed.find(m => m.item === s.row))
+        .sort((a, b) => b.score - a.score);
+      const toSwap = ethCount - maxEthMatch;
+      let swapped = 0;
+      mixed = mixed.map(entry => {
+        if (swapped >= toSwap) return entry;
+        if (ethPref.includes(entry.item.ethnicity) && nonEthRows.length > 0) {
+          const replacement = nonEthRows.shift()!;
+          swapped++;
+          return { item: replacement.row, score: replacement.score };
+        }
+        return entry;
+      });
+    }
+  }
 
   // Load photos and build the final list
   const result: DiscoverProfile[] = [];

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -22,6 +22,7 @@ export type DiscoverProfile = {
   hasListing: boolean;
   roomType: string | null;
   maxBudget: number | null;
+  compatibilityScore: number;  // 0–100, display as "XX% Match"
 };
 
 type PreferenceCoordinateRow = {
@@ -187,16 +188,17 @@ export async function fetchDiscoverProfiles(
     }
   }
 
-  // 80% top scorers + 20% wildcards, capped at limit
+  // Feed mixing: free 70/20/10, premium 85/10/5
   const mixed = applyWildcardMix(
     scored.map(s => ({ item: s.row, score: s.score })),
-    Math.min(limit, scored.length)
+    Math.min(limit, scored.length),
+    options?.isPremium ?? false,
   );
 
   // Load photos and build the final list
   const result: DiscoverProfile[] = [];
 
-  for (const row of mixed) {
+  for (const { item: row, score } of mixed) {
     const urls = await getProfileImageUrls(row.profile_photo_url);
     if (!urls || urls.length === 0) continue;
 
@@ -247,6 +249,7 @@ export async function fetchDiscoverProfiles(
       location,
       roomType: prefs?.room_type ?? null,
       maxBudget: prefs?.max_budget ?? null,
+      compatibilityScore: Math.min(100, Math.round(score * 100)),
     });
   }
 
@@ -285,15 +288,23 @@ function passesPremiumAdvancedFilters(mine: Preferences, theirs: Preferences): b
   const mineDealbreakers = mine.dealbreakers ?? {};
   for (const [key, severity] of Object.entries(mineDealbreakers)) {
     if (severity !== 'hard' && severity !== 'soft') continue;
-    if (key === 'smoking' && theirs.smoking_allowed === true) return false;
-    if (key === 'pets' && theirs.pets_allowed === true) return false;
+    if (key === 'smoking'    && theirs.smoking_allowed === true) return false;
+    if (key === 'pets'       && theirs.pets_allowed === true) return false;
+    if (key === 'parties'    && theirs.social_preference === 'social') return false;
+    if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') return false;
+    if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') return false;
+    if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) return false;
   }
 
   const theirDealbreakers = theirs.dealbreakers ?? {};
   for (const [key, severity] of Object.entries(theirDealbreakers)) {
     if (severity !== 'hard' && severity !== 'soft') continue;
-    if (key === 'smoking' && mine.smoking_allowed === true) return false;
-    if (key === 'pets' && mine.pets_allowed === true) return false;
+    if (key === 'smoking'    && mine.smoking_allowed === true) return false;
+    if (key === 'pets'       && mine.pets_allowed === true) return false;
+    if (key === 'parties'    && mine.social_preference === 'social') return false;
+    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') return false;
+    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') return false;
+    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) return false;
   }
 
   return true;

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -161,6 +161,10 @@ export async function fetchDiscoverProfiles(
     ) as Preferences | null;
 
     if (myPrefs && theirPrefs) {
+      // Age hard filter
+      if (myPrefs.min_age != null && myPrefs.max_age != null && row.age != null) {
+        if (row.age < myPrefs.min_age || row.age > myPrefs.max_age) continue;
+      }
       if (!passesHardFilters(myPrefs, theirPrefs, options?.isPremium ?? false)) continue;
       if (options?.useAdvancedFilters && !passesPremiumAdvancedFilters(myPrefs, theirPrefs)) {
         continue;

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -123,7 +123,7 @@ export async function fetchDiscoverProfiles(
   let query = supabase
     .from('profiles')
     .select(
-      'id, name, age, bio, hobbies, prompts, has_listing, profile_photo_url, subscription_tier, ethnicity, created_at, updated_at, ' +
+      'id, name, age, bio, hobbies, prompts, has_listing, profile_photo_url, subscription_tier, ethnicity, created_at, updated_at, last_active_at, ' +
       'preferences(city, state, min_budget, max_budget, cleanliness_level, social_preference, ' +
       'work_schedule, interests, dealbreakers, pets_allowed, smoking_allowed, room_type, move_in_date, lease_duration_months, search_lat, search_lng, ethnicity_preference)'
     )
@@ -169,6 +169,7 @@ export async function fetchDiscoverProfiles(
         subscription_tier: row.subscription_tier,
         created_at: row.created_at,
         updated_at: row.updated_at,
+        last_active_at: row.last_active_at,
         name: row.name,
         age: row.age,
         bio: row.bio,

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -179,7 +179,7 @@ export async function fetchDiscoverProfiles(
         hobbies: row.hobbies,
         ethnicity: row.ethnicity,
       };
-      const score = scoreCompatibility(myPrefs, theirPrefs, theirMeta);
+      const score = scoreCompatibility(myPrefs, theirPrefs, theirMeta, { has_listing_only: myPrefs.has_listing_only ?? false });
       const reasons = getMatchReasons(myPrefs, theirPrefs, theirMeta);
       scored.push({ row, score, reasons });
     } else {
@@ -222,13 +222,8 @@ export async function fetchDiscoverProfiles(
     }
   }
 
-  // Load photos and build the final list
-  const result: DiscoverProfile[] = [];
-
-  for (const { item: row, score } of mixed) {
-    const urls = await getProfileImageUrls(row.profile_photo_url);
-    if (!urls || urls.length === 0) continue;
-
+  // Load photos for all profiles in parallel to avoid sequential network stalls
+  async function buildProfile(row: typeof rows[0], score: number): Promise<DiscoverProfile | null> {
     const prefs = (
       Array.isArray(row.preferences) ? row.preferences[0] : row.preferences
     ) as Preferences | null;
@@ -241,28 +236,33 @@ export async function fetchDiscoverProfiles(
     const interestChips = Object.values(interests).flat() as string[];
     const hobbies = interestChips.length > 0 ? null : (row.hobbies ?? null);
 
-    // Fetch listing photos if this user has a place listed
-    let listingPhotoUrls: string[] = [];
-    if (row.has_listing === true) {
-      const { data: listing } = await supabase
-        .from('listings')
-        .select('listing_photos')
-        .eq('user_id', row.id)
-        .maybeSingle();
+    const listingFetch: Promise<string[]> = row.has_listing === true
+      ? (async () => {
+          const { data: listing } = await supabase
+            .from('listings')
+            .select('listing_photos')
+            .eq('user_id', row.id)
+            .maybeSingle();
+          const paths: string[] = Array.isArray(listing?.listing_photos)
+            ? listing.listing_photos
+            : [];
+          const signed = await Promise.all(paths.map((p: string) => getProfileImageUrl(p)));
+          return signed.filter((u): u is string => u !== null);
+        })()
+      : Promise.resolve([]);
 
-      const paths: string[] = Array.isArray(listing?.listing_photos)
-        ? listing.listing_photos
-        : [];
+    const [urls, listingPhotoUrls] = await Promise.all([
+      getProfileImageUrls(row.profile_photo_url),
+      listingFetch,
+    ]);
 
-      const signed = await Promise.all(paths.map(p => getProfileImageUrl(p)));
-      listingPhotoUrls = signed.filter((u): u is string => u !== null);
-    }
+    if (!urls || urls.length === 0) return null;
 
     const prompts: PromptEntry[] = Array.isArray(row.prompts)
       ? row.prompts.filter((p: any) => p?.question && p?.answer)
       : [];
 
-    result.push({
+    return {
       id: row.id,
       name: row.name ?? 'Unknown',
       age: row.age ?? null,
@@ -278,10 +278,11 @@ export async function fetchDiscoverProfiles(
       maxBudget: prefs?.max_budget ?? null,
       compatibilityScore: Math.min(100, Math.round(score * 100)),
       matchReasons: reasonsByRow.get(row) ?? [],
-    });
+    };
   }
 
-  return result;
+  const settled = await Promise.all(mixed.map(({ item: row, score }) => buildProfile(row, score)));
+  return settled.filter((p): p is DiscoverProfile => p !== null);
 }
 
 function passesPremiumAdvancedFilters(mine: Preferences, theirs: Preferences): boolean {

--- a/apps/mobile/lib/freeTierLimits.ts
+++ b/apps/mobile/lib/freeTierLimits.ts
@@ -1,8 +1,11 @@
 /**
  * Free vs RoomPear+ product rules (client-enforced; server can mirror later).
- * Premium: unlimited swipes, top picks, undos, and see-all likers (Likes tab).
  */
 export const FREE_TIER_LIMITS = {
   swipesPerDay: 10,
   topPicksPerDay: 1,
+} as const;
+
+export const PREMIUM_TIER_LIMITS = {
+  topPicksPerDay: 7,
 } as const;

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -15,6 +15,7 @@ export interface ProfileMeta {
   subscription_tier?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  last_active_at?: string | null;
   name?: string | null;
   age?: number | null;
   bio?: string | null;
@@ -208,9 +209,12 @@ export function scoreCompatibility(
     const ageHours = (Date.now() - new Date(theirMeta.created_at).getTime()) / 3_600_000;
     if (ageHours < 48) score *= 1.15;
   }
-  if (theirMeta.updated_at) {
-    const idleDays = (Date.now() - new Date(theirMeta.updated_at).getTime()) / 86_400_000;
-    if (idleDays < 7) score *= 1.05;
+  const lastActive = theirMeta.last_active_at ?? theirMeta.updated_at;
+  if (lastActive) {
+    const idleDays = (Date.now() - new Date(lastActive).getTime()) / 86_400_000;
+    if (idleDays < 1)  score *= 1.10; // active today
+    else if (idleDays < 7)  score *= 1.05; // active this week
+    else if (idleDays < 30) score *= 1.02; // active this month
   }
 
   return score;

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -300,6 +300,87 @@ export function selectTopPicks<T>(
     .slice(0, count);
 }
 
+// ─── Match reasons ────────────────────────────────────────────────────────────
+
+/**
+ * Returns up to 5 human-readable reasons why two profiles are compatible.
+ * Premium-only display feature — compute freely, gate rendering in UI.
+ */
+export function getMatchReasons(
+  mine: Preferences,
+  theirs: Preferences,
+  theirMeta: ProfileMeta,
+): string[] {
+  const reasons: string[] = [];
+
+  // Shared interests
+  const myInterests = flattenInterests(mine.interests);
+  const theirInterests = flattenInterests(theirs.interests);
+  const shared = [...myInterests].filter(x => theirInterests.has(x));
+  if (shared.length >= 3) {
+    reasons.push(`${shared.length} shared interests`);
+  } else if (shared.length === 2) {
+    reasons.push(`Both into ${shared[0]} & ${shared[1]}`);
+  } else if (shared.length === 1) {
+    reasons.push(`Both into ${shared[0]}`);
+  }
+
+  // Cleanliness
+  if (mine.cleanliness_level != null && theirs.cleanliness_level != null) {
+    if (Math.abs(mine.cleanliness_level - theirs.cleanliness_level) <= 1) {
+      reasons.push('Similar cleanliness habits');
+    }
+  }
+
+  // Social preference
+  if (mine.social_preference && theirs.social_preference && mine.social_preference === theirs.social_preference) {
+    const label: Record<string, string> = {
+      quiet: 'Both prefer a quiet home',
+      balanced: 'Both balanced socially',
+      social: 'Both love socializing',
+    };
+    reasons.push(label[mine.social_preference] ?? 'Similar social vibe');
+  }
+
+  // Work schedule
+  if (mine.work_schedule && theirs.work_schedule) {
+    if (mine.work_schedule === theirs.work_schedule) {
+      reasons.push(`Both on ${mine.work_schedule} schedule`);
+    } else {
+      const flex = (s: string) => s === 'Flexible' || s === 'Remote';
+      if (flex(mine.work_schedule) || flex(theirs.work_schedule)) {
+        reasons.push('Flexible schedule match');
+      }
+    }
+  }
+
+  // Budget overlap
+  if (mine.min_budget != null && mine.max_budget != null &&
+      theirs.min_budget != null && theirs.max_budget != null) {
+    const overlapMin = Math.max(mine.min_budget, theirs.min_budget);
+    const overlapMax = Math.min(mine.max_budget, theirs.max_budget);
+    if (overlapMax >= overlapMin) {
+      reasons.push(`Budget overlap $${overlapMin}–$${overlapMax}/mo`);
+    }
+  }
+
+  // Move-in timing
+  if (mine.move_in_date && theirs.move_in_date) {
+    const flex = (d: string) => d.toLowerCase() === 'flexible';
+    if (flex(mine.move_in_date) || flex(theirs.move_in_date) || mine.move_in_date === theirs.move_in_date) {
+      reasons.push('Move-in timing lines up');
+    }
+  }
+
+  // Same city
+  if (mine.city && theirs.city &&
+      mine.city.trim().toLowerCase() === theirs.city.trim().toLowerCase()) {
+    reasons.push(`Both looking in ${theirs.city.trim()}`);
+  }
+
+  return reasons.slice(0, 5);
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function socialPreferenceScore(a: string, b: string): number {

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -1,12 +1,11 @@
 /**
- * Matching algorithm for RoomPear.
+ * RoomPear matching algorithm.
  *
- * 4 layers:
- *   1. Hard filters  — location (same state), budget overlap, hard dealbreakers
+ * Layers:
+ *   1. Hard filters  — location, budget, age, gender, hard dealbreakers
  *   2. Compatibility — Lifestyle 35% | Interests 30% | Budget 20% | Dealbreakers 15%
- *   3. Boost factors — profile completeness ×1.0–1.20 | premium ×1.10
- *                      new user <48 h ×1.15 | recently active <7 d ×1.05
- *   4. Wildcard mix  — 80% top scorers + 20% random from the rest
+ *   3. Boost factors — completeness, premium, new user, recently active, city, listing
+ *   4. Feed mixing   — free: 70/20/10 | premium: 85/10/5 (with score thresholds + fallback)
  */
 
 import type { Preferences } from './preferences';
@@ -21,36 +20,31 @@ export interface ProfileMeta {
   bio?: string | null;
   hobbies?: string[] | null;
   ethnicity?: string | null;
+  has_listing?: boolean | null;
+  prompts?: Array<{ question: string; answer: string }> | null;
 }
 
-// ─── Hard filters ────────────────────────────────────────────────────────────
+// ─── Hard filters ─────────────────────────────────────────────────────────────
 
 /**
  * Returns false if the candidate should be excluded from the deck entirely.
- * isPremium: pets/smoking hard filters are premium-only — free users see them ranked lower instead.
+ * isPremium: pets/smoking hard-filter is premium-only (free users get score penalty instead).
  */
 export function passesHardFilters(mine: Preferences, theirs: Preferences, isPremium = false): boolean {
-  // Same state required (flexible for a small user base)
+  // State match (location fallback when no radius is set)
   if (mine.state && theirs.state) {
-    if (mine.state.trim().toLowerCase() !== theirs.state.trim().toLowerCase()) {
-      return false;
-    }
+    if (mine.state.trim().toLowerCase() !== theirs.state.trim().toLowerCase()) return false;
   }
 
-  // Budget ranges must overlap
-  if (
-    mine.min_budget != null && mine.max_budget != null &&
-    theirs.min_budget != null && theirs.max_budget != null
-  ) {
-    const overlapMax = Math.min(mine.max_budget, theirs.max_budget);
-    const overlapMin = Math.max(mine.min_budget, theirs.min_budget);
-    if (overlapMax < overlapMin) return false;
+  // Budget overlap
+  if (mine.min_budget != null && mine.max_budget != null &&
+      theirs.min_budget != null && theirs.max_budget != null) {
+    if (Math.min(mine.max_budget, theirs.max_budget) < Math.max(mine.min_budget, theirs.min_budget)) return false;
   }
 
-  // My hard dealbreakers vs their self-reported traits.
-  // Pets/smoking hard filtering is premium-only — free users get them ranked lower instead.
-  const myDealbreakers = mine.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(myDealbreakers)) {
+  // Hard dealbreakers — pets/smoking are premium-only hard filters; others apply to all
+  const myDB = mine.dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(myDB)) {
     if (severity !== 'hard') continue;
     if (key === 'smoking'    && isPremium && theirs.smoking_allowed === true) return false;
     if (key === 'pets'       && isPremium && theirs.pets_allowed    === true) return false;
@@ -60,9 +54,9 @@ export function passesHardFilters(mine: Preferences, theirs: Preferences, isPrem
     if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) return false;
   }
 
-  // Their hard dealbreakers vs my self-reported traits (avoid wasted swipes)
-  const theirDealbreakers = theirs.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(theirDealbreakers)) {
+  // Their hard dealbreakers vs my traits
+  const theirDB = theirs.dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(theirDB)) {
     if (severity !== 'hard') continue;
     if (key === 'smoking'    && mine.smoking_allowed === true) return false;
     if (key === 'pets'       && mine.pets_allowed    === true) return false;
@@ -78,13 +72,14 @@ export function passesHardFilters(mine: Preferences, theirs: Preferences, isPrem
 // ─── Compatibility score ──────────────────────────────────────────────────────
 
 /**
- * Returns a raw compatibility score (0–1, higher = better).
- * Boost factors can push it above 1.
+ * Returns a compatibility score (0–1+). Boost factors can push it above 1.
+ * Convert to display % with: Math.min(100, Math.round(score * 100))
  */
 export function scoreCompatibility(
   mine: Preferences,
   theirs: Preferences,
-  theirMeta: ProfileMeta
+  theirMeta: ProfileMeta,
+  myMeta?: { has_listing_only?: boolean },
 ): number {
   let score = 0;
 
@@ -98,15 +93,14 @@ export function scoreCompatibility(
     lifestyleWeightSum += 0.40;
   }
   if (mine.social_preference && theirs.social_preference) {
-    lifestyleRaw += (mine.social_preference === theirs.social_preference ? 1 : 0) * 0.35;
+    lifestyleRaw += socialPreferenceScore(mine.social_preference, theirs.social_preference) * 0.35;
     lifestyleWeightSum += 0.35;
   }
   if (mine.work_schedule && theirs.work_schedule) {
-    lifestyleRaw += (mine.work_schedule === theirs.work_schedule ? 1 : 0) * 0.25;
+    lifestyleRaw += workScheduleScore(mine.work_schedule, theirs.work_schedule) * 0.25;
     lifestyleWeightSum += 0.25;
   }
 
-  // Neutral (0.5) when no lifestyle data available
   score += (lifestyleWeightSum > 0 ? lifestyleRaw / lifestyleWeightSum : 0.5) * 0.35;
 
   // ── Interests (30%) ────────────────────────────────────────────────────────
@@ -118,103 +112,97 @@ export function scoreCompatibility(
     const union = new Set([...myInterests, ...theirInterests]);
     score += (intersection.size / union.size) * 0.30;
   } else {
-    score += 0.15; // neutral when no interests data
+    score += 0.15; // neutral fallback
   }
 
   // ── Budget (20%) ───────────────────────────────────────────────────────────
-  if (
-    mine.min_budget != null && mine.max_budget != null &&
-    theirs.min_budget != null && theirs.max_budget != null
-  ) {
+  if (mine.min_budget != null && mine.max_budget != null &&
+      theirs.min_budget != null && theirs.max_budget != null) {
     const overlapMin = Math.max(mine.min_budget, theirs.min_budget);
     const overlapMax = Math.min(mine.max_budget, theirs.max_budget);
-    const rangeMin = Math.min(mine.min_budget, theirs.min_budget);
-    const rangeMax = Math.max(mine.max_budget, theirs.max_budget);
-    const overlap = Math.max(0, overlapMax - overlapMin);
-    const range = rangeMax - rangeMin;
+    const rangeMin   = Math.min(mine.min_budget, theirs.min_budget);
+    const rangeMax   = Math.max(mine.max_budget, theirs.max_budget);
+    const overlap    = Math.max(0, overlapMax - overlapMin);
+    const range      = rangeMax - rangeMin;
     score += (range > 0 ? overlap / range : 1) * 0.20;
   } else {
-    score += 0.10; // neutral
+    score += 0.10;
   }
 
   // ── Dealbreakers (15%) ─────────────────────────────────────────────────────
+  // hard conflict (free users only, since premium hard-filters them out): -0.10
+  // soft conflict: -0.05
   let dealScore = 0.15;
-  const myDealbreakers = mine.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(myDealbreakers)) {
-    if (severity !== 'soft') continue;
-    if (key === 'smoking'    && theirs.smoking_allowed === true) dealScore -= 0.05;
-    if (key === 'pets'       && theirs.pets_allowed    === true) dealScore -= 0.05;
-    if (key === 'parties'    && theirs.social_preference === 'social') dealScore -= 0.05;
-    if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') dealScore -= 0.05;
-    if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') dealScore -= 0.05;
-    if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) dealScore -= 0.05;
+  const myDB = mine.dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(myDB)) {
+    if (severity !== 'hard' && severity !== 'soft') continue;
+    const penalty = severity === 'hard' ? 0.10 : 0.05;
+    if (key === 'smoking'    && theirs.smoking_allowed === true) dealScore -= penalty;
+    if (key === 'pets'       && theirs.pets_allowed    === true) dealScore -= penalty;
+    if (key === 'parties'    && theirs.social_preference === 'social') dealScore -= penalty;
+    if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') dealScore -= penalty;
+    if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') dealScore -= penalty;
+    if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) dealScore -= penalty;
   }
-  const theirDealbreakers = theirs.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(theirDealbreakers)) {
-    if (severity !== 'soft') continue;
-    if (key === 'smoking'    && mine.smoking_allowed === true) dealScore -= 0.05;
-    if (key === 'pets'       && mine.pets_allowed    === true) dealScore -= 0.05;
-    if (key === 'parties'    && mine.social_preference === 'social') dealScore -= 0.05;
-    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') dealScore -= 0.05;
-    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') dealScore -= 0.05;
-    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) dealScore -= 0.05;
+  const theirDB = theirs.dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(theirDB)) {
+    if (severity !== 'hard' && severity !== 'soft') continue;
+    const penalty = severity === 'hard' ? 0.10 : 0.05;
+    if (key === 'smoking'    && mine.smoking_allowed === true) dealScore -= penalty;
+    if (key === 'pets'       && mine.pets_allowed    === true) dealScore -= penalty;
+    if (key === 'parties'    && mine.social_preference === 'social') dealScore -= penalty;
+    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') dealScore -= penalty;
+    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') dealScore -= penalty;
+    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) dealScore -= penalty;
   }
   score += Math.max(0, dealScore);
 
-  // ── Move-in date compatibility (soft boost) ────────────────────────────────
+  // ── Soft boosts (move-in, lease, ethnicity, city) ──────────────────────────
   if (mine.move_in_date && theirs.move_in_date) {
-    const flexVals = ['flexible', 'Flexible'];
-    const mineFlex = flexVals.includes(mine.move_in_date);
-    const theirsFlex = flexVals.includes(theirs.move_in_date);
-    if (mineFlex || theirsFlex || mine.move_in_date === theirs.move_in_date) {
+    const flex = (d: string) => d.toLowerCase() === 'flexible';
+    if (flex(mine.move_in_date) || flex(theirs.move_in_date) || mine.move_in_date === theirs.move_in_date) {
       score += 0.04;
     }
   }
-
-  // ── Lease duration compatibility (soft boost) ──────────────────────────────
   if (mine.lease_duration_months != null && theirs.lease_duration_months != null) {
-    const mineFlex = mine.lease_duration_months === 0;
-    const theirsFlex = theirs.lease_duration_months === 0;
-    if (mineFlex || theirsFlex || mine.lease_duration_months === theirs.lease_duration_months) {
+    if (mine.lease_duration_months === 0 || theirs.lease_duration_months === 0 ||
+        mine.lease_duration_months === theirs.lease_duration_months) {
       score += 0.03;
     }
   }
 
-  // ── Ethnicity preference (soft boost) ──────────────────────────────────────
-  // Only applied when the viewer has set a preference — never hard-filters.
+  // Ethnicity — strong soft boost, never a hard filter
   const myEthPref = mine.ethnicity_preference ?? [];
-  if (myEthPref.length > 0 && theirMeta.ethnicity) {
-    if (myEthPref.includes(theirMeta.ethnicity)) score += 0.08;
+  if (myEthPref.length > 0 && theirMeta.ethnicity && myEthPref.includes(theirMeta.ethnicity)) {
+    score += 0.08;
   }
 
-  // ── City match bonus ────────────────────────────────────────────────────────
-  if (
-    mine.city && theirs.city &&
-    mine.city.trim().toLowerCase() === theirs.city.trim().toLowerCase()
-  ) {
+  if (mine.city && theirs.city &&
+      mine.city.trim().toLowerCase() === theirs.city.trim().toLowerCase()) {
     score += 0.05;
   }
 
-  // ── Boost factors ──────────────────────────────────────────────────────────
-
-  // Profile completeness (like Hinge/CMB — rewards users who filled out their profile)
-  // Max boost: ×1.20 for a fully completed profile
-  const completeness = profileCompletenessBoost(theirMeta, theirs);
-  score *= completeness;
-
-  if (theirMeta.subscription_tier === 'premium') {
-    score *= 1.10;
+  // Has listing boost — only when viewer prefers listings
+  if (myMeta?.has_listing_only && theirMeta.has_listing === true) {
+    score += 0.06;
   }
+
+  // ── Boost factors ──────────────────────────────────────────────────────────
+  score *= profileCompletenessBoost(theirMeta, theirs);
+
+  if (theirMeta.subscription_tier === 'premium') score *= 1.10;
+
   if (theirMeta.created_at) {
     const ageHours = (Date.now() - new Date(theirMeta.created_at).getTime()) / 3_600_000;
     if (ageHours < 48) score *= 1.15;
   }
+
   const lastActive = theirMeta.last_active_at ?? theirMeta.updated_at;
   if (lastActive) {
     const idleDays = (Date.now() - new Date(lastActive).getTime()) / 86_400_000;
-    if (idleDays < 1)  score *= 1.10; // active today
-    else if (idleDays < 7)  score *= 1.05; // active this week
-    else if (idleDays < 30) score *= 1.02; // active this month
+    if (idleDays < 1)       score *= 1.10;
+    else if (idleDays < 7)  score *= 1.05;
+    else if (idleDays < 30) score *= 1.02;
   }
 
   return score;
@@ -222,19 +210,12 @@ export function scoreCompatibility(
 
 // ─── Profile completeness boost ──────────────────────────────────────────────
 
-/**
- * Returns a multiplier between 1.0 and 1.20 based on how complete the profile is.
- * Incentivises users to fill out their profile — same signal Hinge/CMB use.
- *
- * Fields checked (each worth equal share of the 0.20 range):
- *   Profile: bio, hobbies (≥1), age
- *   Preferences: city/state, budget, cleanliness, social_preference, work_schedule, interests (≥1 category)
- */
 function profileCompletenessBoost(meta: ProfileMeta, prefs: Preferences): number {
   const checks = [
     !!meta.bio?.trim(),
-    Array.isArray(meta.hobbies) && meta.hobbies.length > 0,
     meta.age != null,
+    Array.isArray(meta.hobbies) && meta.hobbies.length > 0,
+    Array.isArray(meta.prompts) && meta.prompts.filter(p => p?.answer?.trim()).length >= 2,
     !!(prefs.city?.trim()),
     prefs.min_budget != null && prefs.max_budget != null,
     prefs.cleanliness_level != null,
@@ -242,40 +223,98 @@ function profileCompletenessBoost(meta: ProfileMeta, prefs: Preferences): number
     !!prefs.work_schedule,
     prefs.interests != null && Object.values(prefs.interests).some(v => v.length > 0),
   ];
-
-  const filled = checks.filter(Boolean).length;
-  const ratio = filled / checks.length; // 0 to 1
-  return 1.0 + ratio * 0.20;            // 1.0 to 1.20
+  const ratio = checks.filter(Boolean).length / checks.length;
+  return 1.0 + ratio * 0.20; // 1.0 – 1.20
 }
 
-// ─── Wildcard mix ─────────────────────────────────────────────────────────────
+// ─── Feed mixing ──────────────────────────────────────────────────────────────
 
 /**
- * Returns `count` items: 80% from the top scorers, 20% random from the rest.
- * Prevents filter-bubble lock-in.
+ * Returns up to `count` scored items using tiered mixing:
+ *   Free:    70% high (≥0.65) | 20% medium (0.40–0.65) | 10% wildcard (<0.40)
+ *   Premium: 85% high         | 10% medium              |  5% wildcard
+ *
+ * Progressive fallback: if pool is too small, thresholds are relaxed automatically.
  */
 export function applyWildcardMix<T>(
   scored: Array<{ item: T; score: number }>,
-  count: number
-): T[] {
+  count: number,
+  isPremium = false,
+): Array<{ item: T; score: number }> {
   if (scored.length === 0) return [];
 
   scored.sort((a, b) => b.score - a.score);
 
-  const topCount = Math.ceil(count * 0.8);
-  const wildcardCount = count - topCount;
+  const HIGH_THRESHOLD    = 0.65;
+  const MED_THRESHOLD     = 0.40;
+  const WILDCARD_MIN      = 0.15;
+  const minPool           = isPremium ? 0.40 : 0.20;
 
-  const top = scored.slice(0, topCount).map(x => x.item);
-  const rest = scored
-    .slice(topCount)
-    .sort(() => Math.random() - 0.5)
-    .slice(0, wildcardCount)
-    .map(x => x.item);
+  // Progressive fallback to avoid empty states
+  let pool = scored.filter(x => x.score >= minPool);
+  if (pool.length < count) pool = scored.filter(x => x.score >= WILDCARD_MIN);
+  if (pool.length < count) pool = scored;
 
-  return [...top, ...rest];
+  const high     = pool.filter(x => x.score >= HIGH_THRESHOLD);
+  const medium   = pool.filter(x => x.score >= MED_THRESHOLD && x.score < HIGH_THRESHOLD);
+  const wildcard = pool.filter(x => x.score < MED_THRESHOLD);
+
+  const highRatio     = isPremium ? 0.85 : 0.70;
+  const medRatio      = isPremium ? 0.10 : 0.20;
+  const highCount     = Math.round(count * highRatio);
+  const medCount      = Math.round(count * medRatio);
+  const wildcardCount = Math.max(0, count - highCount - medCount);
+
+  const shuffle = <U>(arr: U[]): U[] => [...arr].sort(() => Math.random() - 0.5);
+
+  const result: Array<{ item: T; score: number }> = [
+    ...high.slice(0, highCount),
+    ...shuffle(medium).slice(0, medCount),
+    ...shuffle(wildcard).slice(0, wildcardCount),
+  ];
+
+  // Fill remainder if buckets ran dry
+  if (result.length < count) {
+    const used = new Set(result.map(r => r.item));
+    const extras = pool.filter(x => !used.has(x.item)).slice(0, count - result.length);
+    result.push(...extras);
+  }
+
+  return result.slice(0, count);
+}
+
+// ─── Top Picks selection ──────────────────────────────────────────────────────
+
+/**
+ * Returns the highest-scoring profiles that meet the Top Picks threshold.
+ * No wildcards — only genuinely high-compatibility profiles.
+ */
+export function selectTopPicks<T>(
+  scored: Array<{ item: T; score: number }>,
+  count: number,
+): Array<{ item: T; score: number }> {
+  const TOP_PICKS_THRESHOLD = 0.70;
+  return scored
+    .filter(x => x.score >= TOP_PICKS_THRESHOLD)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, count);
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function socialPreferenceScore(a: string, b: string): number {
+  if (a === b) return 1.0;
+  if (a === 'balanced' || b === 'balanced') return 0.5; // adjacent
+  return 0.0; // quiet ↔ social: opposite ends
+}
+
+function workScheduleScore(a: string, b: string): number {
+  if (a === b) return 1.0;
+  const isFlexible = (s: string) => s === 'Flexible' || s === 'Remote';
+  if (isFlexible(a) || isFlexible(b)) return 0.7;
+  if ((a === '9-to-5' && b === 'Night Shift') || (a === 'Night Shift' && b === '9-to-5')) return 0.0;
+  return 0.4;
+}
 
 function flattenInterests(interests?: Record<string, string[]>): Set<string> {
   if (!interests) return new Set();

--- a/apps/mobile/lib/preferences.ts
+++ b/apps/mobile/lib/preferences.ts
@@ -75,6 +75,8 @@ export interface Preferences {
   ethnicity_preference?: string[];
   gender_preference?: string;
   has_listing_only?: boolean;
+  min_age?: number;
+  max_age?: number;
   created_at?: string;
   updated_at?: string;
 }

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
-  FlatList,
   Image,
   Modal,
   Platform,
@@ -267,11 +266,6 @@ export default function DiscoverScreen() {
   const nextProfile = profiles[currentIndex + 1];
   const remaining = profiles.length - currentIndex;
 
-  // Top Picks: highest-compatibility profiles not yet swiped, score ≥ 70
-  const topPicks = profiles
-    .map((p, i) => ({ profile: p, index: i }))
-    .filter(({ profile: p, index: i }) => p.compatibilityScore >= 70 && i >= currentIndex)
-    .slice(0, 5);
 
   if (loading) {
     return (
@@ -361,33 +355,6 @@ export default function DiscoverScreen() {
             </TouchableOpacity>
           </View>
         </View>
-
-        {/* ── Top Picks row ── */}
-        {topPicks.length > 0 && (
-          <View style={styles.topPicksSection}>
-            <Text style={styles.topPicksLabel}>⭐ Top Picks</Text>
-            <FlatList
-              data={topPicks}
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              keyExtractor={({ profile }) => profile.id}
-              contentContainerStyle={{ gap: 8, paddingHorizontal: 16 }}
-              renderItem={({ item: { profile: p, index: i } }) => (
-                <TouchableOpacity
-                  style={styles.topPickThumb}
-                  onPress={() => setCurrentIndex(i)}
-                  activeOpacity={0.8}
-                >
-                  <Image source={{ uri: p.photoUrls[0] }} style={styles.topPickPhoto} />
-                  <View style={styles.topPickOverlay}>
-                    <Text style={styles.topPickName} numberOfLines={1}>{p.name.split(' ')[0]}</Text>
-                    <Text style={styles.topPickScore}>{p.compatibilityScore}%</Text>
-                  </View>
-                </TouchableOpacity>
-              )}
-            />
-          </View>
-        )}
 
         {/* ── Card stack ── */}
         <View style={styles.cardArea}>
@@ -750,46 +717,4 @@ const styles = StyleSheet.create({
   matchBtnSecondary: { paddingVertical: 10, width: '100%', alignItems: 'center' },
   matchBtnSecondaryText: { color: C.gray, fontSize: 15, fontWeight: '500' },
 
-  // ── Top Picks row ──
-  topPicksSection: {
-    paddingTop: 6,
-    paddingBottom: 4,
-  },
-  topPicksLabel: {
-    fontSize: 12,
-    fontWeight: '700',
-    color: C.text,
-    paddingHorizontal: 16,
-    marginBottom: 6,
-    opacity: 0.7,
-  },
-  topPickThumb: {
-    width: 68,
-    height: 84,
-    borderRadius: 12,
-    overflow: 'hidden',
-  },
-  topPickPhoto: {
-    width: '100%',
-    height: '100%',
-  },
-  topPickOverlay: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    backgroundColor: 'rgba(0,0,0,0.45)',
-    paddingHorizontal: 5,
-    paddingVertical: 4,
-  },
-  topPickName: {
-    color: '#fff',
-    fontSize: 10,
-    fontWeight: '700',
-  },
-  topPickScore: {
-    color: 'rgba(255,255,255,0.80)',
-    fontSize: 9,
-    fontWeight: '600',
-  },
 });

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -397,6 +397,8 @@ export default function DiscoverScreen() {
           userId={userId}
           onClose={() => setFiltersOpen(false)}
           onApply={() => userId && loadProfiles(userId)}
+          isPremium={hasPremiumAccess}
+          onUpgrade={openPaywallIfNeeded}
         />
       ) : null}
 

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
+  FlatList,
   Image,
   Modal,
   Platform,
@@ -267,6 +268,12 @@ export default function DiscoverScreen() {
   const nextProfile = profiles[currentIndex + 1];
   const remaining = profiles.length - currentIndex;
 
+  // Top Picks: highest-compatibility profiles not yet swiped, score ≥ 70
+  const topPicks = profiles
+    .map((p, i) => ({ profile: p, index: i }))
+    .filter(({ profile: p, index: i }) => p.compatibilityScore >= 70 && i >= currentIndex)
+    .slice(0, 5);
+
   if (loading) {
     return (
       <Background>
@@ -356,6 +363,33 @@ export default function DiscoverScreen() {
           </View>
         </View>
 
+        {/* ── Top Picks row ── */}
+        {topPicks.length > 0 && (
+          <View style={styles.topPicksSection}>
+            <Text style={styles.topPicksLabel}>⭐ Top Picks</Text>
+            <FlatList
+              data={topPicks}
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              keyExtractor={({ profile }) => profile.id}
+              contentContainerStyle={{ gap: 8, paddingHorizontal: 16 }}
+              renderItem={({ item: { profile: p, index: i } }) => (
+                <TouchableOpacity
+                  style={styles.topPickThumb}
+                  onPress={() => setCurrentIndex(i)}
+                  activeOpacity={0.8}
+                >
+                  <Image source={{ uri: p.photoUrls[0] }} style={styles.topPickPhoto} />
+                  <View style={styles.topPickOverlay}>
+                    <Text style={styles.topPickName} numberOfLines={1}>{p.name.split(' ')[0]}</Text>
+                    <Text style={styles.topPickScore}>{p.compatibilityScore}%</Text>
+                  </View>
+                </TouchableOpacity>
+              )}
+            />
+          </View>
+        )}
+
         {/* ── Card stack ── */}
         <View style={styles.cardArea}>
 
@@ -382,6 +416,7 @@ export default function DiscoverScreen() {
               canUndo={currentIndex > 0}
               actionDisabled={actionDisabled}
               onReport={() => setReportTarget({ id: currentProfile.id, name: currentProfile.name })}
+              showMatchReasons={hasPremiumAccess}
             />
           </Animated.View>
         </View>
@@ -714,4 +749,47 @@ const styles = StyleSheet.create({
   matchBtnText: { color: C.white, fontWeight: '700', fontSize: 16 },
   matchBtnSecondary: { paddingVertical: 10, width: '100%', alignItems: 'center' },
   matchBtnSecondaryText: { color: C.gray, fontSize: 15, fontWeight: '500' },
+
+  // ── Top Picks row ──
+  topPicksSection: {
+    paddingTop: 6,
+    paddingBottom: 4,
+  },
+  topPicksLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: C.text,
+    paddingHorizontal: 16,
+    marginBottom: 6,
+    opacity: 0.7,
+  },
+  topPickThumb: {
+    width: 68,
+    height: 84,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  topPickPhoto: {
+    width: '100%',
+    height: '100%',
+  },
+  topPickOverlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    paddingHorizontal: 5,
+    paddingVertical: 4,
+  },
+  topPickName: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  topPickScore: {
+    color: 'rgba(255,255,255,0.80)',
+    fontSize: 9,
+    fontWeight: '600',
+  },
 });

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -23,7 +23,7 @@ import { fetchDiscoverProfiles, recordSwipe, type DiscoverProfile } from '../lib
 import { getProfileImageUrls } from '../lib/storage';
 import { profilePhotoPathsFromRow } from '../lib/profileDisplay';
 import { getDiscoverUsage, recordDiscoverAction } from '../lib/dailyDiscoverUsage';
-import { FREE_TIER_LIMITS } from '../lib/freeTierLimits';
+import { FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../lib/freeTierLimits';
 import { usePurchases } from '../context/PurchasesContext';
 import { hasRoomPearPlusEntitlement, isPremiumProfileTier } from '../lib/purchasesConfig';
 import SwipeCard from '../components/SwipeCard';
@@ -212,20 +212,19 @@ export default function DiscoverScreen() {
     if (actionDisabled) return;
     if (!userId) return;
 
-    if (!hasPremiumAccess) {
-      const usage = await getDiscoverUsage(userId);
-      if (direction === 'top_pick') {
-        if (
-          usage.swipes >= FREE_TIER_LIMITS.swipesPerDay ||
-          usage.topPicks >= FREE_TIER_LIMITS.topPicksPerDay
-        ) {
-          await openPaywallIfNeeded();
-          return;
-        }
-      } else if (usage.swipes >= FREE_TIER_LIMITS.swipesPerDay) {
+    const usage = await getDiscoverUsage(userId);
+    if (direction === 'top_pick') {
+      const topPickLimit = hasPremiumAccess
+        ? PREMIUM_TIER_LIMITS.topPicksPerDay
+        : FREE_TIER_LIMITS.topPicksPerDay;
+      if (usage.topPicks >= topPickLimit) {
         await openPaywallIfNeeded();
         return;
       }
+    }
+    if (!hasPremiumAccess && usage.swipes >= FREE_TIER_LIMITS.swipesPerDay) {
+      await openPaywallIfNeeded();
+      return;
     }
 
     setActionDisabled(true);
@@ -417,6 +416,7 @@ export default function DiscoverScreen() {
               actionDisabled={actionDisabled}
               onReport={() => setReportTarget({ id: currentProfile.id, name: currentProfile.name })}
               showMatchReasons={hasPremiumAccess}
+              onUnlockReasons={hasPremiumAccess ? undefined : openPaywallIfNeeded}
             />
           </Animated.View>
         </View>


### PR DESCRIPTION
## Summary
- Full 4-layer matching: hard filters → compatibility scoring → boost factors → feed mixing
- Compatibility scoring: Lifestyle 35% / Interests 30% / Budget 20% / Dealbreakers 15% with gradient social/schedule scoring
- Feed mixing: Free 70/20/10, Premium 85/10/5 with progressive fallback
- Premium strict filters for pets, smoking, parties, cleanliness, schedule, social vibe, room type, move-in
- Compatibility % badge on every SwipeCard
- Match reasons: premium sees green chips, free sees 🔒 See why you match (opens paywall)
- Top Picks row: horizontal scroll of ≥70% profiles above card stack
- Premium 7 top picks/day, free 1/day — both enforce paywall
- Default 25-mile radius when coords exist but no radius set
- Ethnicity cap: max 65% of feed matches preference to ensure diversity
- last_active_at written on app load, used in boost factors
- Age hard filter via min_age/max_age preferences
- 42 unit tests covering all pure matching functions