### PR TITLE
Reveals/swipes tracked through server now

### DIFF
--- a/apps/mobile/__tests__/lib/likes.test.ts
+++ b/apps/mobile/__tests__/lib/likes.test.ts
@@ -8,12 +8,14 @@ const mockDeleteEqLiker = jest.fn();
 const mockDeleteEqUser = jest.fn();
 const mockDelete = jest.fn();
 const mockFrom = jest.fn();
+const mockRpc = jest.fn();
 
 function loadLikesModule() {
   jest.resetModules();
   jest.doMock('../../lib/supabase', () => ({
     supabase: {
       from: (...args: unknown[]) => mockFrom(...args),
+      rpc: (name: string, params?: unknown) => mockRpc(name, params),
     },
   }));
   jest.doMock('../../lib/storage', () => ({
@@ -37,6 +39,7 @@ describe('likes integration behavior', () => {
     mockDeleteEqLiker.mockReset();
     mockDelete.mockReset();
     mockFrom.mockReset();
+    mockRpc.mockReset();
 
     mockEq.mockImplementation(() => ({ single: mockSingle }));
     mockSelect.mockImplementation(() => ({ eq: mockEq }));
@@ -51,7 +54,6 @@ describe('likes integration behavior', () => {
       if (table === 'profiles') {
         return {
           select: mockSelect,
-          update: mockUpdate,
         };
       }
       if (table === 'like_reveals') {
@@ -67,30 +69,57 @@ describe('likes integration behavior', () => {
     });
   });
 
-  it('consumeReveal spends daily reveal when available', async () => {
+  it('consumeReveal maps RPC daily success', async () => {
     const likes = loadLikesModule();
-    mockSingle.mockResolvedValueOnce({
-      data: { last_free_reveal_at: null, bonus_reveal_balance: 3 },
+    mockRpc.mockResolvedValueOnce({
+      data: { success: true, used_bonus: false },
       error: null,
     });
 
-    const result = await likes.consumeReveal('user-1');
+    const result = await likes.consumeReveal();
 
     expect(result).toEqual({ success: true, usedBonus: false });
-    expect(mockUpdate).toHaveBeenCalledWith({ last_free_reveal_at: expect.any(String) });
+    expect(mockRpc).toHaveBeenCalledWith('consume_like_reveal_quota', undefined);
   });
 
-  it('consumeReveal spends bonus reveal when daily already used', async () => {
+  it('consumeReveal maps RPC bonus success', async () => {
     const likes = loadLikesModule();
-    mockSingle.mockResolvedValueOnce({
-      data: { last_free_reveal_at: new Date().toISOString(), bonus_reveal_balance: 2 },
+    mockRpc.mockResolvedValueOnce({
+      data: { success: true, used_bonus: true },
       error: null,
     });
 
-    const result = await likes.consumeReveal('user-1');
+    const result = await likes.consumeReveal();
 
     expect(result).toEqual({ success: true, usedBonus: true });
-    expect(mockUpdate).toHaveBeenCalledWith({ bonus_reveal_balance: 1 });
+  });
+
+  it('consumeReveal maps RPC failure', async () => {
+    const likes = loadLikesModule();
+    mockRpc.mockResolvedValueOnce({
+      data: { success: false, reason: 'already_used' },
+      error: null,
+    });
+
+    const result = await likes.consumeReveal();
+
+    expect(result).toEqual({ success: false, reason: 'already_used' });
+  });
+
+  it('consumeReveal maps RPC transport error', async () => {
+    const likes = loadLikesModule();
+    mockRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Could not find the function' },
+    });
+
+    const result = await likes.consumeReveal();
+
+    expect(result).toMatchObject({
+      success: false,
+      reason: 'rpc_failed',
+      rpcErrorMessage: 'Could not find the function',
+    });
   });
 
   it('loads persisted revealed ids', async () => {

--- a/apps/mobile/__tests__/lib/matching.test.ts
+++ b/apps/mobile/__tests__/lib/matching.test.ts
@@ -368,3 +368,37 @@ describe('getMatchReasons', () => {
     ))).toBe(true);
   });
 });
+
+// ─── usageDay (America/Los_Angeles daily buckets for server-backed quotas) ───
+
+describe('usageDay', () => {
+  let laCalendarDayBounds: (now?: Date) => { startIso: string; endIso: string };
+  let isSameLaCalendarDay: (a: Date | string, b?: Date | string) => boolean;
+  let fromZonedTime: (d: Date | string | number, tz: string) => Date;
+  let ROOMPEAR_DAILY_TZ: string;
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const u = require('../../lib/usageDay');
+    laCalendarDayBounds = u.laCalendarDayBounds;
+    isSameLaCalendarDay = u.isSameLaCalendarDay;
+    ROOMPEAR_DAILY_TZ = u.ROOMPEAR_DAILY_TZ;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    fromZonedTime = require('date-fns-tz').fromZonedTime;
+  });
+
+  test('laCalendarDayBounds is [LA midnight, next LA midnight) for an instant in that LA day', () => {
+    const fixed = fromZonedTime('2026-06-15 18:30:00', ROOMPEAR_DAILY_TZ);
+    const { startIso, endIso } = laCalendarDayBounds(fixed);
+    expect(startIso).toBe(fromZonedTime('2026-06-15 00:00:00', ROOMPEAR_DAILY_TZ).toISOString());
+    expect(endIso).toBe(fromZonedTime('2026-06-16 00:00:00', ROOMPEAR_DAILY_TZ).toISOString());
+  });
+
+  test('isSameLaCalendarDay matches same Pacific calendar date only', () => {
+    const a = fromZonedTime('2026-01-10 08:00:00', ROOMPEAR_DAILY_TZ);
+    const b = fromZonedTime('2026-01-10 20:00:00', ROOMPEAR_DAILY_TZ);
+    expect(isSameLaCalendarDay(a, b)).toBe(true);
+    const c = fromZonedTime('2026-01-11 01:00:00', ROOMPEAR_DAILY_TZ);
+    expect(isSameLaCalendarDay(a, c)).toBe(false);
+  });
+});

--- a/apps/mobile/lib/dailyDiscoverUsage.ts
+++ b/apps/mobile/lib/dailyDiscoverUsage.ts
@@ -1,48 +1,31 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
-const STORAGE_PREFIX = 'roompear_discover_usage_v1';
-
-function localDateKey(): string {
-  const d = new Date();
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
-function storageKey(userId: string): string {
-  return `${STORAGE_PREFIX}:${userId}:${localDateKey()}`;
-}
+import { supabase } from './supabase';
+import { laCalendarDayBounds } from './usageDay';
 
 export type DiscoverDailyUsage = {
   swipes: number;
   topPicks: number;
 };
 
+/**
+ * Today's swipe and top-pick counts for the user, derived from `swipes` rows
+ * (America/Los_Angeles calendar day — same bucketing as server-stored `timestamptz`).
+ */
 export async function getDiscoverUsage(userId: string): Promise<DiscoverDailyUsage> {
-  try {
-    const raw = await AsyncStorage.getItem(storageKey(userId));
-    if (!raw) return { swipes: 0, topPicks: 0 };
-    const p = JSON.parse(raw) as Partial<DiscoverDailyUsage>;
-    return {
-      swipes: typeof p.swipes === 'number' ? p.swipes : 0,
-      topPicks: typeof p.topPicks === 'number' ? p.topPicks : 0,
-    };
-  } catch {
+  const { startIso, endIso } = laCalendarDayBounds();
+  const { data, error } = await supabase
+    .from('swipes')
+    .select('direction')
+    .eq('swiper_id', userId)
+    .gte('created_at', startIso)
+    .lt('created_at', endIso);
+
+  if (error) {
+    console.warn('getDiscoverUsage', error.message);
     return { swipes: 0, topPicks: 0 };
   }
-}
-
-export async function recordDiscoverAction(
-  userId: string,
-  direction: 'like' | 'pass' | 'top_pick'
-): Promise<void> {
-  const u = await getDiscoverUsage(userId);
-  if (direction === 'top_pick') {
-    u.swipes += 1;
-    u.topPicks += 1;
-  } else {
-    u.swipes += 1;
-  }
-  await AsyncStorage.setItem(storageKey(userId), JSON.stringify(u));
+  const rows = data ?? [];
+  return {
+    swipes: rows.length,
+    topPicks: rows.filter((r) => r.direction === 'top_pick').length,
+  };
 }

--- a/apps/mobile/lib/likes.ts
+++ b/apps/mobile/lib/likes.ts
@@ -89,51 +89,39 @@ export async function fetchLikers(userId: string): Promise<Liker[]> {
   return result;
 }
 
-export type ConsumeRevealReason = 'already_used' | 'no_bonus';
+export type ConsumeRevealReason =
+  | 'already_used'
+  | 'no_bonus'
+  /** PostgREST / transport error (migration missing, offline, etc.) — differs from exhausted quota */
+  | 'rpc_failed';
 
 /**
- * Uses the daily free reveal first; if already used today, consumes one bonus reveal.
+ * Server-side reveal quota (RPC): LA daily free reveal first, then bonus_reveal_balance.
+ * Must match `consume_like_reveal_quota` in Supabase.
  */
-export async function consumeReveal(
-  userId: string
-): Promise<{ success: boolean; reason?: ConsumeRevealReason; usedBonus?: boolean }> {
-  const { data, error } = await supabase
-    .from('profiles')
-    .select('last_free_reveal_at, bonus_reveal_balance')
-    .eq('id', userId)
-    .single();
+export async function consumeReveal(): Promise<{
+  success: boolean;
+  reason?: ConsumeRevealReason;
+  usedBonus?: boolean;
+  rpcErrorMessage?: string;
+}> {
+  const { data, error } = await supabase.rpc('consume_like_reveal_quota');
 
-  if (error || !data) {
-    return { success: false, reason: 'already_used' };
+  if (error) {
+    console.warn('consumeReveal', error.message);
+    return { success: false, reason: 'rpc_failed', rpcErrorMessage: error.message };
   }
 
-  const lastReveal: string | null = data.last_free_reveal_at ?? null;
-  const todayStr = new Date().toDateString();
-  const dailyAvailable = !lastReveal || new Date(lastReveal).toDateString() !== todayStr;
-  const bonus = Math.max(0, Number(data.bonus_reveal_balance ?? 0));
-
-  if (dailyAvailable) {
-    await supabase
-      .from('profiles')
-      .update({ last_free_reveal_at: new Date().toISOString() })
-      .eq('id', userId);
-    return { success: true, usedBonus: false };
+  const row = data as { success?: boolean; used_bonus?: boolean; reason?: string } | null;
+  if (!row || row.success !== true) {
+    const r = row?.reason;
+    return {
+      success: false,
+      reason: r === 'no_bonus' ? 'no_bonus' : 'already_used',
+    };
   }
 
-  if (bonus <= 0) {
-    return { success: false, reason: 'already_used' };
-  }
-
-  const { error: upErr } = await supabase
-    .from('profiles')
-    .update({ bonus_reveal_balance: bonus - 1 })
-    .eq('id', userId);
-
-  if (upErr) {
-    return { success: false, reason: 'no_bonus' };
-  }
-
-  return { success: true, usedBonus: true };
+  return { success: true, usedBonus: Boolean(row.used_bonus) };
 }
 
 export async function fetchPersistedRevealedIds(userId: string): Promise<Set<string>> {

--- a/apps/mobile/lib/usageDay.ts
+++ b/apps/mobile/lib/usageDay.ts
@@ -1,0 +1,38 @@
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
+
+/** IANA zone for daily quotas (swipes, top picks, free reveal). Pacific observes DST (PDT/PST). */
+export const ROOMPEAR_DAILY_TZ = 'America/Los_Angeles';
+
+export function laCalendarDateString(when: Date = new Date()): string {
+  return formatInTimeZone(when, ROOMPEAR_DAILY_TZ, 'yyyy-MM-dd');
+}
+
+/** Next Gregorian yyyy-MM-dd after `ymd` (civil date math; safe for quota boundaries). */
+function incrementGregorianYmd(ymd: string): string {
+  const [yStr, mStr, dStr] = ymd.split('-');
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const d = Number(dStr);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + 1);
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`;
+}
+
+/**
+ * [startIso, endIso) for the Los Angeles calendar day containing `when`.
+ * Used with `swipes.created_at` (timestamptz) so counts align with Postgres.
+ */
+export function laCalendarDayBounds(when: Date = new Date()): { startIso: string; endIso: string } {
+  const ymd = laCalendarDateString(when);
+  const start = fromZonedTime(`${ymd} 00:00:00`, ROOMPEAR_DAILY_TZ);
+  const nextYmd = incrementGregorianYmd(ymd);
+  const end = fromZonedTime(`${nextYmd} 00:00:00`, ROOMPEAR_DAILY_TZ);
+  return { startIso: start.toISOString(), endIso: end.toISOString() };
+}
+
+/** True when both instants fall on the same America/Los_Angeles calendar date. */
+export function isSameLaCalendarDay(a: Date | string, b: Date | string = new Date()): boolean {
+  const da = typeof a === 'string' ? new Date(a) : a;
+  const db = typeof b === 'string' ? new Date(b) : b;
+  return laCalendarDateString(da) === laCalendarDateString(db);
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,8 @@
     "@rnmapbox/maps": "^10.3.0",
     "@supabase/supabase-js": "^2.89.0",
     "@turf/circle": "^7.3.4",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^17.2.3",
     "expo": "~54.0.30",
     "expo-blur": "~15.0.8",

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -21,7 +21,7 @@ import { supabase } from '../lib/supabase';
 import { fetchDiscoverProfiles, recordSwipe, type DiscoverProfile } from '../lib/discover';
 import { getProfileImageUrls } from '../lib/storage';
 import { profilePhotoPathsFromRow } from '../lib/profileDisplay';
-import { getDiscoverUsage, recordDiscoverAction } from '../lib/dailyDiscoverUsage';
+import { getDiscoverUsage } from '../lib/dailyDiscoverUsage';
 import { FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../lib/freeTierLimits';
 import { usePurchases } from '../context/PurchasesContext';
 import { hasRoomPearPlusEntitlement, isPremiumProfileTier } from '../lib/purchasesConfig';
@@ -241,7 +241,6 @@ export default function DiscoverScreen() {
             sharedInterests,
           });
         }
-        await recordDiscoverAction(userId, direction);
         await refreshDailyUsage(userId);
       }
       setCurrentIndex(prev => prev + 1);

--- a/apps/mobile/screens/LikesScreen.tsx
+++ b/apps/mobile/screens/LikesScreen.tsx
@@ -29,6 +29,7 @@ import {
   type Liker,
 } from '../lib/likes';
 import { recordSwipe } from '../lib/discover';
+import { isSameLaCalendarDay } from '../lib/usageDay';
 import { usePurchases } from '../context/PurchasesContext';
 import { hasRoomPearPlusEntitlement, isPremiumProfileTier } from '../lib/purchasesConfig';
 import type { MainTabParamList } from '../navigation/MainTabNavigator';
@@ -132,6 +133,24 @@ export default function LikesScreen() {
     likersRef.current = likers;
   }, [likers]);
 
+  const refreshRevealQuota = useCallback(async (uid: string) => {
+    const { data: profile, error } = await supabase
+      .from('profiles')
+      .select('last_free_reveal_at, bonus_reveal_balance')
+      .eq('id', uid)
+      .maybeSingle();
+
+    if (error) {
+      console.warn('refreshRevealQuota', error.message);
+      return;
+    }
+
+    const lastReveal: string | null = profile?.last_free_reveal_at ?? null;
+    const usedToday = !!lastReveal && isSameLaCalendarDay(lastReveal, new Date());
+    setDailyRevealSpentToday(usedToday);
+    setBonusRevealBalance(Math.max(0, Number(profile?.bonus_reveal_balance ?? 0)));
+  }, []);
+
   const load = useCallback(async (isRefresh = false, skipIfFresh = false) => {
     if (isRefresh) setRefreshing(true);
 
@@ -180,6 +199,10 @@ export default function LikesScreen() {
       setRevealedIds(new Set(likersRef.current.map((l) => l.id)));
     }
 
+    // Always sync quota from DB before the stale-focus short-circuit, or banner / canReveal can
+    // disagree with the server after a consume on another tab or stale local state.
+    await refreshRevealQuota(uid);
+
     if (
       skipIfFresh &&
       initialLoadDoneRef.current &&
@@ -190,18 +213,6 @@ export default function LikesScreen() {
       setLoading(false);
       return;
     }
-
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('last_free_reveal_at, bonus_reveal_balance')
-      .eq('id', uid)
-      .single();
-
-    const lastReveal: string | null = profile?.last_free_reveal_at ?? null;
-    const usedToday =
-      !!lastReveal && new Date(lastReveal).toDateString() === new Date().toDateString();
-    setDailyRevealSpentToday(usedToday);
-    setBonusRevealBalance(Math.max(0, Number(profile?.bonus_reveal_balance ?? 0)));
 
     const data = await fetchLikers(uid);
     setLikers(data);
@@ -215,7 +226,7 @@ export default function LikesScreen() {
     lastFetchedAtRef.current = Date.now();
     setLoading(false);
     setRefreshing(false);
-  }, [isRoomPearPlus, customerInfo]);
+  }, [isRoomPearPlus, customerInfo, refreshRevealQuota]);
 
   /** When RC / DB flips to paid while you stay on this tab, or likers list arrives after premium, unlock all. */
   useEffect(() => {
@@ -283,7 +294,7 @@ export default function LikesScreen() {
       return;
     }
 
-    const result = await consumeReveal(userId);
+    const result = await consumeReveal();
     if (result.success) {
       setRevealedIds((prev) => new Set([...prev, liker.id]));
       if (result.usedBonus) {
@@ -293,13 +304,19 @@ export default function LikesScreen() {
       }
     } else {
       await unpersistRevealedLiker(userId, liker.id);
+      await refreshRevealQuota(userId);
+      const rpcDown = result.reason === 'rpc_failed';
       Alert.alert(
-        'No reveals left today',
-        'Come back tomorrow, invite friends from Profile for bonus reveals, or upgrade to RoomPear+ for unlimited access to your likers.',
-        [
-          { text: 'Not now', style: 'cancel' },
-          { text: 'View RoomPear+', onPress: () => void openPaywallIfNeeded() },
-        ]
+        rpcDown ? 'Reveal unavailable' : 'No reveals left today',
+        rpcDown
+          ? "We couldn't confirm your reveal quota. Check your connection and try again.\nIf this keeps happening, the app server may need the latest migrations."
+          : 'Come back tomorrow, invite friends from Profile for bonus reveals, or upgrade to RoomPear+ for unlimited access to your likers.',
+        rpcDown
+          ? [{ text: 'OK', style: 'cancel' }]
+          : [
+              { text: 'Not now', style: 'cancel' },
+              { text: 'View RoomPear+', onPress: () => void openPaywallIfNeeded() },
+            ]
       );
     }
   }

--- a/backend/supabase/migrations/20260430120000_swipes_top_pick_constraint_and_index.sql
+++ b/backend/supabase/migrations/20260430120000_swipes_top_pick_constraint_and_index.sql
@@ -1,0 +1,7 @@
+-- App records direction 'top_pick'; original table only allowed like/pass.
+ALTER TABLE public.swipes DROP CONSTRAINT IF EXISTS swipes_direction_check;
+ALTER TABLE public.swipes
+  ADD CONSTRAINT swipes_direction_check CHECK (direction IN ('like', 'pass', 'top_pick'));
+
+-- Speed daily swipe / top-pick counts (swiper_id + UTC day window on created_at).
+CREATE INDEX IF NOT EXISTS swipes_swiper_created_at_idx ON public.swipes (swiper_id, created_at);

--- a/backend/supabase/migrations/20260430150000_consume_like_reveal_quota_rpc.sql
+++ b/backend/supabase/migrations/20260430150000_consume_like_reveal_quota_rpc.sql
@@ -1,0 +1,94 @@
+-- Server-side reveal quota: one free reveal per America/Los_Angeles calendar day,
+-- then bonus_reveal_balance decrements. Clients cannot forge these fields (see trigger).
+
+CREATE OR REPLACE FUNCTION public.protect_profile_economy_fields()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF current_setting('roompear.profile_system_update', TRUE) IS NOT DISTINCT FROM 'true' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.last_free_reveal_at IS DISTINCT FROM OLD.last_free_reveal_at THEN
+    NEW.last_free_reveal_at := OLD.last_free_reveal_at;
+  END IF;
+
+  IF NEW.referral_code IS DISTINCT FROM OLD.referral_code THEN
+    NEW.referral_code := OLD.referral_code;
+  END IF;
+
+  IF NEW.referred_by_user_id IS DISTINCT FROM OLD.referred_by_user_id THEN
+    IF OLD.referred_by_user_id IS NOT NULL THEN
+      NEW.referred_by_user_id := OLD.referred_by_user_id;
+    ELSIF NEW.referred_by_user_id IS NOT NULL THEN
+      RAISE EXCEPTION 'referred_by_user_id cannot be set directly';
+    END IF;
+  END IF;
+
+  IF NEW.bonus_reveal_balance IS DISTINCT FROM OLD.bonus_reveal_balance THEN
+    IF NEW.bonus_reveal_balance > OLD.bonus_reveal_balance THEN
+      RAISE EXCEPTION 'bonus_reveal_balance cannot be increased directly';
+    END IF;
+    IF NEW.bonus_reveal_balance < OLD.bonus_reveal_balance THEN
+      NEW.bonus_reveal_balance := OLD.bonus_reveal_balance;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.consume_like_reveal_quota()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  rec public.profiles%ROWTYPE;
+  la_today date := ((CURRENT_TIMESTAMP AT TIME ZONE 'America/Los_Angeles'))::date;
+  reveal_la_date date;
+BEGIN
+  IF uid IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'already_used');
+  END IF;
+
+  PERFORM set_config('roompear.profile_system_update', 'true', true);
+
+  SELECT * INTO rec FROM public.profiles WHERE id = uid FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'already_used');
+  END IF;
+
+  IF rec.last_free_reveal_at IS NULL THEN
+    reveal_la_date := NULL;
+  ELSE
+    reveal_la_date := ((rec.last_free_reveal_at AT TIME ZONE 'America/Los_Angeles'))::date;
+  END IF;
+
+  IF reveal_la_date IS NULL OR reveal_la_date < la_today THEN
+    UPDATE public.profiles
+    SET last_free_reveal_at = now()
+    WHERE id = uid;
+    RETURN jsonb_build_object('success', true, 'used_bonus', false);
+  END IF;
+
+  IF coalesce(rec.bonus_reveal_balance, 0) > 0 THEN
+    UPDATE public.profiles
+    SET bonus_reveal_balance = rec.bonus_reveal_balance - 1
+    WHERE id = uid;
+    RETURN jsonb_build_object('success', true, 'used_bonus', true);
+  END IF;
+
+  RETURN jsonb_build_object('success', false, 'reason', 'already_used');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.consume_like_reveal_quota() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.consume_like_reveal_quota() TO authenticated;
+
+COMMENT ON FUNCTION public.consume_like_reveal_quota() IS
+  'Atomically consumes one reveal quota for auth.uid(): LA daily free reveal first, else bonus_reveal_balance.';

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,10 @@
     "apps/mobile": {
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/nunito": "^0.4.2",
         "@expo/metro-runtime": "~6.1.2",
         "@expo/vector-icons": "^15.0.3",
-        "@react-native-async-storage/async-storage": "^1.24.0",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/datetimepicker": "^8.5.1",
         "@react-native-community/slider": "5.0.1",
         "@react-navigation/bottom-tabs": "^7.15.9",
@@ -31,20 +32,27 @@
         "@rnmapbox/maps": "^10.3.0",
         "@supabase/supabase-js": "^2.89.0",
         "@turf/circle": "^7.3.4",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^17.2.3",
         "expo": "~54.0.30",
         "expo-blur": "~15.0.8",
         "expo-clipboard": "^55.0.13",
-        "expo-constants": "^18.0.12",
+        "expo-constants": "~18.0.13",
+        "expo-device": "~8.0.10",
+        "expo-font": "~14.0.11",
         "expo-image": "~3.0.11",
         "expo-image-picker": "~17.0.10",
         "expo-linear-gradient": "~15.0.8",
+        "expo-notifications": "~0.32.16",
         "expo-status-bar": "~3.0.9",
         "phosphor-react-native": "^3.0.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-purchases": "^9.15.2",
+        "react-native-purchases-ui": "^9.15.2",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -59,18 +67,6 @@
         "jest": "^30.2.0",
         "jest-expo": "^54.0.16",
         "typescript": "~5.9.2"
-      }
-    },
-    "apps/mobile/node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
-      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
-      "license": "MIT",
-      "dependencies": {
-        "merge-options": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "apps/mobile/node_modules/dotenv": {
@@ -1630,6 +1626,11 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@expo-google-fonts/nunito": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/nunito/-/nunito-0.4.2.tgz",
+      "integrity": "sha512-1KCWphw/I2ugqfs9iRHUCkPTnomNgGPtF4AvqVquoEKxr0EL+mcLNLgeixsslbaSFevRR6/KJAE3sc8g0VaY0Q=="
+    },
     "node_modules/@expo/cli": {
       "version": "54.0.20",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.20.tgz",
@@ -2068,6 +2069,11 @@
       "bin": {
         "excpretty": "build/cli.js"
       }
+    },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g=="
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -3790,6 +3796,17 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-community/datetimepicker": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
@@ -4690,6 +4707,24 @@
       "dependencies": {
         "nanoid": "^3.3.11"
       }
+    },
+    "node_modules/@revenuecat/purchases-js": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js/-/purchases-js-1.30.0.tgz",
+      "integrity": "sha512-aNlk6lPWrJ1DncPnw0WZh8nZKbd5S++EcsQxlLnv3HX/jOnMO54zr0SKsz3GJyFa6zh04N6b3qHAgWWm51EWpg=="
+    },
+    "node_modules/@revenuecat/purchases-js-hybrid-mappings": {
+      "version": "17.55.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js-hybrid-mappings/-/purchases-js-hybrid-mappings-17.55.1.tgz",
+      "integrity": "sha512-hXnaWqbedzoAQOGcJUT0WtXBa/NyDUp6X5ntQ0F79FdgdceMGIGIS3QtLVC6CgNRUmZlt1xgBOkq+MX3bsBYSQ==",
+      "dependencies": {
+        "@revenuecat/purchases-js": "1.30.0"
+      }
+    },
+    "node_modules/@revenuecat/purchases-typescript-internal": {
+      "version": "17.55.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal/-/purchases-typescript-internal-17.55.1.tgz",
+      "integrity": "sha512-t49IP5hdlLEi+csqH8J8fo+DvCucWBwDnv+bVQca1Ogdry6VnY0HVdH1z743h9F4vKwFGTJ3XK5TUcahlK+U3Q=="
     },
     "node_modules/@rnmapbox/maps": {
       "version": "10.3.0",
@@ -5855,6 +5890,18 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -5865,6 +5912,20 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -6070,6 +6131,11 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw=="
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6257,17 +6323,48 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -6781,6 +6878,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/debounce": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
@@ -6864,12 +6978,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -7042,7 +7188,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -7134,7 +7279,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7143,7 +7287,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7152,7 +7295,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -7589,6 +7731,14 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "12.0.12",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
@@ -7625,16 +7775,52 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.12.tgz",
-      "integrity": "sha512-WzcKYMVNRRu4NcSzfIVRD5aUQFnSpTZgXFrlWmm19xJoDa4S3/PQNi6PNTBRc49xz9h8FT7HMxRKaC8lr0gflA==",
+      "version": "18.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
+      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "dependencies": {
-        "@expo/config": "~12.0.12",
+        "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
       },
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-device": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-8.0.10.tgz",
+      "integrity": "sha512-jd5BxjaF7382JkDMaC+P04aXXknB2UhWaVx5WiQKA05ugm/8GH5uaz9P9ckWdMKZGQVVEOC8MHaUADoT26KmFA==",
+      "dependencies": {
+        "ua-parser-js": "^0.7.33"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-device/node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/expo-file-system": {
@@ -7647,9 +7833,9 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "14.0.10",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
-      "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
+      "version": "14.0.11",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
+      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -7718,6 +7904,25 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.17",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.17.tgz",
+      "integrity": "sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -7882,6 +8087,20 @@
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg=="
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -7968,6 +8187,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8007,7 +8234,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -8039,7 +8265,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -8113,7 +8338,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8134,11 +8358,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8150,7 +8384,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -8444,11 +8677,37 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -8495,6 +8754,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8518,6 +8810,23 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -8528,6 +8837,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -12655,7 +12978,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -13320,6 +13642,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -13716,6 +14080,14 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
@@ -14072,6 +14444,48 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-purchases": {
+      "version": "9.15.2",
+      "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-9.15.2.tgz",
+      "integrity": "sha512-cAGChbjDp1os6Xc8Wfg83w2ey/Xm/Uq5znoRlXwSW4a/Q8f2gCXLikBfH0bOC+diAkwapN70PwKkP12iGYptyg==",
+      "workspaces": [
+        "examples/purchaseTesterTypescript",
+        "react-native-purchases-ui"
+      ],
+      "dependencies": {
+        "@revenuecat/purchases-js-hybrid-mappings": "17.55.1",
+        "@revenuecat/purchases-typescript-internal": "17.55.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.6.3",
+        "react-native": ">= 0.73.0",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-purchases-ui": {
+      "version": "9.15.2",
+      "resolved": "https://registry.npmjs.org/react-native-purchases-ui/-/react-native-purchases-ui-9.15.2.tgz",
+      "integrity": "sha512-KAB/kcRhLLUs8A4udSY2vCjlKmTQJJK6g+jH+OL2T2Rejvny1NnUCcEAAgwoq7vIV5xrPiAQdP6gsM5fus6c0g==",
+      "dependencies": {
+        "@revenuecat/purchases-typescript-internal": "17.55.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">= 0.73.0",
+        "react-native-purchases": "9.15.2",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {
@@ -14521,6 +14935,22 @@
         }
       ]
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -14658,6 +15088,22 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "dev": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -15596,6 +16042,18 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -15754,6 +16212,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wonka": {


### PR DESCRIPTION
### Summary
Moves like-reveal quota to a Supabase so it can’t be spoofed from the client, and switches daily swipe / top-pick limits to counts read from swipes over an America/Los_Angeles calendar day (with shared usageDay helpers), since no longer uses local. Likes tab now syncs reveal quota on every focus before the stale short-circuit so the banner matches the server, and RPC failures are surfaced separately from “out of reveals.”

### Supabase
consume_like_reveal_quota: SECURITY DEFINER RPC consumes one reveal: free once per LA calendar day, else bonus balance, else failure JSON.
protect_profile_economy_fields: Blocks client-side changes to reveal / referral economy fields unless roompear.profile_system_update is set (RPC uses set_config for the update path).
swipes: direction check extended to include top_pick; composite index (swiper_id, created_at) for daily aggregates.