### PR TITLE
Feat/remove dealbreakers

### DIFF
--- a/apps/mobile/__tests__/lib/matching.test.ts
+++ b/apps/mobile/__tests__/lib/matching.test.ts
@@ -29,6 +29,7 @@ function prefs(overrides: Record<string, any> = {}): any {
     work_schedule: '9-to-5',
     interests: { fitness: ['Gym', 'Yoga'], music: ['Guitar'] },
     dealbreakers: {},
+    discover_filter_dealbreakers: {},
     ...overrides,
   };
 }
@@ -77,48 +78,81 @@ describe('passesHardFilters', () => {
     )).toBe(true);
   });
 
-  test('pets hard dealbreaker — free users still see pet owners', () => {
-    const mine = prefs({ dealbreakers: { pets: 'hard' } });
+  test('pets Discover filter — free swipers ignore pets deck filter keys', () => {
+    const mine = prefs({
+      discover_filter_dealbreakers: { pets: 'hard' },
+      dealbreakers: {},
+    });
     const theirs = prefs({ pets_allowed: true });
     expect(passesHardFilters(mine, theirs, false)).toBe(true);
   });
 
-  test('pets hard dealbreaker — premium users exclude pet owners', () => {
-    const mine = prefs({ dealbreakers: { pets: 'hard' } });
+  test('pets Discover filter — premium swipers exclude pet owners', () => {
+    const mine = prefs({
+      discover_filter_dealbreakers: { pets: 'hard' },
+      dealbreakers: {},
+    });
     const theirs = prefs({ pets_allowed: true });
     expect(passesHardFilters(mine, theirs, true)).toBe(false);
   });
 
-  test('smoking hard dealbreaker — premium only', () => {
-    const mine = prefs({ dealbreakers: { smoking: 'hard' } });
+  test('profile dealbreakers do not exclude the deck — only Discover filters do', () => {
+    const mine = prefs({
+      dealbreakers: { pets: 'hard' },
+      discover_filter_dealbreakers: {},
+    });
+    const theirs = prefs({ pets_allowed: true });
+    expect(passesHardFilters(mine, theirs, false)).toBe(true);
+    expect(passesHardFilters(mine, theirs, true)).toBe(true);
+  });
+
+  test('smoking Discover filter — premium only deck exclusion', () => {
+    const mine = prefs({
+      discover_filter_dealbreakers: { smoking: 'hard' },
+      dealbreakers: {},
+    });
     const theirs = prefs({ smoking_allowed: true });
     expect(passesHardFilters(mine, theirs, false)).toBe(true);
     expect(passesHardFilters(mine, theirs, true)).toBe(false);
   });
 
-  test('parties hard dealbreaker — applies to all users', () => {
-    const mine = prefs({ dealbreakers: { parties: 'hard' } });
+  test('parties Discover filter — applies to all swipers', () => {
+    const mine = prefs({
+      discover_filter_dealbreakers: { parties: 'hard' },
+      dealbreakers: {},
+    });
     const theirs = prefs({ social_preference: 'social' });
     expect(passesHardFilters(mine, theirs, false)).toBe(false);
     expect(passesHardFilters(mine, theirs, true)).toBe(false);
   });
 
-  test('early_bird hard dealbreaker blocks night shift candidate', () => {
-    const mine = prefs({ dealbreakers: { early_bird: 'hard' } });
+  test('early_bird Discover deck filter blocks night shift candidate', () => {
+    const mine = prefs({
+      discover_filter_dealbreakers: { early_bird: 'hard' },
+      dealbreakers: {},
+    });
     const theirs = prefs({ work_schedule: 'Night Shift' });
     expect(passesHardFilters(mine, theirs)).toBe(false);
   });
 
-  test('messy hard dealbreaker blocks cleanliness ≤ 2', () => {
-    const mine = prefs({ dealbreakers: { messy: 'hard' } });
+  test('messy Discover deck filter blocks cleanliness ≤ 2', () => {
+    const mine = prefs({
+      discover_filter_dealbreakers: { messy: 'hard' },
+      dealbreakers: {},
+    });
     expect(passesHardFilters(mine, prefs({ cleanliness_level: 2 }))).toBe(false);
     expect(passesHardFilters(mine, prefs({ cleanliness_level: 3 }))).toBe(true);
   });
 
-  test('bidirectional — their dealbreakers check mine', () => {
-    const mine = prefs({ smoking_allowed: true });
+  test('their profile dealbreakers do not hard-filter the swiper deck', () => {
+    const mine = prefs({
+      smoking_allowed: true,
+      discover_filter_dealbreakers: {},
+      dealbreakers: {},
+    });
     const theirs = prefs({ dealbreakers: { smoking: 'hard' } });
-    expect(passesHardFilters(mine, theirs, false)).toBe(false);
+    expect(passesHardFilters(mine, theirs, false)).toBe(true);
+    expect(passesHardFilters(mine, theirs, true)).toBe(true);
   });
 });
 

--- a/apps/mobile/components/DiscoverFiltersModal.tsx
+++ b/apps/mobile/components/DiscoverFiltersModal.tsx
@@ -95,7 +95,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
       setMaxBudget(prefs?.max_budget ?? 10000);
       setMinAge(prefs?.min_age ?? 18);
       setMaxAge(prefs?.max_age ?? 99);
-      const db = prefs?.dealbreakers ?? {};
+      const db = prefs?.discover_filter_dealbreakers ?? prefs?.dealbreakers ?? {};
       setStrictPets(db.pets === 'hard');
       setStrictSmoking(db.smoking === 'hard');
       setStrictParties(db.parties === 'hard');
@@ -114,14 +114,14 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
   const handleApply = async () => {
     setSaving(true);
     try {
-      const dealbreakers: Record<string, string> = {};
+      const discover_filter_dealbreakers: Record<string, string> = {};
       if (isPremium) {
-        dealbreakers.pets       = strictPets        ? 'hard' : 'none';
-        dealbreakers.smoking    = strictSmoking     ? 'hard' : 'none';
-        dealbreakers.parties    = strictParties     ? 'hard' : 'none';
-        dealbreakers.messy      = strictCleanliness ? 'hard' : 'none';
-        dealbreakers.early_bird = strictEarlyBird   ? 'hard' : 'none';
-        dealbreakers.night_owl  = strictNightOwl    ? 'hard' : 'none';
+        discover_filter_dealbreakers.pets       = strictPets        ? 'hard' : 'none';
+        discover_filter_dealbreakers.smoking    = strictSmoking     ? 'hard' : 'none';
+        discover_filter_dealbreakers.parties    = strictParties     ? 'hard' : 'none';
+        discover_filter_dealbreakers.messy      = strictCleanliness ? 'hard' : 'none';
+        discover_filter_dealbreakers.early_bird = strictEarlyBird   ? 'hard' : 'none';
+        discover_filter_dealbreakers.night_owl  = strictNightOwl    ? 'hard' : 'none';
       }
 
       await savePreferences(userId, {
@@ -135,7 +135,7 @@ export default function DiscoverFiltersModal({ visible, userId, onClose, onApply
         max_budget: maxBudget,
         min_age: minAge,
         max_age: maxAge,
-        ...(isPremium ? { dealbreakers } : {}),
+        ...(isPremium ? { discover_filter_dealbreakers } : {}),
       });
       onApply();
       onClose();

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -313,9 +313,9 @@ function passesPremiumAdvancedFilters(mine: Preferences, theirs: Preferences): b
     }
   }
 
-  // Dealbreakers: for premium filtering, treat both hard and soft conflicts as excludes.
-  const mineDealbreakers = mine.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(mineDealbreakers)) {
+  // Discover deck filters: treat both hard and soft conflicts as excludes for premium layering.
+  const mineDeckFilters = mine.discover_filter_dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(mineDeckFilters)) {
     if (severity !== 'hard' && severity !== 'soft') continue;
     if (key === 'smoking'    && theirs.smoking_allowed === true) return false;
     if (key === 'pets'       && theirs.pets_allowed === true) return false;
@@ -323,17 +323,6 @@ function passesPremiumAdvancedFilters(mine: Preferences, theirs: Preferences): b
     if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') return false;
     if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') return false;
     if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) return false;
-  }
-
-  const theirDealbreakers = theirs.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(theirDealbreakers)) {
-    if (severity !== 'hard' && severity !== 'soft') continue;
-    if (key === 'smoking'    && mine.smoking_allowed === true) return false;
-    if (key === 'pets'       && mine.pets_allowed === true) return false;
-    if (key === 'parties'    && mine.social_preference === 'social') return false;
-    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') return false;
-    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') return false;
-    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) return false;
   }
 
   return true;

--- a/apps/mobile/lib/matching.ts
+++ b/apps/mobile/lib/matching.ts
@@ -2,7 +2,7 @@
  * RoomPear matching algorithm.
  *
  * Layers:
- *   1. Hard filters  — location, budget, age, gender, hard dealbreakers
+ *   1. Hard filters  — location, budget, age, Discover deck filters (not others' profile dealbreakers)
  *   2. Compatibility — Lifestyle 35% | Interests 30% | Budget 20% | Dealbreakers 15%
  *   3. Boost factors — completeness, premium, new user, recently active, city, listing
  *   4. Feed mixing   — free: 70/20/10 | premium: 85/10/5 (with score thresholds + fallback)
@@ -28,7 +28,9 @@ export interface ProfileMeta {
 
 /**
  * Returns false if the candidate should be excluded from the deck entirely.
- * isPremium: pets/smoking hard-filter is premium-only (free users get score penalty instead).
+ * Only the swiper's Discover filters (`discover_filter_dealbreakers`) apply dealbreaker-style deck cuts.
+ * Candidates' profile `dealbreakers` do not remove them from the swiper's deck (they still affect match score).
+ * isPremium: pets/smoking hard deck filters apply only when the swiper has premium Discover access.
  */
 export function passesHardFilters(mine: Preferences, theirs: Preferences, isPremium = false): boolean {
   // State match (location fallback when no radius is set)
@@ -42,28 +44,22 @@ export function passesHardFilters(mine: Preferences, theirs: Preferences, isPrem
     if (Math.min(mine.max_budget, theirs.max_budget) < Math.max(mine.min_budget, theirs.min_budget)) return false;
   }
 
-  // Hard dealbreakers — pets/smoking are premium-only hard filters; others apply to all
-  const myDB = mine.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(myDB)) {
+  // My Discover filters (deck query) — excludes candidates; pets/smoking exclusions only when premium swiper
+  const myDeck = mine.discover_filter_dealbreakers ?? {};
+  for (const [key, severity] of Object.entries(myDeck)) {
     if (severity !== 'hard') continue;
-    if (key === 'smoking'    && isPremium && theirs.smoking_allowed === true) return false;
-    if (key === 'pets'       && isPremium && theirs.pets_allowed    === true) return false;
+    if (key === 'smoking'    && theirs.smoking_allowed === true) {
+      if (!isPremium) continue;
+      return false;
+    }
+    if (key === 'pets'       && theirs.pets_allowed    === true) {
+      if (!isPremium) continue;
+      return false;
+    }
     if (key === 'parties'    && theirs.social_preference === 'social') return false;
     if (key === 'early_bird' && theirs.work_schedule === 'Night Shift') return false;
     if (key === 'night_owl'  && theirs.work_schedule === '9-to-5') return false;
     if (key === 'messy'      && theirs.cleanliness_level != null && theirs.cleanliness_level <= 2) return false;
-  }
-
-  // Their hard dealbreakers vs my traits
-  const theirDB = theirs.dealbreakers ?? {};
-  for (const [key, severity] of Object.entries(theirDB)) {
-    if (severity !== 'hard') continue;
-    if (key === 'smoking'    && mine.smoking_allowed === true) return false;
-    if (key === 'pets'       && mine.pets_allowed    === true) return false;
-    if (key === 'parties'    && mine.social_preference === 'social') return false;
-    if (key === 'early_bird' && mine.work_schedule === 'Night Shift') return false;
-    if (key === 'night_owl'  && mine.work_schedule === '9-to-5') return false;
-    if (key === 'messy'      && mine.cleanliness_level != null && mine.cleanliness_level <= 2) return false;
   }
 
   return true;

--- a/apps/mobile/lib/preferences.ts
+++ b/apps/mobile/lib/preferences.ts
@@ -71,7 +71,10 @@ export interface Preferences {
   work_schedule?: string;
   must_haves?: string[];
   interests?: Record<string, string[]>;
+  /** Declared on profile + onboarding — used for compatibility scoring and when others swipe on you */
   dealbreakers?: Record<string, 'hard' | 'soft' | 'none'>;
+  /** Premium Discover deck filters only — excludes candidates while swiping; independent of profile dealbreakers */
+  discover_filter_dealbreakers?: Record<string, 'hard' | 'soft' | 'none'>;
   ethnicity_preference?: string[];
   gender_preference?: string;
   has_listing_only?: boolean;

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -338,6 +338,8 @@ export default function DiscoverScreen() {
             userId={userId}
             onClose={() => setFiltersOpen(false)}
             onApply={() => userId && loadProfiles(userId, hasPremiumAccess)}
+            isPremium={hasPremiumAccess}
+            onUpgrade={openPaywallIfNeeded}
           />
         ) : null}
       </Background>

--- a/backend/supabase/migrations/20260429160000_preferences_discover_filter_dealbreakers.sql
+++ b/backend/supabase/migrations/20260429160000_preferences_discover_filter_dealbreakers.sql
@@ -1,0 +1,13 @@
+-- Separate Discover deck filters from profile/onboarding dealbreakers.
+-- Existing rows preserve prior Discover behavior by copying legacy dealbreakers into the deck filter column.
+
+ALTER TABLE public.preferences
+  ADD COLUMN IF NOT EXISTS discover_filter_dealbreakers jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+UPDATE public.preferences
+SET discover_filter_dealbreakers = COALESCE(dealbreakers, '{}'::jsonb)
+WHERE dealbreakers IS NOT NULL
+  AND dealbreakers::text NOT IN ('null', '{}');
+
+COMMENT ON COLUMN public.preferences.dealbreakers IS 'Profile/onboarding declared dealbreakers (matching + incoming filters).';
+COMMENT ON COLUMN public.preferences.discover_filter_dealbreakers IS 'Discover deck exclusions while swiping; premium-editable; independent of dealbreakers.';


### PR DESCRIPTION
Adjusted how dealbreakers from profile works - treat as soft filter/preference instead of hard filter, so only premium users can filter and stops other people’s profile dealbreakers from removing them from your stack

