### PR TITLE
Unmatch/report/block available in chats/matches tab

### DIFF
--- a/apps/mobile/components/BlockReportModal.tsx
+++ b/apps/mobile/components/BlockReportModal.tsx
@@ -1,6 +1,5 @@
 import {
   ActivityIndicator,
-  Alert,
   Modal,
   ScrollView,
   StyleSheet,
@@ -9,9 +8,10 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { blockUser, reportUser } from '../lib/blockReport';
+import { unmatchPeer } from '../lib/unmatch';
 
 const REASONS = [
   'Fake profile',
@@ -43,11 +43,24 @@ export default function BlockReportModal({
   const [selectedReason, setSelectedReason] = useState<string | null>(null);
   const [details, setDetails] = useState('');
   const [busy, setBusy] = useState(false);
+  const [panel, setPanel] = useState<'report' | 'block_confirm' | 'report_success'>('report');
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    setPanel('report');
+    setInlineError(null);
+    setBusy(false);
+    setSelectedReason(null);
+    setDetails('');
+  }, [visible]);
 
   function reset() {
     setSelectedReason(null);
     setDetails('');
     setBusy(false);
+    setPanel('report');
+    setInlineError(null);
   }
 
   function handleClose() {
@@ -58,37 +71,30 @@ export default function BlockReportModal({
   async function handleReport() {
     if (!selectedReason) return;
     setBusy(true);
+    setInlineError(null);
     const { success, error } = await reportUser(reporterId, reportedId, selectedReason, details);
     setBusy(false);
     if (!success) {
-      Alert.alert('Error', error ?? 'Could not submit report. Try again.');
+      setInlineError(error ?? 'Could not submit report. Try again.');
+      return;
+    }
+    setPanel('report_success');
+  }
+
+  async function confirmBlock() {
+    setBusy(true);
+    setInlineError(null);
+    const { error: uErr } = await unmatchPeer(reportedId);
+    if (uErr && __DEV__) console.warn('unmatchPeer before block:', uErr);
+    const { success, error: bErr } = await blockUser(reporterId, reportedId);
+    setBusy(false);
+    if (!success) {
+      setInlineError(bErr ?? 'Could not block. Try again.');
       return;
     }
     reset();
     onClose();
-    Alert.alert('Report submitted', 'Thanks for keeping RoomPear safe. We\'ll review this shortly.');
-  }
-
-  async function handleBlock() {
-    Alert.alert(
-      `Block ${reportedName}?`,
-      "They won't appear in your discover and you won't appear in theirs.",
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Block',
-          style: 'destructive',
-          onPress: async () => {
-            setBusy(true);
-            await blockUser(reporterId, reportedId);
-            setBusy(false);
-            reset();
-            onClose();
-            onBlocked();
-          },
-        },
-      ]
-    );
+    onBlocked();
   }
 
   return (
@@ -100,73 +106,126 @@ export default function BlockReportModal({
     >
       <View style={[styles.root, { paddingBottom: insets.bottom + 16 }]}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={handleClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
-            <Text style={styles.cancel}>Cancel</Text>
+          <TouchableOpacity
+            onPress={() => {
+              if (panel === 'block_confirm') {
+                setPanel('report');
+                setInlineError(null);
+                return;
+              }
+              handleClose();
+            }}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text style={styles.cancel}>{panel === 'block_confirm' ? 'Back' : 'Cancel'}</Text>
           </TouchableOpacity>
-          <Text style={styles.title}>Report {reportedName}</Text>
+          <Text style={styles.title}>
+            {panel === 'block_confirm'
+              ? `Block ${reportedName}`
+              : panel === 'report_success'
+                ? 'Thanks'
+                : `Report ${reportedName}`}
+          </Text>
           <View style={{ width: 56 }} />
         </View>
 
-        <ScrollView contentContainerStyle={styles.body} showsVerticalScrollIndicator={false}>
-          <Text style={styles.sectionLabel}>Why are you reporting this profile?</Text>
-          <View style={styles.reasonsGroup}>
-            {REASONS.map((reason, i) => (
-              <TouchableOpacity
-                key={reason}
-                style={[
-                  styles.reasonRow,
-                  i < REASONS.length - 1 && styles.reasonDivider,
-                  selectedReason === reason && styles.reasonRowSelected,
-                ]}
-                onPress={() => setSelectedReason(reason)}
-              >
-                <Text style={[styles.reasonText, selectedReason === reason && styles.reasonTextSelected]}>
-                  {reason}
-                </Text>
-                <View style={[styles.radio, selectedReason === reason && styles.radioSelected]}>
-                  {selectedReason === reason && <View style={styles.radioDot} />}
-                </View>
-              </TouchableOpacity>
-            ))}
+        {panel === 'block_confirm' ? (
+          <View style={styles.body}>
+            <Text style={styles.confirmBlockBody}>
+              They will not appear in your discover and you will not appear in theirs until you unblock them from your
+              profile.
+            </Text>
+            {inlineError ? <Text style={styles.inlineError}>{inlineError}</Text> : null}
+            <TouchableOpacity
+              style={[styles.submitBtn, styles.blockConfirmBtn, busy && styles.submitBtnDisabled]}
+              onPress={confirmBlock}
+              disabled={busy}
+            >
+              {busy ? (
+                <ActivityIndicator color="#FFFFFF" />
+              ) : (
+                <Text style={styles.submitBtnText}>Block {reportedName}</Text>
+              )}
+            </TouchableOpacity>
           </View>
-
-          <Text style={styles.sectionLabel}>Additional details (optional)</Text>
-          <TextInput
-            style={styles.detailsInput}
-            placeholder="Describe what happened…"
-            placeholderTextColor="#A0A8A4"
-            multiline
-            numberOfLines={4}
-            value={details}
-            onChangeText={setDetails}
-            maxLength={500}
-          />
-
-          <TouchableOpacity
-            style={[styles.submitBtn, !selectedReason && styles.submitBtnDisabled]}
-            onPress={handleReport}
-            disabled={!selectedReason || busy}
-          >
-            {busy ? (
-              <ActivityIndicator color="#FFFFFF" />
-            ) : (
-              <Text style={styles.submitBtnText}>Submit report</Text>
-            )}
-          </TouchableOpacity>
-
-          <View style={styles.dividerRow}>
-            <View style={styles.dividerLine} />
-            <Text style={styles.dividerLabel}>or</Text>
-            <View style={styles.dividerLine} />
+        ) : panel === 'report_success' ? (
+          <View style={styles.body}>
+            <Text style={styles.successTitle}>Report submitted</Text>
+            <Text style={styles.successBody}>Thanks for keeping RoomPear safe. We will review this shortly.</Text>
+            <TouchableOpacity style={styles.submitBtn} onPress={handleClose}>
+              <Text style={styles.submitBtnText}>Done</Text>
+            </TouchableOpacity>
           </View>
+        ) : (
+          <ScrollView contentContainerStyle={styles.body} showsVerticalScrollIndicator={false}>
+            {inlineError ? <Text style={styles.inlineError}>{inlineError}</Text> : null}
+            <Text style={styles.sectionLabel}>Why are you reporting this profile?</Text>
+            <View style={styles.reasonsGroup}>
+              {REASONS.map((reason, i) => (
+                <TouchableOpacity
+                  key={reason}
+                  style={[
+                    styles.reasonRow,
+                    i < REASONS.length - 1 && styles.reasonDivider,
+                    selectedReason === reason && styles.reasonRowSelected,
+                  ]}
+                  onPress={() => setSelectedReason(reason)}
+                >
+                  <Text style={[styles.reasonText, selectedReason === reason && styles.reasonTextSelected]}>
+                    {reason}
+                  </Text>
+                  <View style={[styles.radio, selectedReason === reason && styles.radioSelected]}>
+                    {selectedReason === reason && <View style={styles.radioDot} />}
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </View>
 
-          <TouchableOpacity style={styles.blockBtn} onPress={handleBlock} disabled={busy}>
-            <Text style={styles.blockBtnText}>Block {reportedName}</Text>
-          </TouchableOpacity>
-          <Text style={styles.blockHelp}>
-            Blocking removes them from your discover deck and hides you from theirs.
-          </Text>
-        </ScrollView>
+            <Text style={styles.sectionLabel}>Additional details (optional)</Text>
+            <TextInput
+              style={styles.detailsInput}
+              placeholder="Describe what happened…"
+              placeholderTextColor="#A0A8A4"
+              multiline
+              numberOfLines={4}
+              value={details}
+              onChangeText={setDetails}
+              maxLength={500}
+            />
+
+            <TouchableOpacity
+              style={[styles.submitBtn, !selectedReason && styles.submitBtnDisabled]}
+              onPress={handleReport}
+              disabled={!selectedReason || busy}
+            >
+              {busy ? (
+                <ActivityIndicator color="#FFFFFF" />
+              ) : (
+                <Text style={styles.submitBtnText}>Submit report</Text>
+              )}
+            </TouchableOpacity>
+
+            <View style={styles.dividerRow}>
+              <View style={styles.dividerLine} />
+              <Text style={styles.dividerLabel}>or</Text>
+              <View style={styles.dividerLine} />
+            </View>
+
+            <TouchableOpacity
+              style={styles.blockBtn}
+              onPress={() => {
+                setInlineError(null);
+                setPanel('block_confirm');
+              }}
+              disabled={busy}
+            >
+              <Text style={styles.blockBtnText}>Block {reportedName}</Text>
+            </TouchableOpacity>
+            <Text style={styles.blockHelp}>
+              Blocking removes them from your discover deck and hides you from theirs.
+            </Text>
+          </ScrollView>
+        )}
       </View>
     </Modal>
   );
@@ -272,5 +331,32 @@ const styles = StyleSheet.create({
     color: '#A0A8A4',
     textAlign: 'center',
     marginTop: 4,
+  },
+  inlineError: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#D4183D',
+    marginBottom: 12,
+  },
+  confirmBlockBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: '#717182',
+    marginBottom: 20,
+  },
+  blockConfirmBtn: {
+    backgroundColor: '#D4183D',
+  },
+  successTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1A2C24',
+    marginBottom: 10,
+  },
+  successBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: '#717182',
+    marginBottom: 24,
   },
 });

--- a/apps/mobile/components/ChatStyleTopBar.tsx
+++ b/apps/mobile/components/ChatStyleTopBar.tsx
@@ -16,7 +16,10 @@ type Props = {
   onBack: () => void;
   topInset: number;
   backAccessibilityLabel?: string;
+  /** Flag icon — e.g. Discover card report. */
   onReport?: () => void;
+  /** Ellipsis menu — e.g. Chat safety (unmatch / report / block). */
+  onMenu?: () => void;
 };
 
 /** Floating back + title pills (matches Chat screen) — overlay on scroll content. */
@@ -26,6 +29,7 @@ export function ChatStyleTopBar({
   topInset,
   backAccessibilityLabel = 'Go back',
   onReport,
+  onMenu,
 }: Props) {
   return (
     <View style={[styles.wrap, { paddingTop: topInset }]} pointerEvents="box-none">
@@ -48,7 +52,16 @@ export function ChatStyleTopBar({
           </View>
         </View>
 
-        {onReport ? (
+        {onMenu ? (
+          <TouchableOpacity
+            onPress={onMenu}
+            style={styles.roundBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+            accessibilityLabel="More options"
+          >
+            <Ionicons name="ellipsis-horizontal" size={22} color={CHATS_GREEN} />
+          </TouchableOpacity>
+        ) : onReport ? (
           <TouchableOpacity
             onPress={onReport}
             style={styles.roundBtn}

--- a/apps/mobile/components/PeerSafetyActionsModal.tsx
+++ b/apps/mobile/components/PeerSafetyActionsModal.tsx
@@ -1,0 +1,339 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  CHATS_CARD,
+  CHATS_GREEN,
+  CHATS_GREEN_BORDER,
+} from '../theme/chatsAmbient';
+import { supabase } from '../lib/supabase';
+import { blockUser } from '../lib/blockReport';
+import { unmatchPeer } from '../lib/unmatch';
+
+const TEXT = '#1A2C24';
+const GRAY = '#717182';
+const DESTRUCTIVE = '#D4183D';
+
+export type PeerSafetyStart = 'main' | 'confirmUnmatch' | 'confirmBlock';
+
+type Props = {
+  visible: boolean;
+  otherUserId: string | null;
+  otherName: string;
+  /** Initial panel each time the sheet opens. */
+  start?: PeerSafetyStart;
+  onClose: () => void;
+  onOpenReport: () => void;
+  onAfterUnmatchOrBlock: () => void;
+};
+
+type Panel = PeerSafetyStart;
+
+export default function PeerSafetyActionsModal({
+  visible,
+  otherUserId,
+  otherName,
+  start = 'main',
+  onClose,
+  onOpenReport,
+  onAfterUnmatchOrBlock,
+}: Props) {
+  const insets = useSafeAreaInsets();
+  const [panel, setPanel] = useState<Panel>('main');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setPanel(start);
+      setBusy(false);
+      setError(null);
+    }
+  }, [visible, start]);
+
+  function handleClose() {
+    if (busy) return;
+    onClose();
+  }
+
+  async function runUnmatch() {
+    if (!otherUserId) return;
+    setBusy(true);
+    setError(null);
+    const { error: err } = await unmatchPeer(otherUserId);
+    setBusy(false);
+    if (err) {
+      setError(err);
+      return;
+    }
+    onAfterUnmatchOrBlock();
+    handleClose();
+  }
+
+  async function runBlock() {
+    if (!otherUserId) return;
+    setBusy(true);
+    setError(null);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user?.id) {
+      setBusy(false);
+      setError('Not signed in.');
+      return;
+    }
+    const { error: uErr } = await unmatchPeer(otherUserId);
+    if (uErr && __DEV__) console.warn('unmatchPeer before block:', uErr);
+    const { success, error: bErr } = await blockUser(user.id, otherUserId);
+    setBusy(false);
+    if (!success) {
+      setError(bErr ?? 'Could not block.');
+      return;
+    }
+    onAfterUnmatchOrBlock();
+    handleClose();
+  }
+
+  function renderMain() {
+    return (
+      <>
+        <Text style={styles.sheetTitle}>{otherName}</Text>
+
+        <TouchableOpacity
+          style={styles.actionRow}
+          onPress={() => setPanel('confirmUnmatch')}
+          activeOpacity={0.75}
+        >
+          <Ionicons name="heart-dislike-outline" size={22} color={DESTRUCTIVE} />
+          <Text style={[styles.actionLabel, styles.actionLabelDestructive]}>Unmatch</Text>
+          <Ionicons name="chevron-forward" size={18} color={GRAY} style={styles.actionChevron} />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.actionRow}
+          onPress={() => {
+            onOpenReport();
+            handleClose();
+          }}
+          activeOpacity={0.75}
+        >
+          <Ionicons name="flag-outline" size={22} color={CHATS_GREEN} />
+          <Text style={styles.actionLabel}>Report</Text>
+          <Ionicons name="chevron-forward" size={18} color={GRAY} style={styles.actionChevron} />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.actionRow}
+          onPress={() => setPanel('confirmBlock')}
+          activeOpacity={0.75}
+        >
+          <Ionicons name="ban-outline" size={22} color={DESTRUCTIVE} />
+          <Text style={[styles.actionLabel, styles.actionLabelDestructive]}>Block</Text>
+          <Ionicons name="chevron-forward" size={18} color={GRAY} style={styles.actionChevron} />
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.dismissRow} onPress={handleClose} activeOpacity={0.75}>
+          <Text style={styles.dismissText}>Cancel</Text>
+        </TouchableOpacity>
+      </>
+    );
+  }
+
+  function renderConfirmUnmatch() {
+    return (
+      <>
+        <Text style={styles.sheetTitle}>Unmatch?</Text>
+        <Text style={styles.confirmBody}>
+          You will not stay matched in Chats. You may see each other in Discover again after about 30 days unless
+          someone is blocked.
+        </Text>
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        <View style={styles.confirmRow}>
+          <TouchableOpacity
+            style={styles.secondaryBtn}
+            onPress={() => {
+              setError(null);
+              setPanel('main');
+            }}
+            disabled={busy}
+          >
+            <Text style={styles.secondaryBtnText}>Back</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.primaryBtn, styles.primaryBtnDangerFill]}
+            onPress={runUnmatch}
+            disabled={busy}
+          >
+            {busy ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.primaryBtnText}>Unmatch</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </>
+    );
+  }
+
+  function renderConfirmBlock() {
+    return (
+      <>
+        <Text style={styles.sheetTitle}>Block {otherName}?</Text>
+        <Text style={styles.confirmBody}>
+          They will not appear in your discover or matches, and you will not appear in theirs until you unblock them
+          from your profile.
+        </Text>
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        <View style={styles.confirmRow}>
+          <TouchableOpacity
+            style={styles.secondaryBtn}
+            onPress={() => {
+              setError(null);
+              setPanel('main');
+            }}
+            disabled={busy}
+          >
+            <Text style={styles.secondaryBtnText}>Back</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.primaryBtn, styles.primaryBtnDangerFill]}
+            onPress={runBlock}
+            disabled={busy}
+          >
+            {busy ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.primaryBtnText}>Block</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </>
+    );
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
+      <Pressable style={styles.backdrop} onPress={handleClose}>
+        <Pressable style={[styles.sheet, { paddingBottom: insets.bottom + 20 }]} onPress={(e) => e.stopPropagation()}>
+          {panel === 'main' && renderMain()}
+          {panel === 'confirmUnmatch' && renderConfirmUnmatch()}
+          {panel === 'confirmBlock' && renderConfirmBlock()}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(26, 44, 36, 0.45)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: CHATS_CARD,
+    borderTopLeftRadius: 22,
+    borderTopRightRadius: 22,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: CHATS_GREEN_BORDER,
+    paddingHorizontal: 20,
+    paddingTop: 18,
+  },
+  sheetTitle: {
+    fontSize: 19,
+    fontWeight: '700',
+    color: TEXT,
+    marginBottom: 6,
+  },
+  sheetSubtitle: {
+    fontSize: 14,
+    color: GRAY,
+    marginBottom: 16,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: 'rgba(45, 106, 79, 0.15)',
+    gap: 12,
+  },
+  actionLabel: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    color: TEXT,
+  },
+  actionLabelDestructive: {
+    color: DESTRUCTIVE,
+  },
+  actionChevron: { opacity: 0.5 },
+  dismissRow: {
+    marginTop: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  dismissText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: CHATS_GREEN,
+  },
+  confirmBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: GRAY,
+    marginBottom: 18,
+  },
+  errorText: {
+    fontSize: 14,
+    color: DESTRUCTIVE,
+    marginBottom: 12,
+    fontWeight: '600',
+  },
+  confirmRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 4,
+  },
+  secondaryBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER,
+    alignItems: 'center',
+    backgroundColor: '#FAFBFA',
+  },
+  secondaryBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: CHATS_GREEN,
+  },
+  primaryBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 50,
+  },
+  primaryBtnDangerFill: {
+    backgroundColor: DESTRUCTIVE,
+    borderWidth: 0,
+  },
+  primaryBtnText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+});

