### PR TITLE
Enhanced Discover Tab UX

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -22,6 +22,7 @@ import OnboardingScreen from './screens/OnboardingScreen';
 import MainTabNavigator from './navigation/MainTabNavigator';
 import { redeemPendingReferralIfAny } from './lib/referrals';
 import { PurchasesProvider } from './context/PurchasesContext';
+import { DiscoverDeckProvider } from './context/DiscoverDeckContext';
 
 type AppState = 'loading' | 'auth' | 'onboarding' | 'home';
 
@@ -122,9 +123,11 @@ export default function App() {
         )}
         {appState === 'home' && session?.user && (
           <PurchasesProvider userId={session.user.id}>
-            <NavigationContainer>
-              <MainTabNavigator onDevShowOnboarding={__DEV__ ? () => setAppState('onboarding') : undefined} />
-            </NavigationContainer>
+            <DiscoverDeckProvider userId={session.user.id}>
+              <NavigationContainer>
+                <MainTabNavigator onDevShowOnboarding={__DEV__ ? () => setAppState('onboarding') : undefined} />
+              </NavigationContainer>
+            </DiscoverDeckProvider>
           </PurchasesProvider>
         )}
       </SafeAreaProvider>

--- a/apps/mobile/components/SwipeCard.tsx
+++ b/apps/mobile/components/SwipeCard.tsx
@@ -1,8 +1,7 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import {
   View,
   Text,
-  Image,
   FlatList,
   ScrollView,
   StyleSheet,
@@ -12,6 +11,7 @@ import {
   type NativeScrollEvent,
   type ListRenderItemInfo,
 } from 'react-native';
+import { Image as ExpoImage } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { MapPin, ArrowCounterClockwise, X, Star, Heart, Flag } from 'phosphor-react-native';
 import type { DiscoverProfile } from '../lib/discover';
@@ -48,6 +48,12 @@ export default function SwipeCard({
   const [photoIndex, setPhotoIndex] = useState(0);
   const listRef = useRef<FlatList<string>>(null);
 
+  useEffect(() => {
+    setPhotoTab('profile');
+    setPhotoIndex(0);
+    listRef.current?.scrollToOffset({ offset: 0, animated: false });
+  }, [profile.id]);
+
   const profilePhotos = profile.photoUrls.slice(0, profile.profilePhotoCount);
   const listingPhotos = profile.photoUrls.slice(profile.profilePhotoCount);
   const activePhotos = photoTab === 'profile' ? profilePhotos : listingPhotos;
@@ -68,13 +74,16 @@ export default function SwipeCard({
 
   const renderPhoto = useCallback(
     ({ item }: ListRenderItemInfo<string>) => (
-      <Image
+      <ExpoImage
         source={{ uri: item }}
         style={{ width: CARD_WIDTH, height: PHOTO_HEIGHT }}
-        resizeMode="cover"
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        transition={0}
+        recyclingKey={`${profile.id}-${item}`}
       />
     ),
-    []
+    [profile.id]
   );
 
   const firstName = profile.name.split(' ')[0];
@@ -99,10 +108,10 @@ export default function SwipeCard({
         ) : (
           <>
             <FlatList
-              key={photoTab}
+              key={`${profile.id}-${photoTab}`}
               ref={listRef}
               data={activePhotos}
-              keyExtractor={(_, i) => `${photoTab}-${i}`}
+              keyExtractor={(_, i) => `${profile.id}-${photoTab}-${i}`}
               renderItem={renderPhoto}
               horizontal
               pagingEnabled

--- a/apps/mobile/context/DiscoverDeckContext.tsx
+++ b/apps/mobile/context/DiscoverDeckContext.tsx
@@ -1,0 +1,280 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  fetchDiscoverProfiles,
+  type DiscoverProfile,
+} from '../lib/discover';
+import { hasRoomPearPlusEntitlement } from '../lib/purchasesConfig';
+import { fetchProfileIsPremium } from '../lib/profileSubscriptionTier';
+import { usePurchases } from './PurchasesContext';
+
+const BATCH_SIZE = 10;
+const PREFETCH_REMAINING = 3;
+
+type DiscoverDeckContextValue = {
+  userId: string;
+  profiles: DiscoverProfile[];
+  currentIndex: number;
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>;
+  deckInitialLoading: boolean;
+  hasPremiumAccess: boolean;
+  /** Re-read `profiles.subscription_tier` so Discover limits / filters match after dev toggle or RC sync. */
+  syncPremiumFromDatabase: () => Promise<void>;
+  refreshDeck: () => Promise<void>;
+  removeProfileFromDeck: (profileId: string) => void;
+};
+
+const DiscoverDeckContext = createContext<DiscoverDeckContextValue | null>(null);
+
+export function useDiscoverDeck(): DiscoverDeckContextValue {
+  const v = useContext(DiscoverDeckContext);
+  if (!v) {
+    throw new Error('useDiscoverDeck must be used within DiscoverDeckProvider');
+  }
+  return v;
+}
+
+type Props = {
+  userId: string;
+  children: React.ReactNode;
+};
+
+export function DiscoverDeckProvider({ userId, children }: Props) {
+  const { customerInfo, isRoomPearPlus } = usePurchases();
+  const [profiles, setProfiles] = useState<DiscoverProfile[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [deckInitialLoading, setDeckInitialLoading] = useState(true);
+  const [hasPremiumTier, setHasPremiumTier] = useState(false);
+
+  const profilesRef = useRef(profiles);
+  const currentIndexRef = useRef(currentIndex);
+  profilesRef.current = profiles;
+  currentIndexRef.current = currentIndex;
+
+  const customerInfoRef = useRef(customerInfo);
+  const isRoomPearPlusRef = useRef(isRoomPearPlus);
+  customerInfoRef.current = customerInfo;
+  isRoomPearPlusRef.current = isRoomPearPlus;
+
+  const prefetchInFlight = useRef(false);
+  const appendExhausted = useRef(false);
+  /** First fetch finished for this user (even if deck is empty) — avoids refetch on tab blur/focus. */
+  const deckInitRef = useRef<{ userId: string | null; complete: boolean }>({
+    userId: null,
+    complete: false,
+  });
+  /** Tracks premium for "flip to paid → refresh deck" (null = not yet anchored after load). */
+  const prevHasPremiumForDeckRef = useRef<boolean | null>(null);
+
+  const hasPremiumAccess = useMemo(
+    () =>
+      hasRoomPearPlusEntitlement(customerInfo) ||
+      isRoomPearPlus ||
+      hasPremiumTier,
+    [customerInfo, isRoomPearPlus, hasPremiumTier]
+  );
+
+  const hasPremiumAccessRef = useRef(hasPremiumAccess);
+  hasPremiumAccessRef.current = hasPremiumAccess;
+
+  const syncPremiumFromDatabase = useCallback(async () => {
+    const tierPremium = await fetchProfileIsPremium(userId);
+    setHasPremiumTier(tierPremium);
+  }, [userId]);
+
+  const resolvePremiumForFetch = useCallback(async () => {
+    const tierPremium = await fetchProfileIsPremium(userId);
+    setHasPremiumTier(tierPremium);
+    return (
+      hasRoomPearPlusEntitlement(customerInfoRef.current) ||
+      isRoomPearPlusRef.current ||
+      tierPremium
+    );
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) return;
+    void syncPremiumFromDatabase();
+  }, [userId, customerInfo, syncPremiumFromDatabase]);
+
+  const refreshDeck = useCallback(async () => {
+    appendExhausted.current = false;
+    prefetchInFlight.current = false;
+    setDeckInitialLoading(true);
+    try {
+      const premium = await resolvePremiumForFetch();
+      const data = await fetchDiscoverProfiles(userId, BATCH_SIZE, {
+        useAdvancedFilters: premium,
+        isPremium: premium,
+      });
+      setProfiles(data);
+      setCurrentIndex(0);
+    } finally {
+      setDeckInitialLoading(false);
+    }
+  }, [userId, resolvePremiumForFetch]);
+
+  const removeProfileFromDeck = useCallback((profileId: string) => {
+    const prev = profilesRef.current;
+    const idx = prev.findIndex(p => p.id === profileId);
+    if (idx === -1) return;
+    const next = prev.filter(p => p.id !== profileId);
+    let ci = currentIndexRef.current;
+    if (ci > idx) ci -= 1;
+    else if (ci === idx) ci = Math.min(ci, Math.max(0, next.length - 1));
+    ci = Math.max(0, Math.min(ci, Math.max(0, next.length - 1)));
+    setProfiles(next);
+    setCurrentIndex(ci);
+  }, []);
+
+  /** Same user returning to Discover: keep deck. New user / cold deck: load once. */
+  useEffect(() => {
+    if (!userId) {
+      deckInitRef.current = { userId: null, complete: false };
+      prevHasPremiumForDeckRef.current = null;
+      setProfiles([]);
+      setCurrentIndex(0);
+      setDeckInitialLoading(false);
+      return;
+    }
+
+    if (deckInitRef.current.userId === userId && deckInitRef.current.complete) {
+      setDeckInitialLoading(false);
+      return;
+    }
+
+    if (deckInitRef.current.userId !== null && deckInitRef.current.userId !== userId) {
+      prevHasPremiumForDeckRef.current = null;
+      setProfiles([]);
+      setCurrentIndex(0);
+    }
+
+    let cancelled = false;
+    (async () => {
+      setDeckInitialLoading(true);
+      try {
+        const premium = await resolvePremiumForFetch();
+        if (cancelled) return;
+        const data = await fetchDiscoverProfiles(userId, BATCH_SIZE, {
+          useAdvancedFilters: premium,
+          isPremium: premium,
+        });
+        if (cancelled) return;
+        setProfiles(data);
+        setCurrentIndex(0);
+        deckInitRef.current = { userId, complete: true };
+        appendExhausted.current = false;
+      } finally {
+        if (!cancelled) setDeckInitialLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, resolvePremiumForFetch]);
+
+  /** After subscribe / dev premium: rebuild deck with premium scoring + advanced filters (skip cold start). */
+  useEffect(() => {
+    if (!userId) return;
+    if (deckInitialLoading) return;
+
+    const prev = prevHasPremiumForDeckRef.current;
+    if (prev === null) {
+      prevHasPremiumForDeckRef.current = hasPremiumAccess;
+      return;
+    }
+
+    if (!prev && hasPremiumAccess && deckInitRef.current.complete) {
+      prevHasPremiumForDeckRef.current = hasPremiumAccess;
+      void refreshDeck();
+      return;
+    }
+
+    prevHasPremiumForDeckRef.current = hasPremiumAccess;
+  }, [userId, hasPremiumAccess, deckInitialLoading, refreshDeck]);
+
+  useEffect(() => {
+    if (!userId || deckInitialLoading) return;
+    if (appendExhausted.current || prefetchInFlight.current) return;
+
+    const remaining = profiles.length - currentIndex;
+    if (remaining > PREFETCH_REMAINING) return;
+    if (profiles.length === 0) return;
+
+    prefetchInFlight.current = true;
+    let alive = true;
+
+    (async () => {
+      try {
+        const premium = hasPremiumAccessRef.current;
+        const excludeIds = profilesRef.current.map(p => p.id);
+        const more = await fetchDiscoverProfiles(userId, BATCH_SIZE, {
+          useAdvancedFilters: premium,
+          isPremium: premium,
+          excludeIds,
+        });
+        if (!alive) return;
+        if (more.length === 0) {
+          appendExhausted.current = true;
+          return;
+        }
+        setProfiles(prev => {
+          const seen = new Set(prev.map(p => p.id));
+          const merged = [...prev];
+          for (const p of more) {
+            if (!seen.has(p.id)) {
+              seen.add(p.id);
+              merged.push(p);
+            }
+          }
+          return merged;
+        });
+        if (more.length < BATCH_SIZE) {
+          appendExhausted.current = true;
+        }
+      } finally {
+        prefetchInFlight.current = false;
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [userId, deckInitialLoading, profiles.length, currentIndex]);
+
+  const value = useMemo<DiscoverDeckContextValue>(
+    () => ({
+      userId,
+      profiles,
+      currentIndex,
+      setCurrentIndex,
+      deckInitialLoading,
+      hasPremiumAccess,
+      syncPremiumFromDatabase,
+      refreshDeck,
+      removeProfileFromDeck,
+    }),
+    [
+      userId,
+      profiles,
+      currentIndex,
+      deckInitialLoading,
+      hasPremiumAccess,
+      syncPremiumFromDatabase,
+      refreshDeck,
+      removeProfileFromDeck,
+    ]
+  );
+
+  return (
+    <DiscoverDeckContext.Provider value={value}>{children}</DiscoverDeckContext.Provider>
+  );
+}

--- a/apps/mobile/lib/discover.ts
+++ b/apps/mobile/lib/discover.ts
@@ -99,7 +99,12 @@ async function getNearbyCandidateIds(
 export async function fetchDiscoverProfiles(
   userId: string,
   limit = 10,
-  options?: { useAdvancedFilters?: boolean; isPremium?: boolean }
+  options?: {
+    useAdvancedFilters?: boolean;
+    isPremium?: boolean;
+    /** Already in the deck (or otherwise excluded) — merged with swipes/blocks for this fetch. */
+    excludeIds?: string[];
+  }
 ): Promise<DiscoverProfile[]> {
   // Fetch viewer's own preferences for filtering + scoring
   const myPrefs = await getPreferences(userId);
@@ -118,7 +123,9 @@ export async function fetchDiscoverProfiles(
   ]);
 
   const swipedIds = swipedRows?.map((r: any) => r.swiped_id) ?? [];
-  const excludedIds = Array.from(new Set([...swipedIds, ...blockedIds]));
+  const excludedIds = Array.from(
+    new Set([...swipedIds, ...blockedIds, ...(options?.excludeIds ?? [])])
+  );
 
   // Fetch a larger candidate pool so filtering still leaves enough results
   let query = supabase

--- a/apps/mobile/lib/profileSubscriptionTier.ts
+++ b/apps/mobile/lib/profileSubscriptionTier.ts
@@ -1,0 +1,13 @@
+import { supabase } from './supabase';
+import { isPremiumProfileTier } from './purchasesConfig';
+
+/** Reads `profiles.subscription_tier` (source of truth with RevenueCat + dev override). */
+export async function fetchProfileIsPremium(userId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('subscription_tier')
+    .eq('id', userId)
+    .maybeSingle();
+  if (error) return false;
+  return isPremiumProfileTier(data?.subscription_tier as string | undefined);
+}

--- a/apps/mobile/screens/DiscoverScreen.tsx
+++ b/apps/mobile/screens/DiscoverScreen.tsx
@@ -12,19 +12,20 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'expo-blur';
+import { Image as ExpoImage } from 'expo-image';
 import { useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { DotsThreeVertical } from 'phosphor-react-native';
 import { supabase } from '../lib/supabase';
-import { fetchDiscoverProfiles, recordSwipe, type DiscoverProfile } from '../lib/discover';
+import { recordSwipe } from '../lib/discover';
 import { getProfileImageUrls } from '../lib/storage';
 import { profilePhotoPathsFromRow } from '../lib/profileDisplay';
 import { getDiscoverUsage } from '../lib/dailyDiscoverUsage';
 import { FREE_TIER_LIMITS, PREMIUM_TIER_LIMITS } from '../lib/freeTierLimits';
 import { usePurchases } from '../context/PurchasesContext';
-import { hasRoomPearPlusEntitlement, isPremiumProfileTier } from '../lib/purchasesConfig';
+import { useDiscoverDeck } from '../context/DiscoverDeckContext';
 import SwipeCard from '../components/SwipeCard';
 import DiscoverFiltersModal from '../components/DiscoverFiltersModal';
 import BlockReportModal from '../components/BlockReportModal';
@@ -85,17 +86,22 @@ function Background({ children }: { children: React.ReactNode }) {
 
 export default function DiscoverScreen() {
   const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
-  const { isRoomPearPlus, customerInfo, presentPaywall } = usePurchases();
-  const [hasPremiumTier, setHasPremiumTier] = useState(false);
-  const [userId, setUserId] = useState<string | null>(null);
+  const { presentPaywall } = usePurchases();
+  const {
+    userId,
+    profiles,
+    currentIndex,
+    setCurrentIndex,
+    deckInitialLoading,
+    hasPremiumAccess,
+    refreshDeck,
+    removeProfileFromDeck,
+  } = useDiscoverDeck();
   const [myPhotoUrl, setMyPhotoUrl] = useState<string | null>(null);
   const [myHobbies, setMyHobbies] = useState<string[]>([]);
-  const [profiles, setProfiles] = useState<DiscoverProfile[]>([]);
   const [hasActiveRadiusFilter, setHasActiveRadiusFilter] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState(0);
   const [actionDisabled, setActionDisabled] = useState(false);
   const [matchData, setMatchData] = useState<MatchData | null>(null);
-  const [loading, setLoading] = useState(true);
   const [dailyUsage, setDailyUsage] = useState({ swipes: 0, topPicks: 0 });
   const [isPaused, setIsPaused] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -104,7 +110,6 @@ export default function DiscoverScreen() {
   const translateX = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(0)).current;
   const cardOpacity = useRef(new Animated.Value(1)).current;
-  const hasPremiumAccess = hasRoomPearPlusEntitlement(customerInfo) || isRoomPearPlus || hasPremiumTier;
 
   const refreshDailyUsage = useCallback(async (uid: string) => {
     const u = await getDiscoverUsage(uid);
@@ -116,54 +121,49 @@ export default function DiscoverScreen() {
   }, [hasPremiumAccess, presentPaywall]);
 
   useEffect(() => {
-    supabase.auth.getSession().then(async ({ data }) => {
-      const uid = data.session?.user.id ?? null;
-      setUserId(uid);
-      if (uid) {
-        const { data: tierRow } = await supabase
-          .from('profiles')
-          .select('subscription_tier')
-          .eq('id', uid)
-          .maybeSingle();
-        const isPremiumTier = isPremiumProfileTier(tierRow?.subscription_tier as string | undefined);
-        setHasPremiumTier(isPremiumTier);
-        const hasPremiumAtLoad = hasRoomPearPlusEntitlement(customerInfo) || isRoomPearPlus || isPremiumTier;
-        loadProfiles(uid, hasPremiumAtLoad);
-        const { data: me } = await supabase
-          .from('profiles')
-          .select('profile_photo_url, hobbies, is_paused')
-          .eq('id', uid)
-          .single();
-        setIsPaused(me?.is_paused === true);
-        if (me?.profile_photo_url) {
-          const paths = profilePhotoPathsFromRow(me.profile_photo_url);
-          if (paths[0]) {
-            const urls = await getProfileImageUrls(me.profile_photo_url);
-            setMyPhotoUrl(urls?.[0] ?? null);
-          }
+    let cancelled = false;
+    (async () => {
+      const { data: me } = await supabase
+        .from('profiles')
+        .select('profile_photo_url, hobbies, is_paused')
+        .eq('id', userId)
+        .single();
+      if (cancelled) return;
+      setIsPaused(me?.is_paused === true);
+      if (me?.profile_photo_url) {
+        const paths = profilePhotoPathsFromRow(me.profile_photo_url);
+        if (paths[0]) {
+          const urls = await getProfileImageUrls(me.profile_photo_url);
+          if (!cancelled) setMyPhotoUrl(urls?.[0] ?? null);
+        } else {
+          setMyPhotoUrl(null);
         }
-        const { data: myPrefs } = await supabase
-          .from('preferences')
-          .select('interests, search_lat, search_lng, search_radius_miles')
-          .eq('user_id', uid)
-          .single();
-        const radiusMiles = myPrefs?.search_radius_miles;
-        const radiusEnabled =
-          myPrefs?.search_lat != null &&
-          myPrefs?.search_lng != null &&
-          Number.isFinite(radiusMiles) &&
-          radiusMiles > 0;
-        setHasActiveRadiusFilter(radiusEnabled);
-        const interestChips = Object.values(myPrefs?.interests ?? {}).flat() as string[];
-        setMyHobbies(
-          interestChips.length > 0 ? interestChips : (Array.isArray(me?.hobbies) ? me.hobbies : [])
-        );
-        refreshDailyUsage(uid);
       } else {
-        setHasPremiumTier(false);
+        setMyPhotoUrl(null);
       }
-    });
-  }, [isRoomPearPlus, customerInfo, refreshDailyUsage]);
+      const { data: myPrefs } = await supabase
+        .from('preferences')
+        .select('interests, search_lat, search_lng, search_radius_miles')
+        .eq('user_id', userId)
+        .single();
+      if (cancelled) return;
+      const radiusMiles = myPrefs?.search_radius_miles;
+      const radiusEnabled =
+        myPrefs?.search_lat != null &&
+        myPrefs?.search_lng != null &&
+        Number.isFinite(radiusMiles) &&
+        radiusMiles > 0;
+      setHasActiveRadiusFilter(radiusEnabled);
+      const interestChips = Object.values(myPrefs?.interests ?? {}).flat() as string[];
+      setMyHobbies(
+        interestChips.length > 0 ? interestChips : (Array.isArray(me?.hobbies) ? me.hobbies : [])
+      );
+      await refreshDailyUsage(userId);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, refreshDailyUsage]);
 
   useFocusEffect(
     useCallback(() => {
@@ -178,18 +178,14 @@ export default function DiscoverScreen() {
     }, [userId, refreshDailyUsage])
   );
 
-  async function loadProfiles(uid: string, hasPremiumAccess = false) {
-    setLoading(true);
-    const data = await fetchDiscoverProfiles(uid, 10, { useAdvancedFilters: hasPremiumAccess, isPremium: hasPremiumAccess });
-    setProfiles(data);
-    setCurrentIndex(0);
+  const reloadDiscoverVisual = useCallback(async () => {
     translateX.setValue(0);
     translateY.setValue(0);
     cardOpacity.setValue(1);
-    setLoading(false);
-  }
+    await refreshDeck();
+  }, [refreshDeck, translateX, translateY, cardOpacity]);
 
-  function animateOut(direction: Action, onDone: () => void) {
+  function animateOut(direction: Action, onFlyAwayComplete: () => void) {
     const toX =
       direction === 'like' ? SCREEN_WIDTH * 1.5
       : direction === 'pass' ? -SCREEN_WIDTH * 1.5
@@ -202,8 +198,8 @@ export default function DiscoverScreen() {
     ]).start(() => {
       translateX.setValue(0);
       translateY.setValue(0);
-      cardOpacity.setValue(1);
-      onDone();
+      // Keep opacity at 0 until the next profile is committed + faded in (avoids flashing the old card while recordSwipe runs).
+      onFlyAwayComplete();
     });
   }
 
@@ -228,23 +224,33 @@ export default function DiscoverScreen() {
 
     setActionDisabled(true);
     const current = profiles[currentIndex];
-    animateOut(direction, async () => {
-      if (current && userId) {
-        const { isMatch } = await recordSwipe(userId, current.id, direction);
-        if (isMatch) {
-          const sharedInterests = myHobbies.filter(h => (current.hobbies ?? []).includes(h));
-          setMatchData({
-            name: current.name,
-            otherUserId: current.id,
-            theirPhotoUrl: current.photoUrls?.[0] ?? null,
-            myPhotoUrl,
-            sharedInterests,
-          });
-        }
-        await refreshDailyUsage(userId);
-      }
+    animateOut(direction, () => {
       setCurrentIndex(prev => prev + 1);
-      setActionDisabled(false);
+      Animated.timing(cardOpacity, { toValue: 1, duration: 160, useNativeDriver: true }).start(() => {
+        setActionDisabled(false);
+      });
+
+      void (async () => {
+        if (!current || !userId) {
+          await refreshDailyUsage(userId);
+          return;
+        }
+        try {
+          const { isMatch } = await recordSwipe(userId, current.id, direction);
+          if (isMatch) {
+            const sharedInterests = myHobbies.filter(h => (current.hobbies ?? []).includes(h));
+            setMatchData({
+              name: current.name,
+              otherUserId: current.id,
+              theirPhotoUrl: current.photoUrls?.[0] ?? null,
+              myPhotoUrl,
+              sharedInterests,
+            });
+          }
+        } finally {
+          await refreshDailyUsage(userId);
+        }
+      })();
     });
   }
 
@@ -265,8 +271,15 @@ export default function DiscoverScreen() {
   const nextProfile = profiles[currentIndex + 1];
   const remaining = profiles.length - currentIndex;
 
+  useEffect(() => {
+    if (!nextProfile) return;
+    const count = nextProfile.profilePhotoCount || nextProfile.photoUrls.length;
+    const urls = nextProfile.photoUrls.slice(0, Math.min(4, Math.max(0, count)));
+    if (urls.length === 0) return;
+    void ExpoImage.prefetch(urls, 'memory-disk');
+  }, [nextProfile?.id]);
 
-  if (loading) {
+  if (deckInitialLoading) {
     return (
       <Background>
         <View style={styles.centered}>
@@ -318,7 +331,7 @@ export default function DiscoverScreen() {
           </Text>
           <TouchableOpacity
             style={styles.refreshBtn}
-            onPress={() => userId && loadProfiles(userId, hasPremiumAccess)}
+            onPress={() => void reloadDiscoverVisual()}
           >
             <Text style={styles.refreshBtnText}>Refresh</Text>
           </TouchableOpacity>
@@ -336,7 +349,7 @@ export default function DiscoverScreen() {
             visible={filtersOpen}
             userId={userId}
             onClose={() => setFiltersOpen(false)}
-            onApply={() => userId && loadProfiles(userId, hasPremiumAccess)}
+            onApply={() => void reloadDiscoverVisual()}
             isPremium={hasPremiumAccess}
             onUpgrade={openPaywallIfNeeded}
           />
@@ -379,7 +392,7 @@ export default function DiscoverScreen() {
           {/* Back card */}
           {nextProfile && (
             <View style={styles.backCardWrap} pointerEvents="none">
-              <SwipeCard profile={nextProfile} />
+              <SwipeCard key={`deck-back-${nextProfile.id}`} profile={nextProfile} />
             </View>
           )}
 
@@ -391,6 +404,7 @@ export default function DiscoverScreen() {
             ]}
           >
             <SwipeCard
+              key={`deck-front-${currentProfile.id}`}
               profile={currentProfile}
               onPass={() => handleAction('pass')}
               onLike={() => handleAction('like')}
@@ -413,7 +427,7 @@ export default function DiscoverScreen() {
           visible={filtersOpen}
           userId={userId}
           onClose={() => setFiltersOpen(false)}
-          onApply={() => userId && loadProfiles(userId, hasPremiumAccess)}
+          onApply={() => void reloadDiscoverVisual()}
           isPremium={hasPremiumAccess}
           onUpgrade={openPaywallIfNeeded}
         />
@@ -479,8 +493,9 @@ export default function DiscoverScreen() {
           reportedName={reportTarget.name}
           onClose={() => setReportTarget(null)}
           onBlocked={() => {
+            const id = reportTarget?.id;
             setReportTarget(null);
-            setCurrentIndex(i => i + 1);
+            if (id) removeProfileFromDeck(id);
           }}
         />
       )}

--- a/apps/mobile/screens/LikesScreen.tsx
+++ b/apps/mobile/screens/LikesScreen.tsx
@@ -31,7 +31,8 @@ import {
 import { recordSwipe } from '../lib/discover';
 import { isSameLaCalendarDay } from '../lib/usageDay';
 import { usePurchases } from '../context/PurchasesContext';
-import { hasRoomPearPlusEntitlement, isPremiumProfileTier } from '../lib/purchasesConfig';
+import { hasRoomPearPlusEntitlement } from '../lib/purchasesConfig';
+import { fetchProfileIsPremium } from '../lib/profileSubscriptionTier';
 import type { MainTabParamList } from '../navigation/MainTabNavigator';
 import type { LikesStackParamList } from '../navigation/LikesStack';
 import {
@@ -187,12 +188,7 @@ export default function LikesScreen() {
     setUserId(uid);
     // Always re-sync subscription (DB + RC) on every load — must run *before* the stale-focus
     // short-circuit or premium users can stay stuck on blurred / “reveal” UI after purchase.
-    const { data: tierRow } = await supabase
-      .from('profiles')
-      .select('subscription_tier')
-      .eq('id', uid)
-      .maybeSingle();
-    const isPremiumTier = isPremiumProfileTier(tierRow?.subscription_tier as string | undefined);
+    const isPremiumTier = await fetchProfileIsPremium(uid);
     setHasPremiumTier(isPremiumTier);
     const hasPremiumAccess = hasRoomPearPlusEntitlement(customerInfo) || isRoomPearPlus || isPremiumTier;
     if (hasPremiumAccess && likersRef.current.length > 0) {
@@ -237,6 +233,19 @@ export default function LikesScreen() {
     if (likers.length === 0) return;
     setRevealedIds(new Set(likers.map((l) => l.id)));
   }, [userId, customerInfo, isRoomPearPlus, hasPremiumTier, likers]);
+
+  /** Keep `profiles.subscription_tier` in sync when RevenueCat updates (purchase / restore) without leaving the tab. */
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    void (async () => {
+      const premium = await fetchProfileIsPremium(userId);
+      if (!cancelled) setHasPremiumTier(premium);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, customerInfo]);
 
   useFocusEffect(
     useCallback(() => {

--- a/apps/mobile/screens/UserProfileScreen.tsx
+++ b/apps/mobile/screens/UserProfileScreen.tsx
@@ -23,6 +23,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
 import { usePurchases } from '../context/PurchasesContext';
+import { useDiscoverDeck } from '../context/DiscoverDeckContext';
 import { formatPlanLabel, SUBSCRIPTION_TIER_PREMIUM } from '../lib/purchasesConfig';
 import { setDevPremiumForced } from '../lib/devPremiumOverride';
 import { supabase } from '../lib/supabase';
@@ -102,6 +103,7 @@ export default function UserProfileScreen({ route }: Props) {
     presentCustomerCenter,
     logoutPurchases,
   } = usePurchases();
+  const { syncPremiumFromDatabase } = useDiscoverDeck();
   /** Pull dock flush with tab bar — tab scenes often leave a gap above the bar. */
   const profileSheetDockBottom = -Math.min(insets.bottom + 18, 36);
   const { width: windowWidth } = useWindowDimensions();
@@ -732,6 +734,7 @@ export default function UserProfileScreen({ route }: Props) {
         return;
       }
       await loadProfile(user.id);
+      await syncPremiumFromDatabase();
       // Do not call refreshCustomerInfo() when enabling premium: it syncs RC → DB as free without a purchase.
       if (!premiumEnabled) {
         await refreshCustomerInfo();


### PR DESCRIPTION
## Summary 
Improves the Discover tab for both performance and feel: the swipe deck is cached across tab switches (without refetching on unrelated customerInfo churn), new profiles load in batches of 10 with prefetch when the queue runs low, swipes no longer flash the previous card while the network saves, and premium updates from the database or RevenueCat refresh Discover limits and rebuild the deck when the user becomes paid, matching a real subscription without signing out so there is no more delay.

## What changed
### Discover deck & data loading
- Introduced DiscoverDeckProvider (context/DiscoverDeckContext.tsx) mounted under PurchasesProvider in App.tsx, holding profiles, currentIndex, and init state so leaving Discover and returning does not wipe the queue.
Initial load runs once per user (including an empty first result); refreshDeck and filter apply still do a full reload when the user asks.
fetchDiscoverProfiles (lib/discover.ts) accepts optional excludeIds so prefetch appends do not duplicate people already in the queue.
- Prefetches the next batch when remaining ≤ 3, with an exhausted guard to avoid useless repeat fetches until refresh.
### Discover UI / swipe experience
- `DiscoverScreen`: uses deck context; fixes fly-away completion so opacity is not restored to 1 before advancing the index and recordSwipe; advances index then fades in; runs recordSwipe in the background.
- `SwipeCard`: expo-image with disk cache, recyclingKey, list keys tied to profile.id, and reset of photo tab/scroll when the profile changes; DiscoverScreen prefetches the next profile’s first few photo URLs.
- Stable key props on front/back cards.
### Premium & subscription simulation
- `lib/profileSubscriptionTier.ts`: fetchProfileIsPremium centralizes reading profiles.subscription_tier.
- `DiscoverDeckContext`: syncPremiumFromDatabase, effect on customerInfo to resync tier after RC updates; hasPremiumAccess drives UI consistently.
- `UserProfileScreen`: after a successful dev premium toggle, calls syncPremiumFromDatabase so Discover updates even when refreshCustomerInfo is skipped on enable.
- `LikesScreen`: uses the shared helper for tier in load; effect on customerInfo keeps tier in sync on purchase/restore without leaving the tab.
- When hasPremiumAccess goes from false → true after the deck has finished its first load, refreshDeck() runs automatically so premium scoring and advanced filters apply (simulates paying).

## How to Test

1. Discover: Open app → Discover → switch tabs → return; deck and position should persist (no full reload unless Refresh / filters Apply).
2. Swipe ~10+ profiles; prefetch should append without duplicates until the pool is exhausted.
3. Swipe animation: no full-opacity flash of the previous card while the swipe saves.
4. Dev premium toggle (Profile): enable/disable → Discover header/limits and plan behavior update without logout; enabling premium should reload the deck (brief loading state).
5. Likes (optional): after a tier/RC change, premium reveal behavior updates when returning to or staying on Likes.