--- a/apps/mobile/components/ThemedConfirmSheet.tsx
+++ b/apps/mobile/components/ThemedConfirmSheet.tsx
@@ -1,0 +1,154 @@
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  CHATS_CARD,
+  CHATS_GREEN,
+  CHATS_GREEN_BORDER,
+} from '../theme/chatsAmbient';
+
+const TEXT = '#1A2C24';
+const GRAY = '#717182';
+
+type Props = {
+  visible: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  /** Label for the left button in two-button mode (default “Cancel”). */
+  cancelLabel?: string;
+  destructive?: boolean;
+  /** Only a single dismiss/confirm button (e.g. “OK”). */
+  singleAction?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+/** Bottom-sheet style confirm — matches Chats ambient (no platform Alert). */
+export default function ThemedConfirmSheet({
+  visible,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  singleAction = false,
+  onConfirm,
+  onClose,
+}: Props) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={[styles.sheet, { paddingBottom: insets.bottom + 16 }]} onPress={(e) => e.stopPropagation()}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.message}>{message}</Text>
+          {singleAction ? (
+            <TouchableOpacity
+              style={[styles.confirmBtn, styles.confirmBtnFull, destructive && styles.confirmBtnDestructive]}
+              onPress={onConfirm}
+              activeOpacity={0.85}
+            >
+              <Text style={[styles.confirmBtnText, destructive && styles.confirmBtnTextOnDanger]}>
+                {confirmLabel}
+              </Text>
+            </TouchableOpacity>
+          ) : (
+            <View style={styles.row}>
+              <TouchableOpacity style={styles.cancelBtn} onPress={onClose} activeOpacity={0.85}>
+                <Text style={styles.cancelBtnText}>{cancelLabel}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.confirmBtn, destructive && styles.confirmBtnDestructive]}
+                onPress={onConfirm}
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.confirmBtnText, destructive && styles.confirmBtnTextOnDanger]}>
+                  {confirmLabel}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(26, 44, 36, 0.45)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: CHATS_CARD,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: CHATS_GREEN_BORDER,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: TEXT,
+    marginBottom: 8,
+  },
+  message: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: GRAY,
+    marginBottom: 22,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: CHATS_GREEN_BORDER,
+    alignItems: 'center',
+    backgroundColor: '#FAFBFA',
+  },
+  cancelBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: CHATS_GREEN,
+  },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 14,
+    alignItems: 'center',
+    backgroundColor: TEXT,
+  },
+  confirmBtnFull: {
+    flex: 0,
+    alignSelf: 'stretch',
+  },
+  confirmBtnDestructive: {
+    backgroundColor: '#D4183D',
+    borderWidth: 0,
+  },
+  confirmBtnText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  confirmBtnTextOnDanger: {
+    color: '#FFFFFF',
+  },
+});

--- a/apps/mobile/lib/messaging.ts
+++ b/apps/mobile/lib/messaging.ts
@@ -35,6 +35,31 @@ function displayNameFromProfile(name: string | null | undefined, fallbackId: str
  * Conversations the current user is in, newest activity first.
  * Only threads with at least one message (last_message_at set) appear in the list.
  */
+/** Other participant in a 1:1 thread (for safety actions when only `conversationId` is known). */
+export async function fetchOtherParticipantUserId(
+  conversationId: string
+): Promise<{ userId: string | null; error: Error | null }> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { userId: null, error: new Error('Not signed in') };
+  }
+
+  const { data, error } = await supabase
+    .from('conversation_participants')
+    .select('user_id')
+    .eq('conversation_id', conversationId)
+    .neq('user_id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    return { userId: null, error: new Error(error.message) };
+  }
+  const uid = data?.user_id;
+  return { userId: typeof uid === 'string' ? uid : null, error: null };
+}
+
 export async function fetchConversationSummaries(): Promise<{
   data: ConversationSummary[];
   error: Error | null;

--- a/apps/mobile/lib/unmatch.ts
+++ b/apps/mobile/lib/unmatch.ts
@@ -1,0 +1,11 @@
+import { supabase } from './supabase';
+
+/**
+ * Ends a mutual match: both users' like/top_pick rows become passes with a new timestamp
+ * (30-day discover cooldown, same as a normal pass). Hides any shared DM from both lists.
+ */
+export async function unmatchPeer(otherUserId: string): Promise<{ error: string | null }> {
+  const { error } = await supabase.rpc('unmatch_peer', { p_other_user_id: otherUserId });
+  if (error) return { error: error.message };
+  return { error: null };
+}

--- a/apps/mobile/screens/ChatScreen.tsx
+++ b/apps/mobile/screens/ChatScreen.tsx
@@ -21,8 +21,11 @@ import {
   sendMessage,
   ensureMatchConversation,
   clearConversationHiddenFromList,
+  fetchOtherParticipantUserId,
   type ChatMessageRow,
 } from '../lib/messaging';
+import PeerSafetyActionsModal, { type PeerSafetyStart } from '../components/PeerSafetyActionsModal';
+import ThemedConfirmSheet from '../components/ThemedConfirmSheet';
 import {
   CHATS_SCREEN_BG,
   CHATS_CARD,
@@ -108,14 +111,19 @@ function Background({ children }: { children: React.ReactNode }) {
 
 export default function ChatScreen({ navigation, route }: Props) {
   const insets = useSafeAreaInsets();
-  const { conversationId: initialConversationId, otherUserId, title } = route.params;
+  const { conversationId: initialConversationId, otherUserId: routeOtherUserId, title } =
+    route.params;
   const [conversationId, setConversationId] = useState<string | undefined>(initialConversationId);
   const [messages, setMessages] = useState<ChatMessageRow[]>([]);
   const [myUserId, setMyUserId] = useState<string | null>(null);
+  const [otherUserId, setOtherUserId] = useState<string | undefined>(routeOtherUserId);
   const [loading, setLoading] = useState(!!initialConversationId);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
+  const [peerSafetyOpen, setPeerSafetyOpen] = useState(false);
+  const [peerSafetyStart, setPeerSafetyStart] = useState<PeerSafetyStart>('main');
+  const [waitPeerSheet, setWaitPeerSheet] = useState(false);
   /** Bottom inset for keyboard — avoids KeyboardAvoidingView fighting FlatList (jitter). */
   const [keyboardBottom, setKeyboardBottom] = useState(0);
   const listRef = useRef<FlatList<ChatListItem>>(null);
@@ -137,6 +145,31 @@ export default function ChatScreen({ navigation, route }: Props) {
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!cancelled && user) setMyUserId(user.id);
     });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!conversationId || otherUserId) return;
+    let cancelled = false;
+    void (async () => {
+      const { userId, error } = await fetchOtherParticipantUserId(conversationId);
+      if (cancelled) return;
+      if (error) {
+        console.warn('fetchOtherParticipantUserId', error.message);
+        return;
+      }
+      if (userId) setOtherUserId(userId);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId, otherUserId]);
+
+  useEffect(() => {
+    let cancelled = false;
 
     if (!conversationId) return;
 
@@ -184,6 +217,15 @@ export default function ChatScreen({ navigation, route }: Props) {
       supabase.removeChannel(channel);
     };
   }, [conversationId, appendUnique, myUserId]);
+
+  const openSafetyMenu = useCallback(() => {
+    if (!otherUserId) {
+      setWaitPeerSheet(true);
+      return;
+    }
+    setPeerSafetyStart('main');
+    setPeerSafetyOpen(true);
+  }, [otherUserId]);
 
   useEffect(() => {
     if (!conversationId) return;
@@ -264,7 +306,7 @@ export default function ChatScreen({ navigation, route }: Props) {
             onBack={() => navigation.goBack()}
             topInset={insets.top}
             backAccessibilityLabel="Back to chats"
-            onReport={otherUserId ? () => setReportOpen(true) : undefined}
+            onMenu={openSafetyMenu}
           />
         </View>
         <View style={[styles.centered, { paddingTop: insets.top + 56 }]}>
@@ -332,6 +374,7 @@ export default function ChatScreen({ navigation, route }: Props) {
               onBack={() => navigation.goBack()}
               topInset={insets.top}
               backAccessibilityLabel="Back to chats"
+              onMenu={openSafetyMenu}
             />
           </View>
         </View>
@@ -370,6 +413,32 @@ export default function ChatScreen({ navigation, route }: Props) {
           }}
         />
       )}
+      {otherUserId && (
+        <PeerSafetyActionsModal
+          visible={peerSafetyOpen}
+          otherUserId={otherUserId}
+          otherName={title}
+          start={peerSafetyStart}
+          onClose={() => setPeerSafetyOpen(false)}
+          onOpenReport={() => {
+            setPeerSafetyOpen(false);
+            setReportOpen(true);
+          }}
+          onAfterUnmatchOrBlock={() => {
+            setPeerSafetyOpen(false);
+            navigation.goBack();
+          }}
+        />
+      )}
+      <ThemedConfirmSheet
+        visible={waitPeerSheet}
+        title="One moment"
+        message="Still loading this chat. Try again in a second."
+        confirmLabel="OK"
+        singleAction
+        onConfirm={() => setWaitPeerSheet(false)}
+        onClose={() => setWaitPeerSheet(false)}
+      />
     </Background>
   );
 }

--- a/apps/mobile/screens/ChatsScreen.tsx
+++ b/apps/mobile/screens/ChatsScreen.tsx
@@ -9,7 +9,6 @@ import {
   RefreshControl,
   ActivityIndicator,
   Dimensions,
-  Alert,
   TextInput,
 } from 'react-native';
 import { RectButton, Swipeable } from 'react-native-gesture-handler';
@@ -25,6 +24,9 @@ import {
   type ConversationSummary,
 } from '../lib/messaging';
 import { supabase } from '../lib/supabase';
+import BlockReportModal from '../components/BlockReportModal';
+import PeerSafetyActionsModal, { type PeerSafetyStart } from '../components/PeerSafetyActionsModal';
+import ThemedConfirmSheet from '../components/ThemedConfirmSheet';
 import {
   CHATS_SCREEN_BG,
   CHATS_CARD,
@@ -84,6 +86,16 @@ export default function ChatsScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [messagesSearchQuery, setMessagesSearchQuery] = useState('');
+  const [myUserId, setMyUserId] = useState<string | null>(null);
+  const [reportPeer, setReportPeer] = useState<{ id: string; name: string } | null>(null);
+  const [peerSafety, setPeerSafety] = useState<{
+    otherUserId: string;
+    otherName: string;
+    start: PeerSafetyStart;
+  } | null>(null);
+  const [removeConvTarget, setRemoveConvTarget] = useState<ConversationSummary | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const swipeableRefs = useRef<Map<string, Swipeable | null>>(new Map());
   /** Avoid full-screen spinner + list remount on every tab focus — keeps expo-image cache warm. */
   const initialLoadDoneRef = useRef(false);
   const lastUserIdRef = useRef<string | null>(null);
@@ -94,12 +106,15 @@ export default function ChatsScreen({ navigation }: Props) {
     const { data: sessionData } = await supabase.auth.getSession();
     const uid = sessionData.session?.user.id;
     if (!uid) {
+      setMyUserId(null);
       setLoading(false);
       setRefreshing(false);
       initialLoadDoneRef.current = false;
       lastUserIdRef.current = null;
       return;
     }
+
+    setMyUserId(uid);
 
     if (lastUserIdRef.current !== uid) {
       if (lastUserIdRef.current !== null) {
@@ -149,28 +164,21 @@ export default function ChatsScreen({ navigation }: Props) {
   }, [conversations, messagesSearchQuery]);
 
   const confirmRemoveConversation = useCallback((item: ConversationSummary) => {
-    Alert.alert(
-      'Do you wish to delete this conversation?',
-      'It will be removed from your Messages list only. The other person still has the thread; messages are not deleted.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Remove',
-          style: 'destructive',
-          onPress: () => {
-            void (async () => {
-              const { error } = await hideConversationFromList(item.conversationId);
-              if (error) {
-                Alert.alert('Could not remove', error.message);
-                return;
-              }
-              setConversations((prev) => prev.filter((c) => c.conversationId !== item.conversationId));
-            })();
-          },
-        },
-      ]
-    );
+    setRemoveError(null);
+    setRemoveConvTarget(item);
   }, []);
+
+  const runRemoveConversation = useCallback(async () => {
+    if (!removeConvTarget) return;
+    const { error } = await hideConversationFromList(removeConvTarget.conversationId);
+    if (error) {
+      setRemoveError(error.message);
+      return;
+    }
+    setConversations((prev) => prev.filter((c) => c.conversationId !== removeConvTarget.conversationId));
+    setRemoveConvTarget(null);
+    setRemoveError(null);
+  }, [removeConvTarget]);
 
   function renderMatchItem({ item }: { item: Match }) {
     return (
@@ -221,18 +229,77 @@ export default function ChatsScreen({ navigation }: Props) {
   }
 
   function renderConvItem({ item }: { item: ConversationSummary }) {
+    const closeSwipe = () => swipeableRefs.current.get(item.conversationId)?.close();
+
     return (
       <Swipeable
+        ref={(el) => {
+          if (el) swipeableRefs.current.set(item.conversationId, el);
+          else swipeableRefs.current.delete(item.conversationId);
+        }}
         friction={2}
         overshootRight={false}
         renderRightActions={() => (
-          <View style={styles.swipeActionsRight}>
+          <View style={styles.swipeRightCluster}>
             <RectButton
-              style={styles.swipeDeleteBtn}
-              onPress={() => confirmRemoveConversation(item)}
+              style={styles.swipeCompactBtn}
+              onPress={() => {
+                closeSwipe();
+                setPeerSafety({
+                  otherUserId: item.otherUserId,
+                  otherName: item.otherDisplayName,
+                  start: 'confirmUnmatch',
+                });
+              }}
+              accessibilityLabel="Unmatch"
+            >
+              <Ionicons name="heart-dislike-outline" size={20} color={C.destructive} />
+              <Text style={styles.swipeCompactLabel} numberOfLines={1}>
+                Unmatch
+              </Text>
+            </RectButton>
+            <RectButton
+              style={styles.swipeCompactBtn}
+              onPress={() => {
+                closeSwipe();
+                setReportPeer({ id: item.otherUserId, name: item.otherDisplayName });
+              }}
+              accessibilityLabel="Report"
+            >
+              <Ionicons name="flag-outline" size={20} color={C.accent} />
+              <Text style={styles.swipeCompactLabel} numberOfLines={1}>
+                Report
+              </Text>
+            </RectButton>
+            <RectButton
+              style={styles.swipeCompactBtn}
+              onPress={() => {
+                closeSwipe();
+                setPeerSafety({
+                  otherUserId: item.otherUserId,
+                  otherName: item.otherDisplayName,
+                  start: 'confirmBlock',
+                });
+              }}
+              accessibilityLabel="Block"
+            >
+              <Ionicons name="ban-outline" size={20} color={C.destructive} />
+              <Text style={styles.swipeCompactLabel} numberOfLines={1}>
+                Block
+              </Text>
+            </RectButton>
+            <RectButton
+              style={styles.swipeCompactBtn}
+              onPress={() => {
+                closeSwipe();
+                confirmRemoveConversation(item);
+              }}
               accessibilityLabel="Remove conversation from list"
             >
               <Ionicons name="trash-outline" size={22} color={C.gray} />
+              <Text style={[styles.swipeCompactLabel, { color: C.gray }]} numberOfLines={1}>
+                Remove
+              </Text>
             </RectButton>
           </View>
         )}
@@ -243,6 +310,7 @@ export default function ChatsScreen({ navigation }: Props) {
           onPress={() =>
             navigation.navigate('Chat', {
               conversationId: item.conversationId,
+              otherUserId: item.otherUserId,
               title: item.otherDisplayName,
             })
           }
@@ -445,6 +513,56 @@ export default function ChatsScreen({ navigation }: Props) {
           />
         )}
       </SafeAreaView>
+      {myUserId && reportPeer && (
+        <BlockReportModal
+          visible
+          reporterId={myUserId}
+          reportedId={reportPeer.id}
+          reportedName={reportPeer.name}
+          onClose={() => setReportPeer(null)}
+          onBlocked={() => {
+            setReportPeer(null);
+            void load(true);
+          }}
+        />
+      )}
+      {peerSafety && (
+        <PeerSafetyActionsModal
+          visible
+          otherUserId={peerSafety.otherUserId}
+          otherName={peerSafety.otherName}
+          start={peerSafety.start}
+          onClose={() => setPeerSafety(null)}
+          onOpenReport={() => setReportPeer({ id: peerSafety.otherUserId, name: peerSafety.otherName })}
+          onAfterUnmatchOrBlock={() => {
+            setPeerSafety(null);
+            void load(true);
+          }}
+        />
+      )}
+      <ThemedConfirmSheet
+        visible={removeConvTarget !== null}
+        title={removeError ? 'Could not remove' : 'Remove this conversation?'}
+        message={
+          removeError ??
+          'It will be removed from your Messages list only. The other person still has the thread; messages are not deleted.'
+        }
+        confirmLabel={removeError ? 'OK' : 'Remove'}
+        destructive={!removeError}
+        singleAction={!!removeError}
+        onConfirm={() => {
+          if (removeError) {
+            setRemoveConvTarget(null);
+            setRemoveError(null);
+            return;
+          }
+          void runRemoveConversation();
+        }}
+        onClose={() => {
+          setRemoveConvTarget(null);
+          setRemoveError(null);
+        }}
+      />
     </Background>
   );
 }
@@ -657,20 +775,32 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
     elevation: 2,
   },
-  swipeActionsRight: {
-    justifyContent: 'center',
+  swipeRightCluster: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
     marginBottom: 10,
-    marginLeft: 8,
+    marginLeft: 6,
+    gap: 6,
   },
-  swipeDeleteBtn: {
-    backgroundColor: CHATS_CARD,
+  swipeCompactBtn: {
+    width: 56,
     justifyContent: 'center',
     alignItems: 'center',
-    width: 56,
-    minHeight: 78,
-    borderRadius: 18,
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    borderRadius: 16,
     borderWidth: 1,
     borderColor: CHATS_GREEN_BORDER,
+    backgroundColor: CHATS_CARD,
+  },
+  swipeCompactLabel: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: C.text,
+    marginTop: 4,
+    textAlign: 'center',
+    maxWidth: 54,
   },
   convAvatar: {
     width: 52,

--- a/apps/mobile/screens/PublicUserProfileScreen.tsx
+++ b/apps/mobile/screens/PublicUserProfileScreen.tsx
@@ -20,7 +20,9 @@ import { getPreferences, type Preferences } from '../lib/preferences';
 import { formatLocationLine, profilePhotoPathsFromRow } from '../lib/profileDisplay';
 import PublicProfileCard from '../components/PublicProfileCard';
 import { ChatStyleTopBar } from '../components/ChatStyleTopBar';
+import BlockReportModal from '../components/BlockReportModal';
 import { CHATS_CARD, CHATS_GREEN, CHATS_GREEN_BORDER } from '../theme/chatsAmbient';
+import PeerSafetyActionsModal, { type PeerSafetyStart } from '../components/PeerSafetyActionsModal';
 
 type PromptEntry = { question: string; answer: string };
 
@@ -86,6 +88,16 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
   const [bio, setBio] = useState<string | null>(null);
   const [interestChips, setInterestChips] = useState<string[]>([]);
   const [prompts, setPrompts] = useState<PromptEntry[]>([]);
+  const [myUserId, setMyUserId] = useState<string | null>(null);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [peerSafetyOpen, setPeerSafetyOpen] = useState(false);
+  const [peerSafetyStart, setPeerSafetyStart] = useState<PeerSafetyStart>('main');
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user?.id) setMyUserId(user.id);
+    });
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -136,7 +148,7 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
   const openChat = useCallback(() => {
     const title = name || initialName || 'Chat';
     const params = conversationId
-      ? { conversationId, title }
+      ? { conversationId, otherUserId: userId, title }
       : { otherUserId: userId, title };
 
     if (profileSource === 'likes') {
@@ -151,6 +163,12 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
   /** Space below floating bubbles so the card sits on the canvas, not under the pills. */
   const contentTopPad = insets.top + 56 + 12;
 
+  const openSafetyMenu = useCallback(() => {
+    if (profileSource !== 'chats') return;
+    setPeerSafetyStart('main');
+    setPeerSafetyOpen(true);
+  }, [profileSource]);
+
   if (loading) {
     return (
       <View style={styles.root}>
@@ -162,6 +180,7 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
             title={initialName || 'Profile'}
             onBack={() => navigation.goBack()}
             topInset={insets.top}
+            onMenu={profileSource === 'chats' ? openSafetyMenu : undefined}
           />
         </View>
       </View>
@@ -213,6 +232,7 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
           title={name || 'Profile'}
           onBack={() => navigation.goBack()}
           topInset={insets.top}
+          onMenu={profileSource === 'chats' ? openSafetyMenu : undefined}
         />
       </View>
 
@@ -230,6 +250,37 @@ export default function PublicUserProfileScreen({ route, navigation }: Props) {
           <Ionicons name="chatbubbles" size={26} color={CHATS_GREEN} />
         </TouchableOpacity>
       </View>
+
+      {myUserId && profileSource === 'chats' && (
+        <BlockReportModal
+          visible={reportOpen}
+          reporterId={myUserId}
+          reportedId={userId}
+          reportedName={name || initialName || 'User'}
+          onClose={() => setReportOpen(false)}
+          onBlocked={() => {
+            setReportOpen(false);
+            navigation.goBack();
+          }}
+        />
+      )}
+      {profileSource === 'chats' && (
+        <PeerSafetyActionsModal
+          visible={peerSafetyOpen}
+          otherUserId={userId}
+          otherName={name || initialName || 'Profile'}
+          start={peerSafetyStart}
+          onClose={() => setPeerSafetyOpen(false)}
+          onOpenReport={() => {
+            setPeerSafetyOpen(false);
+            setReportOpen(true);
+          }}
+          onAfterUnmatchOrBlock={() => {
+            setPeerSafetyOpen(false);
+            navigation.goBack();
+          }}
+        />
+      )}
     </View>
   );
 }

--- a/backend/supabase/migrations/20260501120000_unmatch_peer_rpc.sql
+++ b/backend/supabase/migrations/20260501120000_unmatch_peer_rpc.sql
@@ -1,0 +1,47 @@
+-- Unmatch: clear mutual match by converting both directed swipes to `pass` with a fresh
+-- `created_at` so discover exclusion matches the 30-day recycle rule for passes.
+-- Also hides any existing DM thread from both users' Messages lists (does not delete messages).
+
+CREATE OR REPLACE FUNCTION public.unmatch_peer(p_other_user_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_me uuid := auth.uid();
+BEGIN
+  IF v_me IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_other_user_id IS NULL OR p_other_user_id = v_me THEN
+    RAISE EXCEPTION 'Invalid peer';
+  END IF;
+
+  UPDATE public.swipes
+  SET
+    direction = 'pass',
+    created_at = now()
+  WHERE direction IN ('like', 'top_pick')
+    AND (
+      (swiper_id = v_me AND swiped_id = p_other_user_id)
+      OR (swiper_id = p_other_user_id AND swiped_id = v_me)
+    );
+
+  UPDATE public.conversation_participants cp
+  SET hidden_from_list_at = now()
+  WHERE cp.user_id IN (v_me, p_other_user_id)
+    AND EXISTS (
+      SELECT 1
+      FROM public.conversation_participants a
+      JOIN public.conversation_participants b
+        ON a.conversation_id = b.conversation_id
+      WHERE a.conversation_id = cp.conversation_id
+        AND a.user_id = v_me
+        AND b.user_id = p_other_user_id
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.unmatch_peer(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.unmatch_peer(uuid) TO authenticated;


### PR DESCRIPTION
### Summary
This change adds unmatch, report, and block for people you are matched with or actively messaging, backed by a new Supabase RPC. Unmatching clears the mutual match by converting both directed swipes rows to pass with a fresh created_at, so Discover respects the same 30-day recycle behavior as an ordinary pass. Shared DMs are hidden from both users’ message lists without deleting messages. The previous Alert-based flows are replaced with bottom sheets that match the Chats visual language.

### Migrations
New migration: backend/supabase/migrations/20260501120000_unmatch_peer_rpc.sql
Adds `unmatch_peer(p_other_user_id uuid)` (security definer): updates reciprocal like/top_pick rows to pass and sets now() on created_at; sets hidden_from_list_at on both participants for any existing 1:1 conversation between the pair.

### How to test
Apply migration, open two accounts, create a mutual match and a thread with messages.
From Chat ⋯: unmatch → both should disappear from Matched; thread hidden from both lists; neither appears in the other’s Discover until passes age past 30 days (or adjust created_at in DB to verify).
From Messages swipe: try Unmatch (confirm), Report (opens report modal), Block (confirm), Remove (themed remove sheet).
Open a match’s profile from Chats; use ⋯ for the same actions.
Block then unblock from profile: pair should stay unmatched if unmatch_peer ran before block (normal path).
